### PR TITLE
Add Keychron Nape Pro auto-sleep timeout get/set

### DIFF
--- a/src/drivers/keychron/hid.test.ts
+++ b/src/drivers/keychron/hid.test.ts
@@ -39,6 +39,7 @@ class FakeHidDevice {
   private customDpi = 800;
   private pollingIndex = 3; // 1000 Hz
   private pollingMask = 0b0001_1111; // 8K…500
+  private sleepSeconds = 600;
   private batteryPercent = 76;
   private batteryStatus = 0;
   private orientation = 2; // 90°
@@ -152,6 +153,18 @@ class FakeHidDevice {
     }
     if (sub === MISC.setPolling) {
       this.pollingIndex = request[2] ?? this.pollingIndex;
+      return;
+    }
+    if (sub === MISC.getSleep) {
+      reply[5] = this.sleepSeconds & 0xff;
+      reply[6] = (this.sleepSeconds >> 8) & 0xff;
+      this.emit(reply);
+      return;
+    }
+    if (sub === MISC.setSleep) {
+      this.sleepSeconds = (request[4] ?? 0) | ((request[5] ?? 0) << 8);
+      reply[2] = 0;
+      this.emit(reply);
     }
   }
 
@@ -217,16 +230,19 @@ test("reads wired Nape Pro status from Launcher misc commands", async () => {
   assert.match(status.connectionDetail ?? "", /90° orientation/);
   assert.equal(status.ui?.family, "keychron-nape");
   assert.equal(status.ui?.hideProcessingCard, true);
+  assert.equal(status.ui?.showAdvancedSection, true);
+  assert.equal(status.sleepTimeout, 600);
   assert.equal(status.liftOffDistance, null);
 });
 
