### PR TITLE
razer: add Mouse Dock Pro and mark Naga V2 Pro verified

### DIFF
--- a/docs/razer-testing.md
+++ b/docs/razer-testing.md
@@ -13,12 +13,23 @@ picker. This is a system grant, not an app setting.
 
 Identifiers verified on hardware:
 
+- `1532:00a4` — Mouse Dock Pro (settings passthrough; verified with Naga V2 Pro)
 - `1532:00a5` — Viper V2 Pro, wired
 - `1532:00a6` — Viper V2 Pro, Stock receiver
+- `1532:00a7` — Naga V2 Pro, wired (firmware 1.3)
+- `1532:00a8` — Naga V2 Pro, stock HyperSpeed receiver
 - `1532:00c0` — Viper V3 Pro, wired
 - `1532:00c1` — Viper V3 Pro, HyperSpeed receiver
 - `1532:008a` — Viper Mini, wired (separate driver)
 - `1532:00b8` — Viper V3 HyperSpeed, stock HyperSpeed receiver
+
+Mouse Dock Pro uses the same 90-byte protocol as the paired mouse. It has no
+fixed polling list: if the paired mouse answers the extended polling command it
+offers up to 8000 Hz; otherwise it stays on the 1 kHz ladder (Naga V2 Pro). Quit
+Razer services before probing — they can return unrelated `0x0f/0x03` feature
+reports.
+
+Naga V2 Pro hardcodes 125/500/1000 Hz on both the cable and the stock receiver.
 
 Claimed but never connected:
 

--- a/docs/razer-testing.md
+++ b/docs/razer-testing.md
@@ -25,9 +25,10 @@ Identifiers verified on hardware:
 
 Mouse Dock Pro uses the same 90-byte protocol as the paired mouse. It has no
 fixed polling list: if the paired mouse answers the extended polling command it
-offers up to 8000 Hz; otherwise it stays on the 1 kHz ladder (Naga V2 Pro). Quit
-Razer services before probing — they can return unrelated `0x0f/0x03` feature
-reports.
+offers up to 8000 Hz; otherwise it stays on the 1 kHz ladder (Naga V2 Pro). The
+DPI ceiling is pinned to the paired Naga V2 Pro (30000); a higher 35k dock path
+has not been hardware-tested. Quit Razer services before probing — they can
+return unrelated `0x0f/0x03` feature reports.
 
 Naga V2 Pro hardcodes 125/500/1000 Hz on both the cable and the stock receiver.
 

