### PR TITLE
feat(Razer): Adding Support Viper v3 Pro SE

### DIFF
--- a/docs/razer-testing.md
+++ b/docs/razer-testing.md
@@ -358,6 +358,46 @@ The picker offers every interface instead, so the right one has to be found by
 trying them. If none answers, that is worth recording — it would mean these need
 a native helper rather than a driver fix.
 
+### Viper V3 Pro SE (`1532:00de` wired, `1532:00df` wireless) — added from the reference, never connected
+
+Added from `RAZER_VIPER_V3_PRO_SE_DEVELOPER_REFERENCE.md`, which is itself built
+on OpenRazer PR **#2818** — a pull request, not merged driver source. That is
+weaker provenance than the rest of the table and the entries should be read that
+way. The PR implements the SE by subclassing the Viper V3 Pro classes, so the
+packet format, DPI pair (`04/05`, `04/85`), extended polling pair (`00/40`,
+`00/c0`) and transaction id `0x1f` all come from `0x00c0`/`0x00c1` at the source
+rather than from a family-name guess.
+
+What is *not* inherited from the V3 Pro, and why:
+
+| Field | SE | Reason |
+| --- | --- | --- |
+| `verified` | `false` | The V3 Pro's flag was earned by a hardware report on its own product ids. |
+| `liftOff` | `false` | Cannot be probed — a mouse without the feature answers `0x0b`/`0x85` with status `0x02` and zeros, which decodes as a legitimate "Low". |
+| `asymmetricLiftOff` | `false` | The mode probe is a *write*, and stays off until the command is confirmed on hardware. |
+
+Three things to measure, in priority order:
+
+1. **The wireless 8 kHz ladder.** `0x00df` carries `RATES_8K` because OpenRazer's
+   SE wireless class exposes it, but Razer's own specification reads "1000 Hz
+   normally, up to 8000 Hz with HyperPolling Dongle". If it ships with a stock
+   1 kHz receiver, the extended command will confirm by read-back and change
+   nothing measurable — the `0x00b7` failure exactly. **Measure the rate with
+   `pointerrawupdate`; do not trust the read-back.**
+2. **Which interface answers.** The reference's descriptor dump shows boot mouse
+   / boot keyboard / auxiliary, not the single Generic Desktop Mouse collection
+   the V3 Pro uses, and says only that the config path "may be exposed through
+   one of the non-pointer HID interfaces". Both entries therefore set
+   `vendorControlInterface: true` and stay out of the narrowed filter list in
+   `vendors.ts`, so the picker offers every interface. Record which one replies —
+   that earns a narrowed filter of its own.
+3. **Whether the wired PID answers at all.** The PR's WebHID smoke test
+   (battery `07/80`) succeeded only on `0x00df`. `0x00de` is untried in a
+   browser.
+
+Not claimed, and not to be guessed: button remapping, Hypershift, macros and
+surface calibration. The SE has no Chroma, so no lighting control applies.
+
 ## Models Chrome may not be able to reach at all
 
 Reported on the Viper Ultimate dongle: **every** collection came back

--- a/docs/razer-testing.md
+++ b/docs/razer-testing.md
@@ -376,24 +376,45 @@ What is *not* inherited from the V3 Pro, and why:
 | `liftOff` | `false` | Cannot be probed — a mouse without the feature answers `0x0b`/`0x85` with status `0x02` and zeros, which decodes as a legitimate "Low". |
 | `asymmetricLiftOff` | `false` | The mode probe is a *write*, and stays off until the command is confirmed on hardware. |
 
-Three things to measure, in priority order:
+### What a `0x00df` capture settled (firmware "Mouse 1.0", stock HyperSpeed receiver)
 