-test("writes DPI and polling then confirms them by reading back", async () => {
+test("writes DPI, polling, and sleep then confirms them by reading back", async () => {
   const fake = new FakeHidDevice();
   const client = new KeychronHidClient(fake as unknown as HIDDevice);
   assert.equal(await client.setDpi(1600), 1600);
   assert.equal(await client.setDpiStageValue(0, 500), 500);
   assert.equal(await client.setActiveDpiStage(2), 2);
   assert.equal(await client.setPollingRate(2000), 2000);
+  assert.equal(await client.setSleepTimeout(120), 120);
   assert.ok(fake.sent.some((packet) =>
     packet[0] === CMD.miscGroup && packet[1] === NAPE.setDpiValue
     && ((packet[3] ?? 0) | ((packet[4] ?? 0) << 8)) === 1600));
@@ -238,6 +254,22 @@ test("writes DPI and polling then confirms them by reading back", async () => {
   assert.ok(fake.sent.some((packet) =>
     packet[0] === CMD.miscGroup && packet[1] === MISC.setPolling
     && packet[2] === KEYCHRON_POLLING_TABLE.indexOf(2000)));
+  assert.ok(fake.sent.some((packet) =>
+    packet[0] === CMD.miscGroup && packet[1] === MISC.setSleep
+    && ((packet[4] ?? 0) | ((packet[5] ?? 0) << 8)) === 120));
+});
+
+test("sleep options stay inside the Launcher 1 minute–12:59:59 range", () => {
+  const options = new KeychronHidClient(device(0x0440)).getSleepOptions();
+  assert.ok(options.length > 0);
+  assert.ok(options.every((seconds) => seconds >= 60 && seconds <= 12 * 3600 + 59 * 60 + 59));
+  assert.equal(options[0], 60);
+});
+
+test("rejects sleep timeouts outside the Launcher range", async () => {
+  const client = new KeychronHidClient(new FakeHidDevice() as unknown as HIDDevice);
+  await assert.rejects(() => client.setSleepTimeout(59), /1 minute/);
+  await assert.rejects(() => client.setSleepTimeout(12 * 3600 + 59 * 60 + 60), /12:59:59/);
 });
 
 test("rejects receiver paths that are not paired to a Nape Pro", async () => {

--- a/src/drivers/keychron/hid.ts
+++ b/src/drivers/keychron/hid.ts
@@ -6,6 +6,9 @@ import {
   KEYCHRON_NAPE_DPI_MAX as DPI_MAX,
   KEYCHRON_NAPE_DPI_MIN as DPI_MIN,
   KEYCHRON_NAPE_DPI_STEP as DPI_STEP,
+  KEYCHRON_NAPE_SLEEP_MAX_SECONDS as SLEEP_MAX,
+  KEYCHRON_NAPE_SLEEP_MIN_SECONDS as SLEEP_MIN,
+  KEYCHRON_NAPE_SLEEP_OPTIONS as SLEEP_OPTIONS,
   KEYCHRON_POLLING_TABLE as POLLING_TABLE,
   KEYCHRON_PRODUCTS as PRODUCTS,
   KEYCHRON_RAW_USAGE as RAW_USAGE,
@@ -15,6 +18,8 @@ import {
   keychronDecodeBattery,
   keychronDecodeFirmware,
   keychronDecodePolling,
+  keychronDecodeSleepTimeout,
+  keychronEncodeSleepTimeout,
   keychronPacket,
 } from "@openmouse/protocol/keychron";
 const QUERY_TIMEOUT_MS = 1200;
@@ -125,6 +130,12 @@ export class KeychronHidClient {
     return options;
   }
 
+  getSleepOptions(): number[] {
+    return [...SLEEP_OPTIONS];
+  }
+
+  readonly canDisableSleep = false;
+
   async readStatus(): Promise<MouseStatus> {
     await this.open();
     const firmware = await this.getFirmwareVersion().catch(() => null);
@@ -133,6 +144,7 @@ export class KeychronHidClient {
     const battery = await this.getBattery().catch(() => null);
     const polling = await this.getPolling().catch(() => null);
     const orientation = await this.getOrientation().catch(() => null);
+    const sleepTimeout = await this.getSleepTimeout().catch(() => null);
     const active = stages.find((entry) => entry.index === stage) ?? stages[0];
     const dpi = active?.value ?? 800;
     const product = PRODUCTS.get(this.device.productId);
@@ -155,6 +167,7 @@ export class KeychronHidClient {
         hideUnsupportedPollingRates: true,
         hideProcessingCard: true,
         forceShowBattery: true,
+        showAdvancedSection: sleepTimeout !== null,
         pollingNote: "Nape Pro exposes polling through Keychron's misc HID commands when the firmware allows it.",
         dpiStageEditor: {
           maxStages: DPI_STAGE_COUNT,
@@ -175,6 +188,7 @@ export class KeychronHidClient {
       connectionDetail: connectionDetail || "Keychron Launcher protocol",
       liftOffDistance: null,
       supportedLiftOffDistances: [],
+      sleepTimeout,
       firmware: [firmware ?? "Firmware unavailable"],
     };
   }
@@ -244,8 +258,26 @@ export class KeychronHidClient {
     throw new Error("Debounce is not exposed by the Nape Pro Launcher protocol.");
   }
 
-  async setSleepTimeout(_timeout: number): Promise<never> {
-    throw new Error("Sleep timeout is not exposed by the Nape Pro Launcher protocol.");
+  async setSleepTimeout(seconds: number): Promise<number> {
+    if (!Number.isInteger(seconds) || seconds < SLEEP_MIN) {
+      throw new Error("The sleep time cannot be less than 1 minute.");
+    }
+    if (seconds > SLEEP_MAX) {
+      throw new Error("The sleep time cannot be more than 12:59:59.");
+    }
+    await this.open();
+    const reply = await this.query(
+      (bytes) => bytes[0] === CMD.miscGroup && bytes[1] === MISC.setSleep,
+      keychronEncodeSleepTimeout(seconds),
+    );
+    if ((reply[2] ?? 0) !== 0) {
+      throw new Error("The Nape Pro rejected the requested sleep timeout.");
+    }
+    const confirmed = await this.getSleepTimeout();
+    if (confirmed !== seconds) {
+      throw new Error(`The mouse kept a ${confirmed} second sleep timeout instead of ${seconds} seconds.`);
+    }
+    return confirmed;
   }
 
   async setPerformanceMode(_enabled: boolean): Promise<never> {
@@ -334,6 +366,14 @@ export class KeychronHidClient {
       [CMD.miscGroup, MISC.getPolling],
     );
     return keychronDecodePolling(response);
+  }
+
+  private async getSleepTimeout(): Promise<number> {
+    const response = await this.query(
+      (bytes) => bytes[0] === CMD.miscGroup && bytes[1] === MISC.getSleep,
+      [CMD.miscGroup, MISC.getSleep],
+    );
+    return keychronDecodeSleepTimeout(response);
   }
 
   private async getFirmwareVersion(): Promise<string | null> {

--- a/src/drivers/keychron/protocol.test.ts
+++ b/src/drivers/keychron/protocol.test.ts
@@ -5,11 +5,15 @@ import {
   KEYCHRON_NAPE_DPI_MAX,
   KEYCHRON_NAPE_DPI_MIN,
   KEYCHRON_NAPE_DPI_STEP,
+  KEYCHRON_NAPE_SLEEP_MAX_SECONDS,
+  KEYCHRON_NAPE_SLEEP_MIN_SECONDS,
   KEYCHRON_PACKET_LENGTH,
   KEYCHRON_POLLING_TABLE,
   keychronDecodeBattery,
   keychronDecodeFirmware,
   keychronDecodePolling,
+  keychronDecodeSleepTimeout,
+  keychronEncodeSleepTimeout,
   keychronPacket,
 } from "@openmouse/protocol/keychron";
 
@@ -71,4 +75,17 @@ test("battery decodes percent and charge state", () => {
     percent: 100,
     state: "Full",
   });
+});
+
+test("sleep decodes little-endian seconds from the Get_Sleep reply layout", () => {
+  assert.equal(keychronDecodeSleepTimeout(new Uint8Array([167, 11, 0, 0, 0, 0x3d, 0])), 61);
+  assert.equal(keychronDecodeSleepTimeout(new Uint8Array([167, 11, 0, 0, 0, 0x78, 0])), 120);
+  assert.equal(keychronDecodeSleepTimeout(new Uint8Array([167, 11, 0, 0, 0, 0xcf, 0xb6])), 46799);
+  assert.equal(KEYCHRON_NAPE_SLEEP_MIN_SECONDS, 60);
+  assert.equal(KEYCHRON_NAPE_SLEEP_MAX_SECONDS, 12 * 3600 + 59 * 60 + 59);
+});
+
+test("sleep encodes the trackball Set_Sleep payload (sleep LE at bytes 4–5)", () => {
+  assert.deepEqual(keychronEncodeSleepTimeout(61), [167, 12, 0, 0, 0x3d, 0, 0, 0]);
+  assert.deepEqual(keychronEncodeSleepTimeout(43200), [167, 12, 0, 0, 0xc0, 0xa8, 0, 0]);
 });

--- a/src/keychron/index.ts
+++ b/src/keychron/index.ts
@@ -13,12 +13,22 @@ export const KEYCHRON_NAPE_COMMAND = {
   getOrientation: 32, getDpiStage: 33, setDpiStage: 34, setDpiValue: 35,
   getDpiValue: 36, getBattery: 49, getCustomDpi: 54, setCustomDpi: 55,
 } as const;
-export const KEYCHRON_MISC_COMMAND = { getPolling: 13, setPolling: 14 } as const;
+export const KEYCHRON_MISC_COMMAND = {
+  getSleep: 11,
+  setSleep: 12,
+  getPolling: 13,
+  setPolling: 14,
+} as const;
 export const KEYCHRON_POLLING_TABLE = [8000, 4000, 2000, 1000, 500, 250, 125] as const;
 /** Nape Pro only — observed on firmware v1.2.6-ZK (stage 5 stores 4000). Other Keychron mice should define their own ranges. */
 export const KEYCHRON_NAPE_DPI_MIN = 50;
 export const KEYCHRON_NAPE_DPI_MAX = 4000;
 export const KEYCHRON_NAPE_DPI_STEP = 50;
+export const KEYCHRON_NAPE_SLEEP_MIN_SECONDS = 60;
+export const KEYCHRON_NAPE_SLEEP_MAX_SECONDS = 12 * 3600 + 59 * 60 + 59;
+export const KEYCHRON_NAPE_SLEEP_OPTIONS = [
+  60, 120, 300, 600, 1800, 3600, 7200, 18_000, 43_200,
+] as const;
 
 export function keychronPacket(command: readonly number[]): Uint8Array<ArrayBuffer> {
   const packet = new Uint8Array(KEYCHRON_PACKET_LENGTH);
@@ -53,5 +63,22 @@ export function keychronDecodeBattery(
       ? "Full"
       : "Discharging";
   return { percent, state };
+}
+
+export function keychronDecodeSleepTimeout(response: Uint8Array): number {
+  return (response[5] ?? 0) | ((response[6] ?? 0) << 8);
+}
+
+export function keychronEncodeSleepTimeout(seconds: number): number[] {
+  return [
+    KEYCHRON_COMMAND.miscGroup,
+    KEYCHRON_MISC_COMMAND.setSleep,
+    0,
+    0,
+    seconds & 0xff,
+    (seconds >> 8) & 0xff,
+    0,
+    0,
+  ];
 }
 


### PR DESCRIPTION
## Summary
- Decode/encode Launcher misc sleep commands (`getSleep` 0x0B / `setSleep` 0x0C) for Nape Pro.
- Expose `getSleepTimeout` / `setSleepTimeout` / `getSleepOptions` and include `sleepTimeout` in `readStatus`.
- Enforce the Launcher range: 60s–12:59:59 (46799s), with matching error messages for out-of-range values.