### PR TITLE
fix(Razer): Fixing errors for some mouses & tests on hardware

### DIFF
--- a/src/drivers/razer/devices.test.ts
+++ b/src/drivers/razer/devices.test.ts
@@ -119,6 +119,21 @@ test("the DeathAdder V3 Pro receiver writes polling on the legacy command", () =
   }
 });
 
+test("the wired DeathAdder V3 writes polling on the extended command", () => {
+  // Reported on hardware: the legacy read `00/85` answered with status 0x05
+  // (not supported) and the extended read `00/c0` answered 8000/4, so the mouse
+  // was running at 2000 Hz while this row still capped the picker at 1000.
+  const wired = RAZER_PRODUCTS.get(0x00b2);
+  assert.equal(wired?.wireless, false);
+  assert.equal(wired?.highRatePolling, true);
+  // The rate the hardware was found at has to survive the round trip, or the
+  // picker offers a value the mouse is already sitting at and cannot be set to.
+  assert.ok(wired?.pollingRates.includes(2000));
+  for (const rate of wired?.pollingRates ?? []) {
+    assert.doesNotThrow(() => razerSetExtendedPollingCommand(rate));
+  }
+});
+
 test("no product asks for a rate its polling command cannot encode", () => {
   // `highRatePolling` picks the encoding and `pollingRates` picks the values
   // offered; they are set independently, so nothing stops a product asking for

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -410,7 +410,18 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   [0x0091, { model: "Viper 8KHz", ...STANDARD, maxDpi: DPI_FOCUS, pollingRates: RATES_8K, highRatePolling: true }],
   [0x00a1, { model: "DeathAdder V2 Lite", ...STANDARD, maxDpi: 8500 }],
   [0x00a3, { model: "Cobra", ...STANDARD, maxDpi: 8500 }],
-  [0x00b2, { model: "DeathAdder V3", ...STANDARD, maxDpi: DPI_FOCUS_PRO }],
+  // Hardware report: the legacy read `00/85` comes back with status 0x05 (not
+  // supported) and the extended read `00/c0` answers 8000/4, so the mouse was
+  // already sitting at 2000 Hz while this row still offered a 1000 Hz ceiling.
+  // Wired, like the Viper 8KHz above, but HyperPolling is the point of the
+  // model and the legacy command cannot encode it.
+  [0x00b2, {
+    model: "DeathAdder V3",
+    ...STANDARD,
+    maxDpi: DPI_FOCUS_PRO,
+    pollingRates: RATES_8K,
+    highRatePolling: true,
+  }],
 
   // ---- index3: wired, control channel on USB interface 3 --------------------
   [0x0096, { model: "Naga X", ...INDEX3, maxDpi: 18_000 }],

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -409,7 +409,6 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   // polling command cannot encode.
   [0x0091, { model: "Viper 8KHz", ...STANDARD, maxDpi: DPI_FOCUS, pollingRates: RATES_8K, highRatePolling: true }],
   [0x00a1, { model: "DeathAdder V2 Lite", ...STANDARD, maxDpi: 8500 }],
-  [0x00a3, { model: "Cobra", ...STANDARD, maxDpi: 8500 }],
   // Hardware report: the legacy read `00/85` comes back with status 0x05 (not
   // supported) and the extended read `00/c0` answers 8000/4, so the mouse was
   // already sitting at 2000 Hz while this row still offered a 1000 Hz ceiling.
@@ -526,4 +525,3 @@ export const RAZER_PRODUCTS: ReadonlyMap<number, RazerProduct> = new Map(
 
 /** Product ids for the WebHID picker filters in `../vendors.ts`. */
 export const RAZER_PRODUCT_IDS: readonly number[] = [...RAZER_PRODUCTS.keys()];
-


### PR DESCRIPTION
Fixing Errors for some razer mouses with hardware checks.
Fixes & Tests for the PR https://github.com/OpenMouse-Project/openmouse/pull/45
Primary implementation references:

Current supported-device list:
https://openrazer.github.io/

OpenRazer repository / current master device table:
https://github.com/openrazer/openrazer

Mouse driver:
https://github.com/openrazer/openrazer/blob/master/driver/razermouse_driver.c

Common report definitions:
https://github.com/openrazer/openrazer/blob/master/driver/razercommon.h

Chroma/common command constructors:
https://github.com/openrazer/openrazer/blob/master/driver/razerchromacommon.c

Mouse driver header / PID constants:
https://github.com/openrazer/openrazer/blob/master/driver/razermouse_driver.h

OpenRazer mouse-driver usage notes:
https://github.com/openrazer/openrazer/wiki/Using-the-mouse-driver

Implementation work was assisted with Claude Code & Codex (For Research)

Tests Results (270/270):
```
ℹ tests 270
ℹ suites 0
ℹ pass 270
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 7592.9868
```



