### PR TITLE
Shared multi-stage DPI APIs for Terra Pro and Nape Pro

### DIFF
--- a/src/drivers/keychron/hid.test.ts
+++ b/src/drivers/keychron/hid.test.ts
@@ -204,6 +204,10 @@ test("reads wired Nape Pro status from Launcher misc commands", async () => {
   assert.equal(status.brand, "Keychron");
   assert.equal(status.name, "Nape Pro");
   assert.equal(status.dpi, 800);
+  assert.deepEqual(status.dpiStages, [400, 800, 1600, 2400, 4000]);
+  assert.equal(status.activeDpiStage, 1);
+  assert.equal(status.ui?.dpiStageEditor?.maxStages, 5);
+  assert.equal(status.ui?.dpiStageEditor?.countEditable, false);
   assert.equal(status.pollingRateHz, 1000);
   assert.deepEqual(status.supportedPollingRates, [500, 1000, 2000, 4000, 8000]);
   assert.equal(status.batteryPercent, 76);
@@ -220,10 +224,17 @@ test("writes DPI and polling then confirms them by reading back", async () => {
   const fake = new FakeHidDevice();
   const client = new KeychronHidClient(fake as unknown as HIDDevice);
   assert.equal(await client.setDpi(1600), 1600);
+  assert.equal(await client.setDpiStageValue(0, 500), 500);
+  assert.equal(await client.setActiveDpiStage(2), 2);
   assert.equal(await client.setPollingRate(2000), 2000);
   assert.ok(fake.sent.some((packet) =>
     packet[0] === CMD.miscGroup && packet[1] === NAPE.setDpiValue
     && ((packet[3] ?? 0) | ((packet[4] ?? 0) << 8)) === 1600));
+  assert.ok(fake.sent.some((packet) =>
+    packet[0] === CMD.miscGroup && packet[1] === NAPE.setDpiValue
+    && packet[2] === 0 && ((packet[3] ?? 0) | ((packet[4] ?? 0) << 8)) === 500));
+  assert.ok(fake.sent.some((packet) =>
+    packet[0] === CMD.miscGroup && packet[1] === NAPE.setDpiStage && packet[2] === 2));
   assert.ok(fake.sent.some((packet) =>
     packet[0] === CMD.miscGroup && packet[1] === MISC.setPolling
     && packet[2] === KEYCHRON_POLLING_TABLE.indexOf(2000)));

--- a/src/drivers/keychron/hid.ts
+++ b/src/drivers/keychron/hid.ts
@@ -156,10 +156,19 @@ export class KeychronHidClient {
         hideProcessingCard: true,
         forceShowBattery: true,
         pollingNote: "Nape Pro exposes polling through Keychron's misc HID commands when the firmware allows it.",
+        dpiStageEditor: {
+          maxStages: DPI_STAGE_COUNT,
+          countEditable: false,
+          minDpi: DPI_MIN,
+          maxDpi: DPI_MAX,
+          stepDpi: DPI_STEP,
+        },
       },
       batteryPercent: battery && battery.percent <= 100 ? battery.percent : null,
       batteryState: battery ? battery.state : "Unknown",
       dpi,
+      dpiStages: stages.map((entry) => entry.value),
+      activeDpiStage: stage,
       pollingRateHz: polling?.rateHz ?? 1000,
       supportedPollingRates: polling?.supported ?? [1000],
       activeProfile: null,
@@ -176,15 +185,31 @@ export class KeychronHidClient {
     }
     await this.open();
     const stage = await this.getDpiStage();
-    // Launcher writes are fire-and-forget (no matching input report).
-    await this.write([CMD.miscGroup, NAPE.setDpiValue, stage & 0xff, dpi & 0xff, (dpi >> 8) & 0xff]);
-    await this.write([CMD.miscGroup, NAPE.setDpiStage, stage & 0xff]);
-    const confirmed = await this.getDpiValue(stage);
-    if (confirmed !== dpi) {
-      await this.write([CMD.miscGroup, NAPE.setCustomDpi, dpi & 0xff, (dpi >> 8) & 0xff]);
-      return await this.getCustomDpi().catch(async () => this.getDpiValue(await this.getDpiStage()));
+    return await this.writeDpiStageValue(stage, dpi);
+  }
+
+  /** Selects the active DPI stage index (0-based). */
+  async setActiveDpiStage(stage: number): Promise<number> {
+    if (!Number.isInteger(stage) || stage < 0 || stage >= DPI_STAGE_COUNT) {
+      throw new Error(`DPI stage must be between 1 and ${DPI_STAGE_COUNT}.`);
     }
+    await this.open();
+    await this.write([CMD.miscGroup, NAPE.setDpiStage, stage & 0xff]);
+    const confirmed = await this.getDpiStage();
+    if (confirmed !== stage) throw new Error(`The mouse kept DPI stage ${confirmed + 1}.`);
     return confirmed;
+  }
+
+  /** Writes one stage's DPI value without requiring it to be active first. */
+  async setDpiStageValue(stage: number, dpi: number): Promise<number> {
+    if (!Number.isInteger(stage) || stage < 0 || stage >= DPI_STAGE_COUNT) {
+      throw new Error(`DPI stage must be between 1 and ${DPI_STAGE_COUNT}.`);
+    }
+    if (dpi < DPI_MIN || dpi > DPI_MAX) {
+      throw new Error(`Nape Pro DPI must be between ${DPI_MIN} and ${DPI_MAX}.`);
+    }
+    await this.open();
+    return await this.writeDpiStageValue(stage, dpi);
   }
 
   async setPollingRate(pollingRateHz: number): Promise<number> {
@@ -253,6 +278,24 @@ export class KeychronHidClient {
       }
     }
     return values;
+  }
+
+  private async writeDpiStageValue(stage: number, dpi: number): Promise<number> {
+    // Launcher writes are fire-and-forget (no matching input report).
+    await this.write([CMD.miscGroup, NAPE.setDpiValue, stage & 0xff, dpi & 0xff, (dpi >> 8) & 0xff]);
+    const active = await this.getDpiStage();
+    if (active === stage) {
+      await this.write([CMD.miscGroup, NAPE.setDpiStage, stage & 0xff]);
+    }
+    const confirmed = await this.getDpiValue(stage);
+    if (confirmed !== dpi) {
+      if (active === stage) {
+        await this.write([CMD.miscGroup, NAPE.setCustomDpi, dpi & 0xff, (dpi >> 8) & 0xff]);
+        return await this.getCustomDpi().catch(async () => this.getDpiValue(stage));
+      }
+      throw new Error(`The mouse kept ${confirmed} DPI instead of ${dpi} DPI.`);
+    }
+    return confirmed;
   }
 
   private async getBattery(): Promise<{ percent: number; state: MouseStatus["batteryState"] }> {

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -46,6 +46,20 @@ export interface MouseUiHints {
   pollingNote?: string;
   /** Sidebar name before first status read. */
   defaultDisplayName?: string;
+  /**
+   * Simple multi-stage DPI editor in the Sensitivity card (single-axis stages).
+   * Distinct from Logitech onboard slots and Endgame CPI tiles. When set with
+   * `dpiStages` on the status, the shared stage list is shown.
+   */
+  dpiStageEditor?: {
+    /** Highest number of stages the mouse can enable. */
+    maxStages: number;
+    /** When false, stage count is fixed and the count picker is hidden. */
+    countEditable?: boolean;
+    minDpi: number;
+    maxDpi: number;
+    stepDpi: number;
+  };
 }
 
 /**

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -127,8 +127,9 @@ export interface MouseStatus {
   finalmouseTournamentScrollTimeoutMs?: number | null;
   signalStrength?: number | null;
   motionSync?: boolean | null;
-  /** NinjaForce DPI stages, where supported. */
+  /** On-device DPI stages, where supported (Teevolution, Ninjutso, …). */
   dpiStages?: number[];
+  /** Active DPI stage index into `dpiStages` (0-based). */
   activeDpiStage?: number;
   ninjutsoSystemMode?: "High Speed" | "Competitive" | "Ultra" | null;
   ninjutsoSystemModes?: Array<"High Speed" | "Competitive" | "Ultra">;

--- a/src/drivers/teevolution/hid.ts
+++ b/src/drivers/teevolution/hid.ts
@@ -129,13 +129,13 @@ export class TeevolutionHidClient {
       const dongleVersion = await this.query(TEEVOLUTION_COMMAND.getDongleVersion).catch(() => null);
       const profile = await this.query(TEEVOLUTION_COMMAND.getCurrentConfig).catch(() => null);
       const rssi = await this.query(TEEVOLUTION_COMMAND.getRssi).catch(() => null);
-      const currentDpi = Math.min(
-        flash[TEEVOLUTION_FLASH.currentDpi] ?? 0,
-        info.profile.dpiStageCount - 1,
-      );
-      const dpi = teevolutionDecodeDpi(
-        flash.slice(TEEVOLUTION_FLASH.dpiValues + currentDpi * 4, TEEVOLUTION_FLASH.dpiValues + currentDpi * 4 + 4),
-      );
+      const stageCount = this.decodeDpiStageCount(flash[TEEVOLUTION_FLASH.maxDpiStage], info.profile);
+      const activeDpiStage = Math.min(flash[TEEVOLUTION_FLASH.currentDpi] ?? 0, stageCount - 1);
+      const dpiStages = Array.from({ length: stageCount }, (_, stage) => {
+        const offset = TEEVOLUTION_FLASH.dpiValues + stage * 4;
+        return teevolutionDecodeDpi(flash.slice(offset, offset + 4));
+      });
+      const dpi = dpiStages[activeDpiStage] ?? dpiStages[0] ?? 0;
       const battery = teevolutionParseBattery(batteryResponse);
       const pollingRateHz = teevolutionDecodePollingRate(flash[TEEVOLUTION_FLASH.reportRate] ?? 1);
       const sensorModeUi = teevolutionSensorModeUi({
@@ -154,6 +154,8 @@ export class TeevolutionHidClient {
         batteryPercent: battery?.percent ?? null,
         batteryState: battery?.charging ? "Charging" : "Discharging",
         dpi,
+        dpiStages,
+        activeDpiStage,
         pollingRateHz,
         supportedPollingRates: info.profile.pollingRates.filter((rate) => rate <= info.maximumPollingRateHz),
         activeProfile: profile && profile[1] === 0 ? (profile[5] ?? 0) + 1 : null,
@@ -219,12 +221,91 @@ export class TeevolutionHidClient {
       throw new Error(`${dpi} DPI is not supported by the ${info.profile.name}.`);
     }
     return await this.withDeviceControl(async () => {
-      const currentDpi = (await this.readFlash(TEEVOLUTION_FLASH.currentDpi, 2))[0] ?? 0;
-      const address = TEEVOLUTION_FLASH.dpiValues
-        + Math.min(currentDpi, info.profile.dpiStageCount - 1) * 4;
-      await this.writeFlash(address, teevolutionEncodeDpi(dpi));
-      const confirmed = teevolutionDecodeDpi(await this.readFlash(address, 4));
-      if (confirmed !== dpi) throw new Error(`The mouse kept ${confirmed} DPI instead of ${dpi} DPI.`);
+      const stageCount = this.decodeDpiStageCount(
+        (await this.readFlash(TEEVOLUTION_FLASH.maxDpiStage, 2))[0],
+        info.profile,
+      );
+      const currentDpi = Math.min((await this.readFlash(TEEVOLUTION_FLASH.currentDpi, 2))[0] ?? 0, stageCount - 1);
+      return await this.writeDpiStageValue(currentDpi, dpi);
+    });
+  }
+
+  /** Selects the active DPI stage index (0-based), matching Teevolink Set_MS_CurrentDPI. */
+  async setActiveDpiStage(stage: number): Promise<number> {
+    const info = this.deviceInfo ?? await this.readDeviceInfo();
+    if (!Number.isInteger(stage) || stage < 0 || stage >= info.profile.dpiStageCount) {
+      throw new Error(`DPI stage must be between 1 and ${info.profile.dpiStageCount}.`);
+    }
+    return await this.withDeviceControl(async () => {
+      const stageCount = this.decodeDpiStageCount(
+        (await this.readFlash(TEEVOLUTION_FLASH.maxDpiStage, 2))[0],
+        info.profile,
+      );
+      if (stage >= stageCount) {
+        await this.writeCheckedByte(TEEVOLUTION_FLASH.maxDpiStage, stage + 1);
+        const enabled = this.decodeDpiStageCount(
+          (await this.readFlash(TEEVOLUTION_FLASH.maxDpiStage, 2))[0],
+          info.profile,
+        );
+        if (enabled <= stage) {
+          throw new Error(`The mouse kept ${enabled} DPI stages; stage ${stage + 1} is unavailable.`);
+        }
+      }
+      await this.writeCheckedByte(TEEVOLUTION_FLASH.currentDpi, stage);
+      const confirmed = (await this.readFlash(TEEVOLUTION_FLASH.currentDpi, 2))[0] ?? 0;
+      if (confirmed !== stage) throw new Error(`The mouse kept DPI stage ${confirmed + 1}.`);
+      return confirmed;
+    });
+  }
+
+  /** Writes one stage's DPI value without changing the active stage index. */
+  async setDpiStageValue(stage: number, dpi: number): Promise<number> {
+    const info = this.deviceInfo ?? await this.readDeviceInfo();
+    if (!teevolutionDpiOptions(info.profile).includes(dpi)) {
+      throw new Error(`${dpi} DPI is not supported by the ${info.profile.name}.`);
+    }
+    if (!Number.isInteger(stage) || stage < 0 || stage >= info.profile.dpiStageCount) {
+      throw new Error(`DPI stage must be between 1 and ${info.profile.dpiStageCount}.`);
+    }
+    return await this.withDeviceControl(async () => {
+      const stageCount = this.decodeDpiStageCount(
+        (await this.readFlash(TEEVOLUTION_FLASH.maxDpiStage, 2))[0],
+        info.profile,
+      );
+      // A staged count increase may not have been flashed yet; enable the slot
+      // before writing it so the UI can edit newly added stages immediately.
+      if (stage >= stageCount) {
+        await this.writeCheckedByte(TEEVOLUTION_FLASH.maxDpiStage, stage + 1);
+        const enabled = this.decodeDpiStageCount(
+          (await this.readFlash(TEEVOLUTION_FLASH.maxDpiStage, 2))[0],
+          info.profile,
+        );
+        if (enabled <= stage) {
+          throw new Error(`The mouse kept ${enabled} DPI stages; stage ${stage + 1} is unavailable.`);
+        }
+      }
+      return await this.writeDpiStageValue(stage, dpi);
+    });
+  }
+
+  /** Sets how many DPI stages are enabled (1…dpiStageCount), matching Teevolink Set_MS_MaxDPI. */
+  async setDpiStageCount(count: number): Promise<number> {
+    const info = this.deviceInfo ?? await this.readDeviceInfo();
+    const max = info.profile.dpiStageCount;
+    if (!Number.isInteger(count) || count < 1 || count > max) {
+      throw new Error(`This Teevolution model supports 1–${max} DPI stages.`);
+    }
+    return await this.withDeviceControl(async () => {
+      await this.writeCheckedByte(TEEVOLUTION_FLASH.maxDpiStage, count);
+      const confirmed = this.decodeDpiStageCount(
+        (await this.readFlash(TEEVOLUTION_FLASH.maxDpiStage, 2))[0],
+        info.profile,
+      );
+      if (confirmed !== count) throw new Error(`The mouse kept ${confirmed} DPI stages instead of ${count}.`);
+      const active = (await this.readFlash(TEEVOLUTION_FLASH.currentDpi, 2))[0] ?? 0;
+      if (active >= confirmed) {
+        await this.writeCheckedByte(TEEVOLUTION_FLASH.currentDpi, confirmed - 1);
+      }
       return confirmed;
     });
   }
@@ -370,6 +451,18 @@ export class TeevolutionHidClient {
       throw new Error("Read the Teevolution device identity before requesting model capabilities.");
     }
     return this.deviceInfo.profile;
+  }
+
+  private decodeDpiStageCount(raw: number | undefined, profile: TeevolutionDeviceProfile): number {
+    return Math.min(Math.max(raw ?? profile.dpiStageCount, 1), profile.dpiStageCount);
+  }
+
+  private async writeDpiStageValue(stage: number, dpi: number): Promise<number> {
+    const address = TEEVOLUTION_FLASH.dpiValues + stage * 4;
+    await this.writeFlash(address, teevolutionEncodeDpi(dpi));
+    const confirmed = teevolutionDecodeDpi(await this.readFlash(address, 4));
+    if (confirmed !== dpi) throw new Error(`The mouse kept ${confirmed} DPI instead of ${dpi} DPI.`);
+    return confirmed;
   }
 
   private async withDeviceControl<T>(operation: () => Promise<T>): Promise<T> {

--- a/src/drivers/teevolution/hid.ts
+++ b/src/drivers/teevolution/hid.ts
@@ -150,6 +150,13 @@ export class TeevolutionHidClient {
           defaultDisplayName: info.profile.name,
           hideUnsupportedPollingRates: true,
           hideSignalCard: true,
+          dpiStageEditor: {
+            maxStages: info.profile.dpiStageCount,
+            countEditable: true,
+            minDpi: info.profile.dpi.min,
+            maxDpi: info.profile.dpi.max,
+            stepDpi: info.profile.dpi.standardStep,
+          },
         },
         batteryPercent: battery?.percent ?? null,
         batteryState: battery?.charging ? "Charging" : "Discharging",

--- a/src/drivers/teevolution/protocol.test.ts
+++ b/src/drivers/teevolution/protocol.test.ts
@@ -140,6 +140,9 @@ test("Terra Pro capabilities are selected by reported CID", () => {
   assert.equal(profile.name, "Terra Pro");
   assert.equal(profile.protocol, "compX-terra-v1");
   assert.equal(profile.dpiStageCount, 4);
+  assert.equal(TEEVOLUTION_FLASH.maxDpiStage, 2);
+  assert.equal(TEEVOLUTION_FLASH.currentDpi, 4);
+  assert.equal(TEEVOLUTION_FLASH.dpiValues, 12);
   assert.deepEqual(profile.pollingRates, [125, 250, 500, 1000, 2000, 4000, 8000]);
   assert.deepEqual(profile.liftOffDistances, ["Low", "Medium", "High"]);
   assert.deepEqual(profile.sensorModes, ["Eco", "High"]);

--- a/src/teevolution/index.ts
+++ b/src/teevolution/index.ts
@@ -87,8 +87,12 @@ export const TEEVOLUTION_COMMAND = {
 /** Flash offsets used by Teevolink / Compx HUB for Terra Pro. */
 export const TEEVOLUTION_FLASH = {
   reportRate: 0,
+  /** Number of enabled DPI stages (1…dpiStageCount). */
+  maxDpiStage: 2,
+  /** Active DPI stage index (0-based). */
   currentDpi: 4,
   liftOffDistance: 10,
+  /** Base of 4-byte DPI stage records. */
   dpiValues: 12,
   dpiLightMode: 76,
   dpiLightBrightness: 78,


### PR DESCRIPTION
## Summary
- Add `ui.dpiStageEditor` on `MouseStatus` so apps can show a shared stage list (max stages, editable count, DPI limits).
- Teevolution Terra Pro: report editor hints alongside existing stage read/write (`setActiveDpiStage`, `setDpiStageValue`, `setDpiStageCount`).
- Keychron Nape Pro: expose all 5 stages in status plus `setActiveDpiStage` / `setDpiStageValue` (fixed count; no stage-count write).

## Test plan
- [ ] `npm run check` in mouse-protocol
- [ ] Keychron tests: status includes `dpiStages` / `dpiStageEditor`; stage value + active stage writes
- [ ] Teevolution: status includes `dpiStageEditor` with `countEditable: true`