-1. **The wireless 8 kHz ladder.** `0x00df` carries `RATES_8K` because OpenRazer's
-   SE wireless class exposes it, but Razer's own specification reads "1000 Hz
-   normally, up to 8000 Hz with HyperPolling Dongle". If it ships with a stock
-   1 kHz receiver, the extended command will confirm by read-back and change
-   nothing measurable — the `0x00b7` failure exactly. **Measure the rate with
-   `pointerrawupdate`; do not trust the read-back.**
-2. **Which interface answers.** The reference's descriptor dump shows boot mouse
-   / boot keyboard / auxiliary, not the single Generic Desktop Mouse collection
-   the V3 Pro uses, and says only that the config path "may be exposed through
-   one of the non-pointer HID interfaces". Both entries therefore set
-   `vendorControlInterface: true` and stay out of the narrowed filter list in
-   `vendors.ts`, so the picker offers every interface. Record which one replies —
-   that earns a narrowed filter of its own.
-3. **Whether the wired PID answers at all.** The PR's WebHID smoke test
-   (battery `07/80`) succeeded only on `0x00df`. `0x00de` is untried in a
-   browser.
+**Polling — resolved, and against the reference.** The row shipped with
+`RATES_8K` because OpenRazer's SE wireless class exposes it. On hardware:
+
+| Read | Reply |
+| --- | --- |
+| extended `0x00`/`0xc0` | status `0x05` — **not supported** |
+| legacy `0x00`/`0x85` | status `0x02`, divisor `0x01` → 1000 Hz |
+
+That is an outright refusal rather than a write that confirms and does nothing,
+so unlike `0x00b7` it needed no rate measurement to settle. `0x00df` is now
+`RATES_1K` with `highRatePolling: false`. The 8 kHz ceiling belongs to the
+HyperPolling dongle, which is a separate receiver with its own product id — the
+panel had been offering four rates the receiver cannot reach.
+
+**Transaction id `0x1f` — confirmed.** Inferred from PR #2818 subclassing the
+Viper V3 Pro; every exchange in the capture used `0x1f` and was answered. A wrong
+id is silent, so this could not have read at all if it were wrong.
+
+**Control interface — confirmed as the plain mouse collection.** The reference's
+descriptor dump suggested the config path might be on a non-pointer interface.
+It is not: the driver opened `usage 0x1:2` and it answered. The other reads all
+returned sensible values — firmware `01 00` → 1.0, battery `00 FD` → 99%, DPI
+`06 40` → 1600, idle `03 84` → 900 s, low battery `0D` → 5%.
+
+Still open:
+
+1. **Every write.** The capture is reads only — no setting was changed, so
+   nothing here promotes the model to `verified`. That needs the numbered
+   checklist above: write DPI, polling and idle timeout, reload, confirm each
+   persisted.
+2. **The wired PID `0x00de`.** Untried in a browser; the PR's own smoke test
+   only ever covered `0x00df`.
+3. **Whether the narrowed filter is now worth adding.** `vendors.ts` still
+   requests the whole device for both ids, and `vendorControlInterface: true`
+   is still set. Now that `0x1:2` is known to answer on the wireless id, the
+   pair could join `RAZER_VIPER_V3_CONTROL_FILTERS` — but `0x00de` has not been
+   seen, and narrowing on one id's evidence is what this file exists to prevent.
 
 Not claimed, and not to be guessed: button remapping, Hypershift, macros and
 surface calibration. The SE has no Chroma, so no lighting control applies.

--- a/src/drivers/razer/devices.test.ts
+++ b/src/drivers/razer/devices.test.ts
@@ -119,6 +119,21 @@ test("the DeathAdder V3 Pro receiver writes polling on the legacy command", () =
   }
 });
 