--- a/src/drivers/razer/devices.test.ts
+++ b/src/drivers/razer/devices.test.ts
@@ -51,7 +51,7 @@ const VERIFIED_SINCE: ReadonlyArray<[number, VerifiedProfile]> = [
   [0x00b8, { model: "Viper V3 HyperSpeed", wireless: true, maxDpi: 30000, transactionId: RAZER_TRANSACTION_ID, rates: RATES_1K, highRate: false }],
   // Mouse Dock Pro with a Naga V2 Pro paired: settings passthrough on `0x1f`,
   // and polling rates discovered from which command the paired mouse answers.
-  [0x00a4, { model: "Mouse Dock Pro", wireless: true, maxDpi: 35000, transactionId: RAZER_TRANSACTION_ID, rates: RATES_1K, highRate: true }],
+  [0x00a4, { model: "Mouse Dock Pro", wireless: true, maxDpi: 30000, transactionId: RAZER_TRANSACTION_ID, rates: RATES_1K, highRate: true }],
   // Naga V2 Pro (firmware 1.3): fixed 1 kHz ladder on cable and stock receiver;
   // also the paired mouse used to verify Dock Pro passthrough.
   [0x00a7, { model: "Naga V2 Pro (Wired)", wireless: false, maxDpi: 30000, transactionId: RAZER_TRANSACTION_ID, rates: RATES_1K, highRate: false }],

--- a/src/drivers/razer/devices.test.ts
+++ b/src/drivers/razer/devices.test.ts
@@ -49,6 +49,13 @@ const VERIFIED_SINCE: ReadonlyArray<[number, VerifiedProfile]> = [
   // command is refused as unsupported, and 125/500/1000 Hz each round-tripped
   // on the legacy one.
   [0x00b8, { model: "Viper V3 HyperSpeed", wireless: true, maxDpi: 30000, transactionId: RAZER_TRANSACTION_ID, rates: RATES_1K, highRate: false }],
+  // Mouse Dock Pro with a Naga V2 Pro paired: settings passthrough on `0x1f`,
+  // and polling rates discovered from which command the paired mouse answers.
+  [0x00a4, { model: "Mouse Dock Pro", wireless: true, maxDpi: 35000, transactionId: RAZER_TRANSACTION_ID, rates: RATES_1K, highRate: true }],
+  // Naga V2 Pro (firmware 1.3): fixed 1 kHz ladder on cable and stock receiver;
+  // also the paired mouse used to verify Dock Pro passthrough.
+  [0x00a7, { model: "Naga V2 Pro (Wired)", wireless: false, maxDpi: 30000, transactionId: RAZER_TRANSACTION_ID, rates: RATES_1K, highRate: false }],
+  [0x00a8, { model: "Naga V2 Pro", wireless: true, maxDpi: 30000, transactionId: RAZER_TRANSACTION_ID, rates: RATES_1K, highRate: true }],
 ];
 
 const VERIFIED = [...REFACTOR_BASELINE, ...VERIFIED_SINCE];
@@ -61,7 +68,7 @@ const VERIFIED = [...REFACTOR_BASELINE, ...VERIFIED_SINCE];
  * hardware-tested", so it is pinned like the others without claiming to be
  * verified.
  */
-const HARDWARE_VERIFIED: readonly number[] = [0x00a5, 0x00a6, 0x00c0, 0x00c1, 0x00b8];
+const HARDWARE_VERIFIED: readonly number[] = [0x00a4, 0x00a5, 0x00a6, 0x00a7, 0x00a8, 0x00c0, 0x00c1, 0x00b8];
 
 test("every pinned product keeps exactly the profile it was given", () => {
   // A silent change to any of these would only show up on hardware, which is
@@ -247,6 +254,9 @@ const EXPECTED_DIVERGENCE: ReadonlyMap<number, { ours: number; openRazer: number
   [0x006e, { ours: 0x3f, openRazer: 0xff, why: "predates the audit; untested either way" }],
   [0x0071, { ours: 0x3f, openRazer: 0xff, why: "predates the audit; untested either way" }],
   [0x0098, { ours: 0x3f, openRazer: 0xff, why: "predates the audit; untested either way" }],
+  // Not a mouse in OpenRazer's table; the dock answers on the paired mouse's
+  // generation id. Confirmed with a Naga V2 Pro.
+  [0x00a4, { ours: 0x1f, openRazer: 0xff, why: "hardware report with Naga V2 Pro: dock answers on 0x1f" }],
 ]);
 
 test("every transaction id matches OpenRazer, or is a divergence with a reason", () => {
@@ -320,6 +330,28 @@ test("only wireless-capable models are sent battery commands", () => {
   }
 });
 
+test("Mouse Dock Pro discovers the paired mouse's polling ladder", () => {
+  const dock = RAZER_PRODUCTS.get(0x00a4);
+  assert.ok(dock);
+  assert.equal(dock.probePollingRates, true);
+  assert.equal(dock.connectionLabel, "Mouse Dock Pro");
+  assert.equal(dock.verified, true);
+  // Pre-probe defaults only; the driver replaces both after the first read.
+  assert.deepEqual([...dock.pollingRates], [...RATES_1K]);
+  assert.equal(dock.highRatePolling, true);
+});
+
+test("Naga V2 Pro is hardware-verified on cable and stock receiver", () => {
+  const wired = RAZER_PRODUCTS.get(0x00a7);
+  const receiver = RAZER_PRODUCTS.get(0x00a8);
+  assert.equal(wired?.verified, true);
+  assert.equal(receiver?.verified, true);
+  assert.deepEqual([...(wired?.pollingRates ?? [])], [...RATES_1K]);
+  assert.deepEqual([...(receiver?.pollingRates ?? [])], [...RATES_1K]);
+  assert.equal(wired?.highRatePolling, false);
+  assert.equal(receiver?.highRatePolling, true);
+});
+
 test("the picker filter list covers every product in the registry", () => {
   // Built from the same map, so this guards the wiring rather than the data:
   // an id in the registry with no filter can never reach the driver.
@@ -334,7 +366,7 @@ test("the catch-all filter does not widen a filter that was deliberately narrowe
   const { RAZER_REGISTRY_FILTERS, SUPPORTED_HID_FILTERS, VENDOR_ID } = await import("../vendors.ts");
 
   const broad = new Set(RAZER_REGISTRY_FILTERS.map((filter) => filter.productId));
-  for (const productId of [0x00a5, 0x00a6, 0x00c0, 0x00c1, 0x006e, 0x0071, 0x0098]) {
+  for (const productId of [0x00a4, 0x00a5, 0x00a6, 0x00c0, 0x00c1, 0x006e, 0x0071, 0x0098]) {
     assert.equal(broad.has(productId), false, `0x${productId.toString(16)} is filtered twice`);
   }
   // Every registry id still reaches the picker, through one filter or another.

--- a/src/drivers/razer/hid.test.ts
+++ b/src/drivers/razer/hid.test.ts
@@ -569,3 +569,67 @@ test("the DeathAdder V2 DPI write uses the legacy transaction id and no-store by
   assert.equal(confirm[1], 0x3f);
   assert.equal(confirm[8], 0x00);
 });
+
+/**
+ * Dock passthrough that answers only one polling command, the way a paired
+ * mouse that lacks (or has) HyperPolling does.
+ */
+function fakeDock(options: { extended: boolean }) {
+  let pending = new Uint8Array(RAZER_PACKET_LENGTH);
+  const device = {
+    vendorId: 0x1532,
+    productId: 0x00a4,
+    productName: "Razer Mouse Dock Pro",
+    opened: true,
+    collections: [{ usagePage: 0x01, usage: 0x02, children: [], featureReports: [], inputReports: [], outputReports: [] }],
+    open: async () => {},
+    close: async () => {},
+    sendFeatureReport: async (_reportId: number, data: Uint8Array) => {
+      const [commandClass, commandId] = [data[6], data[7]];
+      const answer = (dataSize: number, args: number[]) =>
+        replyPacket(commandClass, commandId, dataSize, args, RAZER_STATUS.ok);
+      if (commandClass === 0x00 && commandId === 0x81) pending = answer(0x02, [1, 3]);
+      else if (commandClass === 0x00 && commandId === 0x82) pending = answer(0x16, []);
+      else if (commandClass === 0x07 && commandId === 0x80) pending = answer(0x02, [0x00, 0x80]);
+      else if (commandClass === 0x07 && commandId === 0x84) pending = answer(0x02, [0x00, 0x00]);
+      else if (commandClass === 0x07 && commandId === 0x83) pending = answer(0x02, [0x00, 5]);
+      else if (commandClass === 0x07 && commandId === 0x81) pending = answer(0x02, [0x4d, 0x00]);
+      else if (commandClass === 0x04 && commandId === 0x85) pending = answer(0x07, [0x01, 0x06, 0x40, 0x06, 0x40]);
+      else if (commandClass === 0x00 && commandId === 0xc0) {
+        pending = options.extended
+          ? answer(0x02, [0x00, 8])
+          : replyPacket(commandClass, commandId, data[5], [], RAZER_STATUS.unsupported);
+      } else if (commandClass === 0x00 && commandId === 0x85) {
+        pending = options.extended
+          ? replyPacket(commandClass, commandId, data[5], [], RAZER_STATUS.unsupported)
+          : answer(0x01, [1]);
+      } else if (commandClass === 0x0b) {
+        pending = replyPacket(commandClass, commandId, data[5], [], RAZER_STATUS.unsupported);
+      } else {
+        pending = replyPacket(commandClass, commandId, data[5], [], RAZER_STATUS.unsupported);
+      }
+    },
+    receiveFeatureReport: async () => new DataView(pending.buffer.slice(0)),
+  } as unknown as HIDDevice;
+  return new RazerHidClient(device);
+}
+
+test("Mouse Dock Pro with a 1 kHz mouse stays on the legacy polling ladder", async () => {
+  const { RATES_1K } = await import("@openmouse/protocol/razer-devices");
+  const client = fakeDock({ extended: false });
+  const status = await client.readStatus();
+  assert.equal(status.connectionDetail, "Mouse Dock Pro");
+  assert.equal(status.pollingRateHz, 1000);
+  assert.deepEqual(status.supportedPollingRates, [...RATES_1K]);
+});
+
+test("Mouse Dock Pro with a HyperPolling mouse unlocks the 8 kHz ladder", async () => {
+  const { RATES_8K } = await import("@openmouse/protocol/razer-devices");
+  const client = fakeDock({ extended: true });
+  const status = await client.readStatus();
+  assert.equal(status.connectionDetail, "Mouse Dock Pro");
+  // Extended divisor of 8000 with value 8 → 1000 Hz reported, but the ladder
+  // still opens to 8 kHz because the command itself answered.
+  assert.equal(status.pollingRateHz, 1000);
+  assert.deepEqual(status.supportedPollingRates, [...RATES_8K]);
+});

--- a/src/drivers/razer/hid.ts
+++ b/src/drivers/razer/hid.ts
@@ -1,6 +1,6 @@
 import type { MouseStatus } from "../mouse-types.ts";
 import { VENDOR_ID } from "../vendors.ts";
-import { RATES_1K, RAZER_PRODUCTS, type RazerProduct } from "@openmouse/protocol/razer-devices";
+import { RATES_1K, RATES_8K, RAZER_PRODUCTS, type RazerProduct } from "@openmouse/protocol/razer-devices";
 import { openRazerDevice } from "./hid-open.ts";
 import {
   RAZER_LANDING_MAX,
@@ -106,6 +106,10 @@ export class RazerHidClient {
   // so nothing after the first read needs to ask the mouse again.
   private asymmetric: boolean | null = null;
   private asymmetricKnown = false;
+  /** Filled for dock passthrough after the first polling probe. */
+  private discoveredPollingRates: readonly number[] | null = null;
+  /** Which polling command the paired mouse answers; null until probed. */
+  private discoveredHighRatePolling: boolean | null = null;
 
   readonly device: HIDDevice;
 
@@ -138,6 +142,7 @@ export class RazerHidClient {
    * this is exactly `isWireless()`, which is what it used to read.
    */
   private usesHighRatePolling(): boolean {
+    if (this.discoveredHighRatePolling !== null) return this.discoveredHighRatePolling;
     return this.profile()?.highRatePolling ?? this.isWireless();
   }
 
@@ -153,6 +158,8 @@ export class RazerHidClient {
   async close(): Promise<void> {
     this.staticReads.clear();
     this.asymmetricKnown = false;
+    this.discoveredPollingRates = null;
+    this.discoveredHighRatePolling = null;
     if (this.device.opened) await this.device.close();
   }
 
@@ -173,7 +180,8 @@ export class RazerHidClient {
    * should not present it as the same thing as a tested mouse.
    */
   private connectionDetail(wireless: boolean): string {
-    const link = wireless ? "HyperSpeed receiver" : "Wired USB";
+    const link = this.profile()?.connectionLabel
+      ?? (wireless ? "HyperSpeed receiver" : "Wired USB");
     return this.profile()?.verified === false ? `${link} · untested model` : link;
   }
 
@@ -182,6 +190,7 @@ export class RazerHidClient {
   }
 
   getSupportedPollingRates(): number[] {
+    if (this.discoveredPollingRates) return [...this.discoveredPollingRates];
     return [...(this.profile()?.pollingRates ?? RATES_1K)];
   }
 
@@ -347,6 +356,10 @@ export class RazerHidClient {
   }
 
   async setPollingRate(pollingRateHz: number): Promise<number> {
+    // Dock passthrough: discover the paired mouse's ladder before validating.
+    if (this.profile()?.probePollingRates === true && !this.discoveredPollingRates) {
+      await this.readPollingRateHz();
+    }
     if (!this.getSupportedPollingRates().includes(pollingRateHz)) {
       throw new Error(`This mouse does not support ${pollingRateHz.toLocaleString()} Hz on this connection.`);
     }
@@ -508,13 +521,27 @@ export class RazerHidClient {
    * Wired answers only the legacy command and the receiver only the extended
    * one, so ask for the expected one first and keep the other as a fallback.
    * Asking in the wrong order costs a failed exchange on every refresh.
+   *
+   * Mouse Dock Pro omits a fixed rate list (`probePollingRates`): if extended
+   * polling answers, the paired mouse can use the HyperPolling ladder;
+   * otherwise stay on the 1 kHz ladder (e.g. Naga V2 Pro).
    */
   private async readPollingRateHz(): Promise<number> {
-    const extended = [RAZER_READ.pollingRateExtended, decodeExtendedPollingRate] as const;
-    const legacy = [RAZER_READ.pollingRate, decodeLegacyPollingRate] as const;
-    for (const [command, decode] of this.usesHighRatePolling() ? [extended, legacy] : [legacy, extended]) {
+    const probe = this.profile()?.probePollingRates === true;
+    const extended = [RAZER_READ.pollingRateExtended, decodeExtendedPollingRate, true] as const;
+    const legacy = [RAZER_READ.pollingRate, decodeLegacyPollingRate, false] as const;
+    // Until a dock probe settles, prefer the product's declared encoding so the
+    // first try matches what verified HyperSpeed paths already expect.
+    const preferExtended = this.discoveredHighRatePolling ?? this.profile()?.highRatePolling ?? this.isWireless();
+    for (const [command, decode, isExtended] of preferExtended ? [extended, legacy] : [legacy, extended]) {
       const reply = await this.request(command).catch(() => null);
-      if (reply) return decode(reply);
+      if (!reply) continue;
+      const hz = decode(reply);
+      if (probe) {
+        this.discoveredHighRatePolling = isExtended;
+        this.discoveredPollingRates = isExtended ? RATES_8K : RATES_1K;
+      }
+      return hz;
     }
     throw new Error("The mouse did not report a polling rate.");
   }

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -46,10 +46,14 @@ export const MODDO_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.moddo, usagePage: 0xff, usage: 0x02 },
 ];
 
-// Viper V2/V3 Pro expose their control channel as a Generic Desktop Mouse
-// collection. Limit this broad collection filter to known PIDs so it cannot
-// also surface unrelated Razer keyboards or the Viper V4 Pro's ordinary
-// boot-mouse interfaces.
+// Viper V2/V3 Pro and Mouse Dock Pro expose their control channel as a Generic
+// Desktop Mouse collection. Limit this broad collection filter to known PIDs so
+// it cannot also surface unrelated Razer keyboards or the Viper V4 Pro's
+// ordinary boot-mouse interfaces.
+export const RAZER_MOUSE_DOCK_PRO_CONTROL_FILTERS: HIDDeviceFilter[] = [0x00a4].map(
+  (productId) => ({ vendorId: VENDOR_ID.razer, productId, usagePage: 0x01, usage: 0x02 }),
+);
+
 export const RAZER_VIPER_V2_CONTROL_FILTERS: HIDDeviceFilter[] = [0x00a5, 0x00a6].map(
   (productId) => ({ vendorId: VENDOR_ID.razer, productId, usagePage: 0x01, usage: 0x02 }),
 );
@@ -94,7 +98,7 @@ export const RAZER_DEATHADDER_ESSENTIAL_FILTERS: HIDDeviceFilter[] = [0x006e, 0x
  * broad filter cannot quietly widen one that was deliberately narrowed.
  */
 const RAZER_NARROWED_PRODUCT_IDS: ReadonlySet<number> = new Set([
-  0x00a5, 0x00a6, 0x00c0, 0x00c1, 0x006e, 0x0071, 0x0098, 0x0084,
+  0x00a4, 0x00a5, 0x00a6, 0x00c0, 0x00c1, 0x006e, 0x0071, 0x0098, 0x0084,
 ]);
 
 /**
@@ -194,6 +198,7 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.lamzu },
   { vendorId: VENDOR_ID.orbital, usagePage: 0xff0a, usage: 1 },
   ...TEEVOLUTION_PRODUCT_IDS.map((productId) => ({ vendorId: VENDOR_ID.teevolution, productId })),
+  ...RAZER_MOUSE_DOCK_PRO_CONTROL_FILTERS,
   ...RAZER_VIPER_V2_CONTROL_FILTERS,
   ...RAZER_VIPER_V3_CONTROL_FILTERS,
   ...RAZER_VIPER_MINI_CONTROL_FILTERS,

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -10,7 +10,7 @@
  *
  * The product list and the transport grouping come from OpenRazer's public
  * supported-device table and mouse driver (see
- * `OPENRAZER_ALL_MICE_DEVELOPER_REFERENCE.md`). Only the seven entries marked
+ * `OPENRAZER_ALL_MICE_DEVELOPER_REFERENCE.md`). Only the entries marked
  * `verified: true` have been exercised against real hardware by this project —
  * everything else is transcribed protocol facts, not a tested driver.
  *
@@ -119,6 +119,18 @@ export interface RazerProduct {
    * the WebHID picker.
    */
   nativeOnly?: boolean;
+  /**
+   * Polling rates and which command encodes them follow the paired mouse, not a
+   * fixed list for this product id. The driver probes which command answers and
+   * offers the matching 1 kHz or 8 kHz ladder. `pollingRates` / `highRatePolling`
+   * are then only the pre-probe defaults. Mouse Dock Pro is the only case.
+   */
+  probePollingRates?: boolean;
+  /**
+   * Link label used instead of "HyperSpeed receiver" / "Wired USB" — for docks
+   * that are neither.
+   */
+  connectionLabel?: string;
 }
 
 /** Everything a preset supplies. The transaction id is deliberately not here. */
@@ -172,7 +184,9 @@ const TRANSACTION_3F: readonly number[] = [
 const TRANSACTION_1F: readonly number[] = [
   0x0062, 0x006c, 0x0077, 0x0080, 0x0085, 0x0086, 0x0088, 0x008d, 0x008f,
   0x0090, 0x0094, 0x0096, 0x0099, 0x009a, 0x009c, 0x009e, 0x009f, 0x00a1,
-  0x00a5, 0x00a6, 0x00a7, 0x00a8, 0x00aa, 0x00ab, 0x00af, 0x00b0, 0x00b2,
+  // Mouse Dock Pro is not in OpenRazer's mouse table; hardware with a Naga V2
+  // Pro paired answers on `0x1f` like that generation's mice.
+  0x00a4, 0x00a5, 0x00a6, 0x00a7, 0x00a8, 0x00aa, 0x00ab, 0x00af, 0x00b0, 0x00b2,
   0x00b4, 0x00b6, 0x00b7, 0x00b8, 0x00b9, 0x00be, 0x00bf, 0x00c0, 0x00c1,
   0x00c2, 0x00c3, 0x00c4, 0x00c5, 0x00c7, 0x00c8, 0x00cb, 0x00cc, 0x00cd,
   0x00d0, 0x00d1, 0x00d3, 0x00d4, 0x00d6, 0x00d7,
@@ -450,6 +464,21 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   [0x00b8, { model: "Viper V3 HyperSpeed", ...VIPER_RECEIVER_WIRELESS, highRatePolling: false, liftOff: true, maxDpi: DPI_FOCUS_PRO, verified: true }],
 
   // ---- new-receiver ---------------------------------------------------------
+  // Dock, not a mouse: settings pass through to whichever mouse is paired.
+  // Polling rates are discovered per session — a Naga stays on the 1 kHz ladder,
+  // while a HyperPolling-capable mouse unlocks the 8 kHz one.
+  [0x00a4, {
+    model: "Mouse Dock Pro",
+    ...MODERN_RECEIVER,
+    maxDpi: DPI_FOCUS_PRO_35K,
+    probePollingRates: true,
+    connectionLabel: "Mouse Dock Pro",
+    // Conservative pre-probe defaults; `readPollingRateHz` replaces both once
+    // it knows which command the paired mouse answers.
+    pollingRates: RATES_1K,
+    highRatePolling: true,
+    verified: true,
+  }],
   [0x006f, { model: "Lancehead Wireless", ...LEGACY_RECEIVER, maxDpi: DPI_CHROMA }],
   [0x0070, { model: "Lancehead Wireless (Wired)", ...MODERN_WIRED, maxDpi: DPI_CHROMA }],
   [0x0072, { model: "Mamba Wireless", ...LEGACY_RECEIVER, maxDpi: DPI_CHROMA }],
@@ -463,8 +492,8 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   [0x0090, { model: "Naga Pro", ...LEGACY_RECEIVER }],
   [0x009a, { model: "Pro Click Mini", ...LEGACY_RECEIVER, maxDpi: 12_000 }],
   [0x009c, { model: "DeathAdder V2 X HyperSpeed", ...LEGACY_RECEIVER, maxDpi: 14_000 }],
-  [0x00a7, { model: "Naga V2 Pro (Wired)", ...MODERN_WIRED, maxDpi: DPI_FOCUS_PRO }],
-  [0x00a8, { model: "Naga V2 Pro", ...MODERN_RECEIVER, maxDpi: DPI_FOCUS_PRO }],
+  [0x00a7, { model: "Naga V2 Pro (Wired)", ...MODERN_WIRED, maxDpi: DPI_FOCUS_PRO, verified: true }],
+  [0x00a8, { model: "Naga V2 Pro", ...MODERN_RECEIVER, maxDpi: DPI_FOCUS_PRO, verified: true }],
   [0x00aa, { model: "Basilisk V3 Pro (Wired)", ...MODERN_WIRED, maxDpi: DPI_FOCUS_PRO }],
   [0x00ab, { model: "Basilisk V3 Pro", ...MODERN_RECEIVER, maxDpi: DPI_FOCUS_PRO }],
   [0x00af, { model: "Cobra Pro (Wired)", ...MODERN_WIRED, maxDpi: DPI_FOCUS_PRO }],

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -470,7 +470,10 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   [0x00a4, {
     model: "Mouse Dock Pro",
     ...MODERN_RECEIVER,
-    maxDpi: DPI_FOCUS_PRO_35K,
+    // Verified only with a Naga V2 Pro paired (Focus Pro 30k). A higher dock
+    // ceiling for 35k mice is untested through this path, so keep the observed
+    // sensor limit rather than advertising an unverified range.
+    maxDpi: DPI_FOCUS_PRO,
     probePollingRates: true,
     connectionLabel: "Mouse Dock Pro",
     // Conservative pre-probe defaults; `readPollingRateHz` replaces both once


### PR DESCRIPTION
## Summary
- Register Razer Mouse Dock Pro (`1532:00a4`) with settings passthrough, a narrow HID filter, and per-session polling discovery (`probePollingRates`): extended command → 8 kHz ladder, otherwise 1 kHz.
- Mark Naga V2 Pro wired/receiver (`1532:00a7` / `1532:00a8`) as hardware-verified (firmware 1.3).
- Pin Dock Pro `maxDpi` to the verified Naga Focus Pro 30k ceiling; a 35k path through the dock is untested.
- Document hardware notes in `docs/razer-testing.md` and cover catalog/filter/probe behavior in unit tests.

## Hardware
- Mouse Dock Pro `1532:00a4` — verified with Naga V2 Pro paired (transaction id `0x1f`, 1 kHz ladder)
- Naga V2 Pro wired `1532:00a7` and stock HyperSpeed receiver `1532:00a8` — firmware 1.3; fixed 125/500/1000 Hz
- Dock + HyperPolling (8 kHz) mouse: unit-tested only; not confirmed on hardware

## Test plan
- [x] `npm run check` in mouse-protocol
- [x] OpenMouse `npm run check` with local sibling install (`npm install --no-save --package-lock=false ../mouse-protocol`)
- [ ] Connect Naga V2 Pro wired (`00a7`) and receiver (`00a8`): model, DPI, polling 125/500/1000
- [ ] Connect via Mouse Dock Pro (`00a4`) with Naga paired: connection label, status, DPI/polling writes
- [ ] Quit Razer Synapse/services before probing (unrelated `0x0f/0x03` reports otherwise)
- [ ] Optional: Dock + HyperPolling-capable mouse unlocks 8 kHz ladder

## Notes
- No matching OpenMouse application PR; consumers pick this up via `@openmouse/protocol` after merge.