+test("the wired DeathAdder V3 writes polling on the extended command", () => {
+  // Reported on hardware: the legacy read `00/85` answered with status 0x05
+  // (not supported) and the extended read `00/c0` answered 8000/4, so the mouse
+  // was running at 2000 Hz while this row still capped the picker at 1000.
+  const wired = RAZER_PRODUCTS.get(0x00b2);
+  assert.equal(wired?.wireless, false);
+  assert.equal(wired?.highRatePolling, true);
+  // The rate the hardware was found at has to survive the round trip, or the
+  // picker offers a value the mouse is already sitting at and cannot be set to.
+  assert.ok(wired?.pollingRates.includes(2000));
+  for (const rate of wired?.pollingRates ?? []) {
+    assert.doesNotThrow(() => razerSetExtendedPollingCommand(rate));
+  }
+});
+
 test("no product asks for a rate its polling command cannot encode", () => {
   // `highRatePolling` picks the encoding and `pollingRates` picks the values
   // offered; they are set independently, so nothing stops a product asking for

--- a/src/drivers/razer/devices.test.ts
+++ b/src/drivers/razer/devices.test.ts
@@ -142,6 +142,34 @@ test("the wired DeathAdder V3 writes polling on the extended command", () => {
   }
 });
 
+test("the Viper V3 Pro SE pair matches the reference without inheriting the V3 Pro's evidence", () => {
+  const wired = RAZER_PRODUCTS.get(0x00de);
+  const wireless = RAZER_PRODUCTS.get(0x00df);
+
+  // The SE is a protocol variant, so it shares the V3 Pro's transport, sensor
+  // ceiling and transaction id.
+  for (const product of [wired, wireless]) {
+    assert.equal(product?.transport, "viper-receiver");
+    assert.equal(product?.maxDpi, 35_000);
+    assert.equal(product?.hasBattery, true);
+    // Neither has been connected, so neither may claim the V3 Pro's flags: the
+    // lift-off read cannot distinguish "no feature" from "Low", and `verified`
+    // gates the "untested model" label and the strict battery read.
+    assert.equal(product?.verified, false);
+    assert.equal(product?.liftOff, false);
+    assert.equal(product?.asymmetricLiftOff, false);
+  }
+
+  // Reference §14: the wired class exposes the 1 kHz ladder, the wireless one
+  // the full 8 kHz ladder.
+  assert.deepEqual([...wired?.pollingRates ?? []], [...RATES_1K]);
+  assert.deepEqual([...wireless?.pollingRates ?? []], [...RATES_8K]);
+  assert.equal(wired?.wireless, false);
+  assert.equal(wireless?.wireless, true);
+  assert.equal(wired?.highRatePolling, false);
+  assert.equal(wireless?.highRatePolling, true);
+});
+
 test("no product asks for a rate its polling command cannot encode", () => {
   // `highRatePolling` picks the encoding and `pollingRates` picks the values
   // offered; they are set independently, so nothing stops a product asking for
@@ -261,6 +289,12 @@ const OPENRAZER_TRANSACTION_IDS: ReadonlyMap<number, number> = new Map([
     0x00b4, 0x00b6, 0x00b7, 0x00b8, 0x00b9, 0x00be, 0x00bf, 0x00c0, 0x00c1,
     0x00c2, 0x00c3, 0x00c4, 0x00c5, 0x00c7, 0x00c8, 0x00cb, 0x00cc, 0x00cd,
     0x00d0, 0x00d1, 0x00d3, 0x00d4, 0x00d6, 0x00d7,
+    // Viper V3 Pro SE. Read from PR #2818 rather than the merged driver: its
+    // classes subclass the Viper V3 Pro ones, and the transaction id is a class
+    // property, so the SE inherits `0x1f` from `0x00c0`/`0x00c1` at the source.
+    // Not a divergence — but a pending PR is weaker provenance than the rest of
+    // this table, and still no substitute for connecting one.
+    0x00de, 0x00df,
   ].map((id) => [id, 0x1f] as const),
 ]);
 

--- a/src/drivers/razer/devices.test.ts
+++ b/src/drivers/razer/devices.test.ts
@@ -160,14 +160,20 @@ test("the Viper V3 Pro SE pair matches the reference without inheriting the V3 P
     assert.equal(product?.asymmetricLiftOff, false);
   }
 
-  // Reference §14: the wired class exposes the 1 kHz ladder, the wireless one
-  // the full 8 kHz ladder.
+  // Both rows are on the legacy polling command. The wired one always was; the
+  // wireless one started on the 8 kHz ladder from OpenRazer's SE class until a
+  // capture on the stock HyperSpeed receiver answered the extended read with
+  // status 0x05 (not supported) and the legacy read with a divisor of 1.
+  //
+  // Do not restore RATES_8K here from the reference. The 8 kHz ceiling belongs
+  // to the HyperPolling dongle, which is a different receiver and a different
+  // product id.
   assert.deepEqual([...wired?.pollingRates ?? []], [...RATES_1K]);
-  assert.deepEqual([...wireless?.pollingRates ?? []], [...RATES_8K]);
+  assert.deepEqual([...wireless?.pollingRates ?? []], [...RATES_1K]);
   assert.equal(wired?.wireless, false);
   assert.equal(wireless?.wireless, true);
   assert.equal(wired?.highRatePolling, false);
-  assert.equal(wireless?.highRatePolling, true);
+  assert.equal(wireless?.highRatePolling, false);
 });
 
 test("no product asks for a rate its polling command cannot encode", () => {

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -190,6 +190,12 @@ const TRANSACTION_1F: readonly number[] = [
   0x00b4, 0x00b6, 0x00b7, 0x00b8, 0x00b9, 0x00be, 0x00bf, 0x00c0, 0x00c1,
   0x00c2, 0x00c3, 0x00c4, 0x00c5, 0x00c7, 0x00c8, 0x00cb, 0x00cc, 0x00cd,
   0x00d0, 0x00d1, 0x00d3, 0x00d4, 0x00d6, 0x00d7,
+  // Viper V3 Pro SE. OpenRazer PR #2818 subclasses the Viper V3 Pro classes,
+  // and the transaction id is a property of those classes — so the id comes
+  // from the same source as `0x00c0`/`0x00c1` above rather than from the family
+  // name. The SE reference separately mentions `0xff`, but only for the
+  // HyperPolling dongle indicator command, which this driver does not send.
+  0x00de, 0x00df,
 ];
 
 /**
@@ -446,6 +452,7 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
 
   // ---- viper-receiver -------------------------------------------------------
   [0x007a, { model: "Viper Ultimate (Wired)", ...VIPER_RECEIVER_WIRED }],
+
   // Confirmed on hardware (PR #45): the dongle's Generic-Desktop-Mouse
   // interface is Chrome-protected, so every collection is feat[none] and
   // sendFeatureReport fails on any id. Native HAL only.
@@ -471,6 +478,40 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   // will show a permanent "Low" and refuse every level; that is the thing to
   // check before trusting it.
   [0x00b8, { model: "Viper V3 HyperSpeed", ...VIPER_RECEIVER_WIRELESS, highRatePolling: false, liftOff: true, maxDpi: DPI_FOCUS_PRO, verified: true }],
+
+  // Viper V3 Pro SE (`RZ01-0455`). OpenRazer PR #2818 implements it by
+  // subclassing the Viper V3 Pro rather than writing a new codec, so the packet
+  // format, the DPI pair and the extended polling commands are the same ones
+  // `0x00c0`/`0x00c1` already use.
+  //
+  // Two things are deliberately not inherited from that pair. `verified` stays
+  // false — nothing has connected one here, and the V3 Pro's flag was earned by
+  // a hardware report on its own product ids. `liftOff` stays false because it
+  // cannot be probed: a mouse without the feature answers `0x0b`/`0x85` with
+  // status `0x02` and zeros, which decodes as a legitimate "Low".
+  //
+  // The wireless row takes the 8 kHz ladder because OpenRazer's SE wireless
+  // class exposes it, but Razer's own specification reads "1000 Hz normally, up
+  // to 8000 Hz with HyperPolling Dongle". If this ships with a stock 1 kHz
+  // receiver the extended command will confirm by read-back and change nothing
+  // measurable, exactly as it did on `0x00b7` — so the rate needs measuring,
+  // not reading back, before this row is trusted. See docs/razer-testing.md.
+  [0x00de, {
+    model: "Viper V3 Pro SE (Wired)",
+    ...VIPER_RECEIVER_WIRED,
+    maxDpi: DPI_FOCUS_PRO_35K,
+    // Which interface carries the control channel has not been established for
+    // this model, so accept the vendor-defined shape as well as the plain
+    // mouse one and let the exchange itself reject what cannot answer.
+    vendorControlInterface: true,
+  }],
+  [0x00df, {
+    model: "Viper V3 Pro SE",
+    ...VIPER_RECEIVER_WIRELESS,
+    maxDpi: DPI_FOCUS_PRO_35K,
+    pollingRates: RATES_8K,
+    vendorControlInterface: true,
+  }],
 
   // ---- new-receiver ---------------------------------------------------------
   // Dock, not a mouse: settings pass through to whichever mouse is paired.

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -410,7 +410,18 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   [0x0091, { model: "Viper 8KHz", ...STANDARD, maxDpi: DPI_FOCUS, pollingRates: RATES_8K, highRatePolling: true }],
   [0x00a1, { model: "DeathAdder V2 Lite", ...STANDARD, maxDpi: 8500 }],
   [0x00a3, { model: "Cobra", ...STANDARD, maxDpi: 8500 }],
-  [0x00b2, { model: "DeathAdder V3", ...STANDARD, maxDpi: DPI_FOCUS_PRO }],
+  // Hardware report: the legacy read `00/85` comes back with status 0x05 (not
+  // supported) and the extended read `00/c0` answers 8000/4, so the mouse was
+  // already sitting at 2000 Hz while this row still offered a 1000 Hz ceiling.
+  // Wired, like the Viper 8KHz above, but HyperPolling is the point of the
+  // model and the legacy command cannot encode it.
+  [0x00b2, {
+    model: "DeathAdder V3",
+    ...STANDARD,
+    maxDpi: DPI_FOCUS_PRO,
+    pollingRates: RATES_8K,
+    highRatePolling: true,
+  }],
 
   // ---- index3: wired, control channel on USB interface 3 --------------------
   [0x0096, { model: "Naga X", ...INDEX3, maxDpi: 18_000 }],

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -490,12 +490,17 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   // cannot be probed: a mouse without the feature answers `0x0b`/`0x85` with
   // status `0x02` and zeros, which decodes as a legitimate "Low".
   //
-  // The wireless row takes the 8 kHz ladder because OpenRazer's SE wireless
-  // class exposes it, but Razer's own specification reads "1000 Hz normally, up
-  // to 8000 Hz with HyperPolling Dongle". If this ships with a stock 1 kHz
-  // receiver the extended command will confirm by read-back and change nothing
-  // measurable, exactly as it did on `0x00b7` — so the rate needs measuring,
-  // not reading back, before this row is trusted. See docs/razer-testing.md.
+  // Polling: settled on hardware, and it went the other way from OpenRazer.
+  // `0x00df` first shipped here with the 8 kHz ladder because OpenRazer's SE
+  // wireless class exposes it. A capture on the stock HyperSpeed receiver has
+  // the extended read (`0x00`/`0xc0`) answered with status `0x05` — not
+  // supported — and the legacy read (`0x00`/`0x85`) answering a divisor of 1,
+  // i.e. 1000 Hz. An outright refusal, not a write that confirms and does
+  // nothing, so this needs no rate measurement to settle.
+  //
+  // Razer's own specification agrees: "1000 Hz normally, up to 8000 Hz with
+  // HyperPolling Dongle". The dongle is a different receiver and would enumerate
+  // as its own product id; this row describes the one in the box.
   [0x00de, {
     model: "Viper V3 Pro SE (Wired)",
     ...VIPER_RECEIVER_WIRED,
@@ -509,7 +514,8 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
     model: "Viper V3 Pro SE",
     ...VIPER_RECEIVER_WIRELESS,
     maxDpi: DPI_FOCUS_PRO_35K,
-    pollingRates: RATES_8K,
+    pollingRates: RATES_1K,
+    highRatePolling: false,
     vendorControlInterface: true,
   }],
 

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -409,7 +409,6 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   // polling command cannot encode.
   [0x0091, { model: "Viper 8KHz", ...STANDARD, maxDpi: DPI_FOCUS, pollingRates: RATES_8K, highRatePolling: true }],
   [0x00a1, { model: "DeathAdder V2 Lite", ...STANDARD, maxDpi: 8500 }],
-  [0x00a3, { model: "Cobra", ...STANDARD, maxDpi: 8500 }],
   // Hardware report: the legacy read `00/85` comes back with status 0x05 (not
   // supported) and the extended read `00/c0` answers 8000/4, so the mouse was
   // already sitting at 2000 Hz while this row still offered a 1000 Hz ceiling.
@@ -526,4 +525,3 @@ export const RAZER_PRODUCTS: ReadonlyMap<number, RazerProduct> = new Map(
 
 /** Product ids for the WebHID picker filters in `../vendors.ts`. */
 export const RAZER_PRODUCT_IDS: readonly number[] = [...RAZER_PRODUCTS.keys()];
-


### PR DESCRIPTION
Adding support for Razer Viper v3 Pro SE with hardware checks.
Primary implementation references:
Razer official support:
https://mysupport.razer.com/app/answers/detail/a_id/20579/~/razer-viper-v3-pro-se-%7C-rz01-0455-support-%26-faqs

OpenRazer support issue:
https://github.com/openrazer/openrazer/issues/2669

Physical descriptor duplicate:
https://github.com/openrazer/openrazer/issues/2822

Protocol-family discussion:
https://github.com/openrazer/openrazer/issues/2752

Current SE support PR:
https://github.com/openrazer/openrazer/pull/2818

OpenRazer Viper V3 Pro classes:
https://github.com/openrazer/openrazer/blob/master/daemon/openrazer_daemon/hardware/mouse.py

Razer command constructors:
https://github.com/openrazer/openrazer/blob/master/driver/razerchromacommon.c

Razer mouse driver:
https://github.com/openrazer/openrazer/blob/master/driver/razermouse_driver.c

Implementation work was assisted with Claude Code & Codex (For Research)

Test Results (304/304):
```
ℹ tests 304
ℹ suites 0
ℹ pass 304
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 9344.0876
```