### PR TITLE
feat(razer): add Viper V3 Pro button mapping

### DIFF
--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -171,6 +171,17 @@ export interface MouseStatus {
   eggPollingDivider?: number;
   eggMulticlickFilters?: number[];
   eggButtonMappings?: string[];
+  /**
+   * Every shipped Razer control's current state, keyed by control name — the
+   * four cross-assignable `RazerButtonControl`s and the three two-state
+   * `RazerToggleControl`s share one dict, since each family's renderer
+   * iterates its own fixed control list and the two lists share no control
+   * names. Undefined on a model that has not been confirmed to support the
+   * class `0x02` write at all. A control whose reply the driver cannot decode
+   * (a keyboard shortcut, Hypershift data, an index nothing here knows) is
+   * omitted rather than guessed at.
+   */
+  razerButtonMappings?: Record<string, string>;
   performanceMode?: boolean | null;
   hyperMode?: boolean | null;
   sensorMode?: "Eco" | "High" | "Ultra" | null;

--- a/src/drivers/razer/hid.ts
+++ b/src/drivers/razer/hid.ts
@@ -3,11 +3,15 @@ import { VENDOR_ID } from "../vendors.ts";
 import { RATES_1K, RATES_8K, RAZER_PRODUCTS, type RazerProduct } from "@openmouse/protocol/razer-devices";
 import { openRazerDevice } from "./hid-open.ts";
 import {
+  RAZER_BUTTON_CONTROLS,
+  RAZER_BUTTON_CONTROL_LABEL,
   RAZER_LANDING_MAX,
   RAZER_LANDING_MIN,
   RAZER_LIFT_OFF_MAX,
   RAZER_LIFT_OFF_MIN,
   RAZER_READ,
+  RAZER_TOGGLE_CONTROLS,
+  RAZER_TOGGLE_CONTROL_INFO,
   RAZER_REPORT_ID,
   RAZER_STORAGE,
   RAZER_STATUS,
@@ -27,6 +31,12 @@ import {
   decodeSleepTimeout,
   encodeRazerRequest,
   isRazerGetter,
+  razerDecodeButtonMapping,
+  razerDecodeToggleControl,
+  razerReadButtonMappingCommand,
+  razerReadToggleControlCommand,
+  razerSetButtonMappingCommand,
+  razerSetToggleControlCommand,
   razerReadDpiCommand,
   razerSetDpiCommand,
   razerSetExtendedPollingCommand,
@@ -37,8 +47,11 @@ import {
   razerEnableAsymmetricLiftOffCommand,
   razerSetLowPowerThresholdCommand,
   razerSetSleepTimeoutCommand,
+  type RazerButtonControl,
+  type RazerButtonMapping,
   type RazerCommand,
   type RazerLiftOff,
+  type RazerToggleControl,
   type RazerTrackingDistance,
 } from "@openmouse/protocol/razer";
 
@@ -106,6 +119,15 @@ export class RazerHidClient {
   // so nothing after the first read needs to ask the mouse again.
   private asymmetric: boolean | null = null;
   private asymmetricKnown = false;
+
+  // Same reasoning as asymmetric/asymmetricKnown: read once per connection
+  // rather than on every background refresh. Button-mapping writes use their
+  // own transaction id (RAZER_BUTTON_TRANSACTION_ID) and are confirmed by an
+  // immediate read-back in setButtonMapping — polling this command class on a
+  // timer would put an unrelated read between a write and its own verify-read
+  // for no benefit, since nothing changes these but setButtonMapping itself.
+  private buttonMappings: Record<string, string> | null = null;
+  private buttonMappingsKnown = false;
   /** Filled for dock passthrough after the first polling probe. */
   private discoveredPollingRates: readonly number[] | null = null;
   /** Which polling command the paired mouse answers; null until probed. */
@@ -158,6 +180,7 @@ export class RazerHidClient {
   async close(): Promise<void> {
     this.staticReads.clear();
     this.asymmetricKnown = false;
+    this.buttonMappingsKnown = false;
     this.discoveredPollingRates = null;
     this.discoveredHighRatePolling = null;
     if (this.device.opened) await this.device.close();
@@ -243,6 +266,7 @@ export class RazerHidClient {
     const lowPower = hasBattery ? await this.request(RAZER_READ.lowPowerThreshold).catch(() => null) : null;
     const dpi = decodeDpi(await this.request(razerReadDpiCommand(this.dpiStorageByte())));
     const pollingRateHz = await this.readPollingRateHz();
+    const buttonMappings = await this.currentButtonMappings();
     // Asked of the product, not of the mouse. A model without lift-off can
     // still answer this read — the Basilisk X HyperSpeed returns status 0x02
     // with an all-zero payload, which decodes as a perfectly ordinary "Low" —
@@ -267,9 +291,9 @@ export class RazerHidClient {
         // shares with sleep is opened below, so it would otherwise appear as a
         // permanent "signal is unavailable" placeholder.
         hideSignalCard: true,
-        // Auto sleep is the only card this driver puts in that section, so the
-        // section opens only when the mouse actually answered the sleep read.
-        showAdvancedSection: sleep !== null,
+        // Auto sleep and button mappings are what this driver puts in that
+        // section, so it opens only when at least one of them answered.
+        showAdvancedSection: sleep !== null || buttonMappings !== null,
         forceShowBattery: battery ? true : undefined,
         defaultDisplayName: this.profile()?.model,
       },
@@ -299,8 +323,91 @@ export class RazerHidClient {
           landingRange: { min: RAZER_LANDING_MIN, max: RAZER_LANDING_MAX },
         }
         : null,
+      razerButtonMappings: buttonMappings ?? undefined,
       firmware: [`Mouse ${decodeFirmwareVersion(firmware)}`],
     };
+  }
+
+  /**
+   * Every shipped control's current state, keyed by control name — the four
+   * cross-assignable `RazerButtonControl`s and the three two-state
+   * `RazerToggleControl`s share one dict, since the view layer reads each
+   * family by iterating its own fixed control list (`RAZER_BUTTON_CONTROLS` /
+   * `RAZER_TOGGLE_CONTROLS`), and the two lists share no control names. Null
+   * on a model that has not been confirmed to support this write at all. A
+   * control whose reply this driver cannot decode is omitted rather than
+   * guessed at.
+   */
+  async readButtonMappings(): Promise<Record<string, string> | null> {
+    if (this.profile()?.buttonMapping !== true) return null;
+    const mappings: Record<string, string> = {};
+    await Promise.all([
+      ...RAZER_BUTTON_CONTROLS.map(async (control) => {
+        const reply = await this.request(razerReadButtonMappingCommand(control)).catch(() => null);
+        const mapping = reply ? razerDecodeButtonMapping(reply) : null;
+        if (mapping) mappings[control] = mapping;
+      }),
+      ...RAZER_TOGGLE_CONTROLS.map(async (control) => {
+        const reply = await this.request(razerReadToggleControlCommand(control)).catch(() => null);
+        const state = reply ? razerDecodeToggleControl(control, reply) : null;
+        if (state) mappings[control] = state;
+      }),
+    ]);
+    // Every control failing means the transport does not answer class 0x02 at
+    // all — the cable (0x00c0) has never been tested against it, only the
+    // receiver. Collapse that to null so the card is hidden outright rather
+    // than rendered empty, the same way readLiftOff degrades.
+    return Object.keys(mappings).length > 0 ? mappings : null;
+  }
+
+  /** Probes once, then trusts what setButtonMapping leaves behind. */
+  private async currentButtonMappings(): Promise<Record<string, string> | null> {
+    if (!this.buttonMappingsKnown) {
+      this.buttonMappings = await this.readButtonMappings();
+      this.buttonMappingsKnown = true;
+    }
+    return this.buttonMappings;
+  }
+
+  /**
+   * Sets one control's mapping and confirms it by reading the same control
+   * back — not a formality here: this write silently no-ops under the driver's
+   * default transaction id, so a status-only check would have shipped a
+   * control that looked correct and did nothing. See
+   * `RAZER_BUTTON_TRANSACTION_ID`.
+   */
+  async setButtonMapping(control: RazerButtonControl, mapping: RazerButtonMapping): Promise<RazerButtonMapping> {
+    await this.request(razerSetButtonMappingCommand(control, mapping));
+    const reply = await this.request(razerReadButtonMappingCommand(control));
+    const confirmed = razerDecodeButtonMapping(reply);
+    if (confirmed !== mapping) {
+      throw new Error(
+        `The mouse kept ${confirmed ?? "an unrecognised mapping"} for ${RAZER_BUTTON_CONTROL_LABEL[control]} instead of ${mapping}.`,
+      );
+    }
+    this.buttonMappings = { ...this.buttonMappings, [control]: confirmed };
+    this.buttonMappingsKnown = true;
+    return confirmed;
+  }
+
+  /**
+   * Sets a two-state control (Scroll Up/Down, the bottom sensitivity button)
+   * and confirms it the same way `setButtonMapping` does — read-back after
+   * write, not status alone. `label` must be the control's own enabled label
+   * or "Disabled"; `razerSetToggleControlCommand` throws otherwise.
+   */
+  async setToggleControl(control: RazerToggleControl, label: string): Promise<string> {
+    await this.request(razerSetToggleControlCommand(control, label));
+    const reply = await this.request(razerReadToggleControlCommand(control));
+    const confirmed = razerDecodeToggleControl(control, reply);
+    if (confirmed !== label) {
+      throw new Error(
+        `The mouse kept ${confirmed ?? "an unrecognised state"} for ${RAZER_TOGGLE_CONTROL_INFO[control].label} instead of ${label}.`,
+      );
+    }
+    this.buttonMappings = { ...this.buttonMappings, [control]: confirmed };
+    this.buttonMappingsKnown = true;
+    return confirmed;
   }
 
   async setDpi(dpi: number, dpiY: number = dpi): Promise<number> {
@@ -575,7 +682,13 @@ export class RazerHidClient {
 
   private async exchange(command: RazerCommand, transactionIdOverride?: number): Promise<Uint8Array> {
     await this.open();
-    const transactionId = transactionIdOverride ?? this.profile()?.transactionId ?? RAZER_TRANSACTION_ID;
+    // A command may pin its own transaction id — the class `0x02` button write
+    // silently no-ops under the shared one. An explicit call-site override
+    // still wins over both.
+    const transactionId = transactionIdOverride
+      ?? command.transactionId
+      ?? this.profile()?.transactionId
+      ?? RAZER_TRANSACTION_ID;
     const request = encodeRazerRequest(command, transactionId);
     // A busy status means the mouse will answer this same request later, so the
     // reads keep going without a re-send. A corrupt reply means the exchange

--- a/src/drivers/razer/protocol.test.ts
+++ b/src/drivers/razer/protocol.test.ts
@@ -37,6 +37,19 @@ import {
   razerEnableAsymmetricLiftOffCommand,
   razerSetLowPowerThresholdCommand,
   razerSetSleepTimeoutCommand,
+  RAZER_BUTTON_CONTROLS,
+  RAZER_BUTTON_CONTROL_LABEL,
+  RAZER_BUTTON_MAPPINGS,
+  RAZER_BUTTON_TRANSACTION_ID,
+  RAZER_LOCKED_BUTTON_CONTROL,
+  RAZER_TOGGLE_CONTROLS,
+  RAZER_TOGGLE_CONTROL_INFO,
+  razerDecodeButtonMapping,
+  razerDecodeToggleControl,
+  razerReadButtonMappingCommand,
+  razerReadToggleControlCommand,
+  razerSetButtonMappingCommand,
+  razerSetToggleControlCommand,
 } from "@openmouse/protocol/razer";
 
 /**
@@ -519,4 +532,249 @@ test("serial text stops at the terminator", () => {
   );
 
   assert.equal(decodeSerial(args), "PM0000H00000000");
+});
+
+/*
+ * Button-mapping fixtures are Viper V3 Pro (firmware 1.12) captures logged in
+ * BUTTONS-RUNBOOK.md, read with Synapse fully closed. Checksums are re-derived
+ * since only the byte content was recorded, not the checksummed packet.
+ */
+test("button mapping decodes a control's own default action", () => {
+  const args = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 04 00 01 01 04 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+
+  assert.equal(razerDecodeButtonMapping(args), "Mouse Button 4");
+});
+
+test("button mapping decodes Disabled", () => {
+  const args = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 04 00 00 00 00 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+
+  assert.equal(razerDecodeButtonMapping(args), "Disabled");
+});
+
+test("button mapping decodes a physically-confirmed cross-control remap", () => {
+  // Mouse Button 4's slot written with Right Click's index, then Left Click's
+  // index — pressing the physical button right-clicked, then left-clicked.
+  // Not just a changed read-back; see BUTTONS-RUNBOOK.md.
+  const asRightClick = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 04 00 01 01 02 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+  const asLeftClick = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 04 00 01 01 01 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+
+  assert.equal(razerDecodeButtonMapping(asRightClick), "Right Click");
+  assert.equal(razerDecodeButtonMapping(asLeftClick), "Left Click");
+});
+
+test("button mapping decodes Left Click and Right Click's own defaults", () => {
+  const left = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 01 01 01 01 01 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+  const right = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 02 01 01 01 02 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+
+  assert.equal(razerDecodeButtonMapping(left), "Left Click");
+  assert.equal(razerDecodeButtonMapping(right), "Right Click");
+});
+
+test("an unrecognised button-mapping type decodes to null, not a guess", () => {
+  // Type 0x02 has never been captured — this driver has no business claiming
+  // to know what it means.
+  const args = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 04 00 02 01 05 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+
+  assert.equal(razerDecodeButtonMapping(args), null);
+});
+
+test("a button-mapping write matches the packet this driver's own write was physically confirmed with", () => {
+  // Transcribed from writeAndVerify() output: Mouse Button 4 set to Right
+  // Click's index, status 0x02, read-back changed and physically confirmed
+  // by pressing the button. See BUTTONS-RUNBOOK.md.
+  const packet = encodeRazerRequest(razerSetButtonMappingCommand("mouse4", "Right Click"), RAZER_BUTTON_TRANSACTION_ID);
+
+  assert.equal(packet[5], 0x0a);
+  assert.equal(packet[6], 0x02);
+  assert.equal(packet[7], 0x0c);
+  assert.deepEqual([...packet.slice(8, 18)], [0x01, 0x04, 0x00, 0x01, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00]);
+  assert.equal(packet[88], razerChecksum(packet));
+});
+
+test("a button-mapping write clears the high bit of the matching read", () => {
+  assert.equal(RAZER_WRITE.buttonMapping.commandClass, RAZER_READ.buttonMapping.commandClass);
+  assert.equal(RAZER_WRITE.buttonMapping.commandId, RAZER_READ.buttonMapping.commandId & 0x7f);
+});
+
+test("the button write carries its own transaction id, not the shared default", () => {
+  // Confirmed on hardware: RAZER_TRANSACTION_ID (0x1f) silently no-ops this
+  // write — status 0x02 (ok), read-back even changes — while any other id
+  // (0x10 and 0x02 both tried) persists it and was physically confirmed at
+  // the button. Every other write in this file uses the shared default
+  // without issue, so this is the one exception.
+  assert.equal(RAZER_WRITE.buttonMapping.transactionId, RAZER_BUTTON_TRANSACTION_ID);
+  assert.notEqual(RAZER_BUTTON_TRANSACTION_ID, RAZER_TRANSACTION_ID);
+});
+
+test("a button-mapping read selects the control by index", () => {
+  const mouse4 = encodeRazerRequest(razerReadButtonMappingCommand("mouse4"));
+  const mouse5 = encodeRazerRequest(razerReadButtonMappingCommand("mouse5"));
+
+  assert.deepEqual([...mouse4.slice(8, 11)], [0x01, 0x04, 0x00]);
+  assert.deepEqual([...mouse5.slice(8, 11)], [0x01, 0x05, 0x00]);
+});
+
+test("Left Click is fixed on the Standard layer, matching Synapse's own restriction", () => {
+  assert.throws(() => razerSetButtonMappingCommand("leftClick", "Right Click"), RazerProtocolError);
+  assert.throws(() => razerSetButtonMappingCommand("leftClick", "Disabled"), RazerProtocolError);
+  assert.doesNotThrow(() => razerSetButtonMappingCommand("leftClick", "Left Click"));
+  // No such restriction on the other three — each can take any mapping,
+  // including disabling itself.
+  assert.doesNotThrow(() => razerSetButtonMappingCommand("rightClick", "Disabled"));
+  assert.doesNotThrow(() => razerSetButtonMappingCommand("mouse4", "Left Click"));
+});
+
+test("button-mapping writes round-trip through the decoder", () => {
+  for (const [control, mapping] of [
+    ["leftClick", "Left Click"],
+    ["rightClick", "Right Click"],
+    ["mouse4", "Mouse Button 4"],
+    ["mouse4", "Right Click"],
+    ["mouse4", "Left Click"],
+    ["mouse5", "Disabled"],
+  ] as const) {
+    const request = encodeRazerRequest(razerSetButtonMappingCommand(control, mapping));
+    assert.equal(razerDecodeButtonMapping(request.slice(8)), mapping);
+  }
+});
+
+/*
+ * Toggle-control fixtures (Scroll Up, Scroll Down, the bottom sensitivity
+ * button) are Viper V3 Pro captures logged in BUTTONS-RUNBOOK.md, same
+ * conventions as the button-mapping fixtures above. Scroll Click is
+ * deliberately not covered here yet — see the comment on RazerToggleControl.
+ */
+test("toggle control decodes its own default action", () => {
+  const scrollUp = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 09 00 01 01 09 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+  const scrollDown = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 0a 00 01 01 0a 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+  const sensitivityButton = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 60 00 06 01 06 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+
+  assert.equal(razerDecodeToggleControl("scrollUp", scrollUp), "Scroll Up");
+  assert.equal(razerDecodeToggleControl("scrollDown", scrollDown), "Scroll Down");
+  // The bottom button's default is actionType 0x06 — not the plain-button
+  // shape the other three use — captured verbatim rather than decoded from a
+  // shared formula, per the comment on RAZER_TOGGLE_CONTROL_INFO.
+  assert.equal(razerDecodeToggleControl("sensitivityButton", sensitivityButton), "Cycle Up Sensitivity Stages");
+});
+
+test("toggle control decodes Disabled", () => {
+  for (const [control, index] of [["scrollUp", "09"], ["scrollDown", "0a"], ["sensitivityButton", "60"]] as const) {
+    const args = decodeRazerResponse(
+      reply(`02 1f 00 00 00 0a 02 8c 01 ${index} 00 00 00 00 00 00 00 00`),
+      RAZER_READ.buttonMapping,
+    );
+    assert.equal(razerDecodeToggleControl(control, args), "Disabled");
+  }
+});
+
+test("an unrecognised toggle-control encoding decodes to null, not a guess", () => {
+  // Type 0x02 has never been captured for any control in this file.
+  const args = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 09 00 02 01 09 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+
+  assert.equal(razerDecodeToggleControl("scrollUp", args), null);
+});
+
+test("a toggle control does not decode another control's default as its own", () => {
+  // Scroll Down's own default (type=1, len=1, value=0x0a) is structurally
+  // identical to a plain-button record — decoding it as Scroll Up must not
+  // succeed just because the shape matches; the value has to match too.
+  const scrollDownDefault = decodeRazerResponse(
+    reply("02 1f 00 00 00 0a 02 8c 01 0a 00 01 01 0a 00 00 00 00"),
+    RAZER_READ.buttonMapping,
+  );
+
+  assert.equal(razerDecodeToggleControl("scrollUp", scrollDownDefault), null);
+});
+
+test("a toggle-control write matches the packet physically confirmed with it", () => {
+  // Scroll Up: transcribed from writeAndVerify() output restoring it to its
+  // own default — before (disabled) -> after (default) was a real, clean
+  // transition driven by this exact write, and scrolling up physically
+  // worked afterward. See BUTTONS-RUNBOOK.md.
+  const scrollUp = encodeRazerRequest(razerSetToggleControlCommand("scrollUp", "Scroll Up"), RAZER_BUTTON_TRANSACTION_ID);
+  assert.deepEqual([...scrollUp.slice(8, 18)], [0x01, 0x09, 0x00, 0x01, 0x01, 0x09, 0x00, 0x00, 0x00, 0x00]);
+  assert.equal(scrollUp[88], razerChecksum(scrollUp));
+
+  // Sensitivity button: both directions of its disable/restore cycle were
+  // clean transitions driven by this driver's own write and both physically
+  // confirmed — the most completely verified of the three.
+  const disable = encodeRazerRequest(razerSetToggleControlCommand("sensitivityButton", "Disabled"), RAZER_BUTTON_TRANSACTION_ID);
+  assert.deepEqual([...disable.slice(8, 18)], [0x01, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+  const restore = encodeRazerRequest(razerSetToggleControlCommand("sensitivityButton", "Cycle Up Sensitivity Stages"), RAZER_BUTTON_TRANSACTION_ID);
+  assert.deepEqual([...restore.slice(8, 18)], [0x01, 0x60, 0x00, 0x06, 0x01, 0x06, 0x00, 0x00, 0x00, 0x00]);
+});
+
+test("a toggle-control read selects the control by index", () => {
+  const scrollUp = encodeRazerRequest(razerReadToggleControlCommand("scrollUp"));
+  const scrollDown = encodeRazerRequest(razerReadToggleControlCommand("scrollDown"));
+  const sensitivityButton = encodeRazerRequest(razerReadToggleControlCommand("sensitivityButton"));
+
+  assert.deepEqual([...scrollUp.slice(8, 11)], [0x01, 0x09, 0x00]);
+  assert.deepEqual([...scrollDown.slice(8, 11)], [0x01, 0x0a, 0x00]);
+  assert.deepEqual([...sensitivityButton.slice(8, 11)], [0x01, 0x60, 0x00]);
+});
+
+test("an invalid label for a toggle control throws instead of sending garbage", () => {
+  assert.throws(() => razerSetToggleControlCommand("scrollUp", "Right Click"), RazerProtocolError);
+  assert.throws(() => razerSetToggleControlCommand("scrollUp", "Scroll Down"), RazerProtocolError);
+  assert.doesNotThrow(() => razerSetToggleControlCommand("scrollUp", "Scroll Up"));
+  assert.doesNotThrow(() => razerSetToggleControlCommand("scrollUp", "Disabled"));
+});
+
+test("toggle-control writes round-trip through the decoder", () => {
+  for (const control of RAZER_TOGGLE_CONTROLS) {
+    const info = RAZER_TOGGLE_CONTROL_INFO[control];
+    for (const label of [info.enabledLabel, "Disabled"]) {
+      const request = encodeRazerRequest(razerSetToggleControlCommand(control, label));
+      assert.equal(razerDecodeToggleControl(control, request.slice(8)), label);
+    }
+  }
+});
+
+test("button controls and toggle controls share no control names or option labels", () => {
+  // The two families write into the same status dict, keyed by control name
+  // (see hid.ts's readButtonMappings) — a shared key would let one family's
+  // renderer read the other's state. A shared option label ("Disabled"
+  // aside, which means the same thing everywhere) would risk the same
+  // confusion one level up, in the rendered <option> lists.
+  const buttonNames: readonly string[] = RAZER_BUTTON_CONTROLS;
+  const toggleNames: readonly string[] = RAZER_TOGGLE_CONTROLS;
+  assert.equal(buttonNames.some((name) => toggleNames.includes(name)), false);
+
+  const buttonOnlyMappings = RAZER_BUTTON_MAPPINGS.filter((mapping) => mapping !== "Disabled");
+  const toggleEnabledLabels = RAZER_TOGGLE_CONTROLS.map((control) => RAZER_TOGGLE_CONTROL_INFO[control].enabledLabel);
+  assert.equal(buttonOnlyMappings.some((mapping) => toggleEnabledLabels.includes(mapping)), false);
 });

--- a/src/razer/codec.ts
+++ b/src/razer/codec.ts
@@ -34,6 +34,18 @@ export const RAZER_TRANSACTION_ID_1F = 0x1f;
  */
 export const RAZER_TRANSACTION_ID = RAZER_TRANSACTION_ID_1F;
 
+/**
+ * The button-mapping write (class `0x02`) is the one command on this mouse
+ * that rejects `RAZER_TRANSACTION_ID` silently: status `0x02` (ok), the
+ * read-back even changes, but the physical button keeps its old function.
+ * Confirmed on hardware by writing a plain mouse-button action, pressing the
+ * button, and finding it unchanged with `0x1f` and correct with any other id
+ * (`0x02` and `0x10` both round-tripped and worked physically). Every other
+ * write on this mouse uses `0x1f` without issue, so this is specific to class
+ * `0x02` rather than a general transport quirk.
+ */
+export const RAZER_BUTTON_TRANSACTION_ID = 0x10;
+
 const ARGS_OFFSET = 8;
 const CHECKSUM_INDEX = 88;
 const CHECKSUM_FIRST = 2;
@@ -55,6 +67,8 @@ export interface RazerCommand {
   commandId: number;
   dataSize: number;
   args?: readonly number[];
+  /** Overrides the per-product transaction id for this command alone. See `RAZER_BUTTON_TRANSACTION_ID`. */
+  transactionId?: number;
 }
 
 /**
@@ -82,6 +96,15 @@ export const RAZER_READ = {
   pollingRate: { commandClass: 0x00, commandId: 0x85, dataSize: 0x01 },
   pollingRateExtended: { commandClass: 0x00, commandId: 0xc0, dataSize: 0x02, args: [0x00] },
   liftOff: { commandClass: 0x0b, commandId: 0x85, dataSize: 0x05 },
+  /**
+   * One control's button mapping. `args` is `[0x01, controlIndex, layer]`.
+   * `controlIndex` reliably selects the right control — confirmed by reading
+   * several controls back to back and always getting that control's own data.
+   * `layer` is not honored the same way: requesting Hypershift (`0x01`) for a
+   * control whose Standard mapping was just read back returned the Standard
+   * value again. Only Standard-layer reads are trusted.
+   */
+  buttonMapping: { commandClass: 0x02, commandId: 0x8c, dataSize: 0x0a },
 } as const satisfies Record<string, RazerCommand>;
 
 /**
@@ -100,6 +123,17 @@ export const RAZER_WRITE = {
   sensorSetting: { commandClass: 0x0b, commandId: 0x0b, dataSize: 0x04 },
   sleepTimeout: { commandClass: 0x07, commandId: 0x03, dataSize: 0x02 },
   lowPowerThreshold: { commandClass: 0x07, commandId: 0x01, dataSize: 0x02 },
+  /**
+   * Silently rejects `RAZER_TRANSACTION_ID` — see `RAZER_BUTTON_TRANSACTION_ID`.
+   * `razerSetButtonMappingCommand` and `razerSetToggleControlCommand` are the
+   * only places that should build this.
+   */
+  buttonMapping: {
+    commandClass: 0x02,
+    commandId: 0x0c,
+    dataSize: 0x0a,
+    transactionId: RAZER_BUTTON_TRANSACTION_ID,
+  },
 } as const satisfies Record<string, Omit<RazerCommand, "args">>;
 
 export function razerSetDpiCommand(x: number, y: number, storageByte: number = RAZER_STORAGE): RazerCommand {
@@ -542,3 +576,189 @@ export function decodeExtendedPollingRate(args: Uint8Array): number {
   return Math.round(8000 / args[1]);
 }
 
+
+/**
+ * The four controls the button-mapping write has been confirmed against, on
+ * the Viper V3 Pro's Standard layer. Left Click and Right Click use standard
+ * USB HID button numbering (1, 2), confirmed physically rather than assumed —
+ * writing Mouse Button 4's slot with each index and pressing it produced a
+ * real left-click and right-click. Mouse Button 4/5 matched their Synapse
+ * names directly. Cross-assignable among each other, plus Disabled.
+ *
+ * Scroll Up, Scroll Down and the bottom sensitivity button ship too, but as a
+ * separate, narrower kind of control — see `RazerToggleControl`. Scroll Click
+ * and Hypershift remain unshipped: Scroll Click's index is known but this
+ * driver's own write to it has only been physically checked against the wrong
+ * action, and Hypershift's read does not honour a requested layer at all.
+ */
+export type RazerButtonControl = "leftClick" | "rightClick" | "mouse4" | "mouse5";
+
+export const RAZER_BUTTON_CONTROLS: readonly RazerButtonControl[] = ["leftClick", "rightClick", "mouse4", "mouse5"];
+
+const RAZER_BUTTON_CONTROL_INDEX: Record<RazerButtonControl, number> = {
+  leftClick: 0x01,
+  rightClick: 0x02,
+  mouse4: 0x04,
+  mouse5: 0x05,
+};
+
+/** Every mapping the panel can offer: each control's own action, plus Disabled. */
+export const RAZER_BUTTON_MAPPINGS = ["Left Click", "Right Click", "Mouse Button 4", "Mouse Button 5", "Disabled"] as const;
+export type RazerButtonMapping = (typeof RAZER_BUTTON_MAPPINGS)[number];
+
+// Each control's own label doubles as the mapping that plays its native
+// action, so the type carries that: "leftClick"'s label is also a valid
+// RazerButtonMapping, not just display text.
+export const RAZER_BUTTON_CONTROL_LABEL: Record<RazerButtonControl, RazerButtonMapping> = {
+  leftClick: "Left Click",
+  rightClick: "Right Click",
+  mouse4: "Mouse Button 4",
+  mouse5: "Mouse Button 5",
+};
+
+const RAZER_MAPPING_CONTROL: Partial<Record<RazerButtonMapping, RazerButtonControl>> = Object.fromEntries(
+  RAZER_BUTTON_CONTROLS.map((control) => [RAZER_BUTTON_CONTROL_LABEL[control], control]),
+);
+
+/**
+ * Encodes a mapping into the write's trailing `[type, len, value]`.
+ * `type=0x01, len=0x01, value=<control index>` makes the target control
+ * perform *that* index's action — confirmed cross-control on hardware, not
+ * just identity: Mouse Button 4 written with Right Click's index physically
+ * right-clicked. `type=0x00` is Disabled.
+ */
+function razerEncodeButtonMapping(mapping: RazerButtonMapping): readonly [number, number, number] {
+  if (mapping === "Disabled") return [0x00, 0x00, 0x00];
+  const control = RAZER_MAPPING_CONTROL[mapping];
+  if (!control) throw new RazerProtocolError(`"${mapping}" is not a button mapping this driver can send.`);
+  return [0x01, 0x01, RAZER_BUTTON_CONTROL_INDEX[control]];
+}
+
+/**
+ * Decodes a button-mapping reply back to a label. Returns null for an
+ * encoding this driver does not recognise — a keyboard shortcut, a control
+ * outside the four shipped here, or anything else unmapped — so a caller can
+ * preserve it rather than misrepresent it as one of the known five.
+ */
+export function razerDecodeButtonMapping(args: Uint8Array): RazerButtonMapping | null {
+  const type = args[3];
+  const value = args[5];
+  if (type === 0x00) return "Disabled";
+  if (type !== 0x01) return null;
+  const control = RAZER_BUTTON_CONTROLS.find((candidate) => RAZER_BUTTON_CONTROL_INDEX[candidate] === value);
+  return control ? RAZER_BUTTON_CONTROL_LABEL[control] : null;
+}
+
+/** Only the Standard layer is trusted for reads — see `RAZER_READ.buttonMapping`. */
+export function razerReadButtonMappingCommand(control: RazerButtonControl): RazerCommand {
+  return { ...RAZER_READ.buttonMapping, args: [0x01, RAZER_BUTTON_CONTROL_INDEX[control], 0x00] };
+}
+
+/**
+ * Left Click cannot be reassigned or disabled on the Standard layer — Synapse
+ * enforces the same restriction, presumably because it is the only reliable
+ * way to interact with Windows (and with Synapse itself) at all. Exported so
+ * the UI can disable the control outright instead of letting a user hit the
+ * error.
+ */
+export const RAZER_LOCKED_BUTTON_CONTROL: RazerButtonControl = "leftClick";
+
+export function razerSetButtonMappingCommand(control: RazerButtonControl, mapping: RazerButtonMapping): RazerCommand {
+  if (control === RAZER_LOCKED_BUTTON_CONTROL && mapping !== RAZER_BUTTON_CONTROL_LABEL[RAZER_LOCKED_BUTTON_CONTROL]) {
+    throw new RazerProtocolError(
+      `${RAZER_BUTTON_CONTROL_LABEL[RAZER_LOCKED_BUTTON_CONTROL]} is fixed on the Standard layer and cannot be reassigned or disabled.`,
+    );
+  }
+  const [type, len, value] = razerEncodeButtonMapping(mapping);
+  return {
+    ...RAZER_WRITE.buttonMapping,
+    args: [0x01, RAZER_BUTTON_CONTROL_INDEX[control], 0x00, type, len, value, 0x00, 0x00, 0x00, 0x00],
+  };
+}
+
+/**
+ * Scroll Up, Scroll Down and the bottom sensitivity button, each restricted
+ * to exactly two states: their own factory action, or Disabled. Unlike
+ * `RazerButtonControl`, these are not cross-assignable — assigning one of
+ * these an action from `RAZER_BUTTON_MAPPINGS`, or assigning a button one of
+ * these controls' actions, has never been attempted on hardware and is not
+ * exposed here. Deliberately a separate type from `RazerButtonControl` and
+ * kept out of `RAZER_BUTTON_MAPPINGS` for that reason, even though three of
+ * these four values would otherwise fit the same plain-action shape.
+ *
+ * Each control's enabled state is a fixed, opaque payload captured verbatim
+ * from the mouse rather than something constructed from a shared formula,
+ * because the bottom sensitivity button's default ("Cycle Up Sensitivity
+ * Stages") is not a plain-button action at all — `actionType=0x06`, a type
+ * this driver otherwise never decodes.
+ *
+ * Scroll Click (index `0x03`) is deliberately not included: its index is
+ * known and Synapse's own disable was physically confirmed, but the one
+ * physical test run against this driver's own write to that index checked
+ * the wrong result (scroll-down instead of the click), so it has not
+ * separately cleared this driver's own bar yet.
+ */
+export type RazerToggleControl = "scrollUp" | "scrollDown" | "sensitivityButton";
+
+export const RAZER_TOGGLE_CONTROLS: readonly RazerToggleControl[] = ["scrollUp", "scrollDown", "sensitivityButton"];
+
+export interface RazerToggleControlInfo {
+  index: number;
+  /** Display heading for the control itself, independent of its current state. */
+  label: string;
+  /** The label for this control's one non-Disabled state. */
+  enabledLabel: string;
+  /** `[actionType, actionLen, actionValue]` for the enabled state, captured verbatim from the mouse. */
+  enabledArgs: readonly [number, number, number];
+}
+
+export const RAZER_TOGGLE_CONTROL_INFO: Record<RazerToggleControl, RazerToggleControlInfo> = {
+  scrollUp: { index: 0x09, label: "Scroll Up", enabledLabel: "Scroll Up", enabledArgs: [0x01, 0x01, 0x09] },
+  scrollDown: { index: 0x0a, label: "Scroll Down", enabledLabel: "Scroll Down", enabledArgs: [0x01, 0x01, 0x0a] },
+  sensitivityButton: {
+    index: 0x60,
+    label: "Sensitivity Button",
+    enabledLabel: "Cycle Up Sensitivity Stages",
+    enabledArgs: [0x06, 0x01, 0x06],
+  },
+};
+
+/** Only the Standard layer is trusted for reads — see `RAZER_READ.buttonMapping`. */
+export function razerReadToggleControlCommand(control: RazerToggleControl): RazerCommand {
+  return { ...RAZER_READ.buttonMapping, args: [0x01, RAZER_TOGGLE_CONTROL_INFO[control].index, 0x00] };
+}
+
+/**
+ * Decodes a toggle control's reply to its own enabled label or "Disabled".
+ * Returns null for anything else — Hypershift data, a Synapse reassignment
+ * this driver has never captured, or noise — so a caller can preserve it
+ * rather than misrepresent it as one of the two known states.
+ */
+export function razerDecodeToggleControl(control: RazerToggleControl, args: Uint8Array): string | null {
+  const type = args[3];
+  const len = args[4];
+  const value = args[5];
+  if (type === 0x00 && len === 0x00 && value === 0x00) return "Disabled";
+  const info = RAZER_TOGGLE_CONTROL_INFO[control];
+  const [enabledType, enabledLen, enabledValue] = info.enabledArgs;
+  if (type === enabledType && len === enabledLen && value === enabledValue) return info.enabledLabel;
+  return null;
+}
+
+export function razerSetToggleControlCommand(control: RazerToggleControl, label: string): RazerCommand {
+  const info = RAZER_TOGGLE_CONTROL_INFO[control];
+  let type: number;
+  let len: number;
+  let value: number;
+  if (label === "Disabled") {
+    [type, len, value] = [0x00, 0x00, 0x00];
+  } else if (label === info.enabledLabel) {
+    [type, len, value] = info.enabledArgs;
+  } else {
+    throw new RazerProtocolError(`${info.label} only supports "${info.enabledLabel}" or "Disabled".`);
+  }
+  return {
+    ...RAZER_WRITE.buttonMapping,
+    args: [0x01, info.index, 0x00, type, len, value, 0x00, 0x00, 0x00, 0x00],
+  };
+}

--- a/src/razer/codec.ts
+++ b/src/razer/codec.ts
@@ -127,6 +127,20 @@ export const RAZER_WRITE = {
    * Silently rejects `RAZER_TRANSACTION_ID` — see `RAZER_BUTTON_TRANSACTION_ID`.
    * `razerSetButtonMappingCommand` and `razerSetToggleControlCommand` are the
    * only places that should build this.
+   *
+   * **Stored in device memory, not volatile.** Confirmed on a Viper V3 Pro
+   * (`0x00c1`): Mouse Button 4 was disabled, the host application closed, the
+   * mouse powered off at its switch for 10 seconds and powered back on. The
+   * button was still dead on reconnect and the read reported Disabled, with
+   * Synapse never running. So a caller does not need to re-apply mappings
+   * after a power cycle, and a user's change survives independently of any
+   * host software.
+   *
+   * The leading argument byte is always `0x01` here. On this device `0x01` is
+   * also `RAZER_STORAGE`, the persistent store DPI writes through, which makes
+   * a storage selector the obvious reading — but that byte has never been
+   * varied on this command, so it is recorded as an unknown rather than
+   * assigned that meaning.
    */
   buttonMapping: {
     commandClass: 0x02,

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -72,6 +72,15 @@ export interface RazerProduct {
   transactionId: number;
   /** Battery commands only exist on models that have a cell. */
   hasBattery: boolean;
+  /**
+   * Class `0x02` button mapping (`RAZER_READ`/`RAZER_WRITE.buttonMapping`) has
+   * only ever been exercised on the Viper V3 Pro. Other Razer mice may well use
+   * a different class or a different control-index scheme, so nothing is
+   * offered to them until it has been checked on hardware. Gates both
+   * `RazerButtonControl` and `RazerToggleControl` — same command, same
+   * per-model risk, no reason to split them.
+   */
+  buttonMapping?: boolean;
   /** Also accept a vendor-defined collection as the control interface. */
   vendorControlInterface?: boolean;
   /** DPI storage selector; some generations use the no-store command form. */
@@ -377,7 +386,12 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   [0x00a5, { model: "Viper V2 Pro", wireless: false, highRatePolling: false, ...VIPER_V2_PRO }],
   [0x00a6, { model: "Viper V2 Pro", wireless: true, highRatePolling: true, ...VIPER_V2_PRO }],
   [0x00c0, { model: "Viper V3 Pro", wireless: false, pollingRates: RATES_1K, highRatePolling: false, ...VIPER_V3_PRO }],
-  [0x00c1, { model: "Viper V3 Pro", wireless: true, pollingRates: RATES_8K, highRatePolling: true, ...VIPER_V3_PRO }],
+  // `buttonMapping` is set here rather than on the shared `VIPER_V3_PRO`
+  // preset because class 0x02 has only ever been exercised over the receiver.
+  // The cable (0x00c0) is the same mouse and very likely answers the same way,
+  // but that has not been checked, and a shared protocol family is not
+  // evidence for a specific product id and connection path.
+  [0x00c1, { model: "Viper V3 Pro", wireless: true, pollingRates: RATES_8K, highRatePolling: true, ...VIPER_V3_PRO, buttonMapping: true }],
   [0x006e, { model: "DeathAdder Essential", ...DEATHADDER_ESSENTIAL }],
   [0x0071, { model: "DeathAdder Essential White Edition", ...DEATHADDER_ESSENTIAL }],
   [0x0098, { model: "DeathAdder Essential (2021)", ...DEATHADDER_ESSENTIAL }],


### PR DESCRIPTION
**Base:** `OpenMouse-Project/mouse-protocol` `main`
**Head:** `Pochiiko/mouse-protocol` `vv3p-button-mapping`


feat(razer): add Viper V3 Pro button mapping

Adds configurable button mapping for the Razer Viper V3 Pro, reverse-engineered
and verified on hardware (firmware 1.12, HyperSpeed receiver).

## Protocol

Class `0x02`:

| | Class / ID | dataSize | Payload |
| --- | --- | --- | --- |
| Read | `0x02`/`0x8c` | `0x0a` | `[0x01, controlIndex, layer]` |
| Write | `0x02`/`0x0c` | `0x0a` | `[0x01, controlIndex, layer, actionType, actionLen, actionValue, 0,0,0,0]` |

**The write silently no-ops under the shared transaction id `0x1f`** — status
`0x02` (ok), the read-back even changes, but the physical button keeps its old
function. Confirmed by writing a plain mouse-button action, pressing the button,
and finding it unchanged with `0x1f` and correct with any other id (`0x02` and
`0x10` both round-tripped and worked physically). Hence
`RAZER_BUTTON_TRANSACTION_ID = 0x10`, pinned on the command itself.
`encodeRazerRequest` already accepted a per-call id, so `exchange()` now prefers
`command.transactionId` over the per-product one — no signature change.

## Two control types, deliberately not one

**`RazerButtonControl`** (`leftClick`, `rightClick`, `mouse4`, `mouse5`) —
cross-assignable between each other's actions or Disabled. Cross-control was
confirmed on hardware, not just identity: Mouse Button 4 written with Right
Click's index physically right-clicked. Left Click is locked on the Standard
layer, matching Synapse's own restriction.

**`RazerToggleControl`** (`scrollUp`, `scrollDown`, `sensitivityButton`) — only
switches between its own captured factory action and Disabled. Kept a separate
type and out of `RAZER_BUTTON_MAPPINGS` because cross-assigning these has never
been attempted on hardware, and because the sensitivity button's default
("Cycle Up Sensitivity Stages") is `actionType 0x06` — not a plain-button action
and not decoded generally. Its enabled payload is stored verbatim from the
capture rather than constructed.

## Control indices

Each settled by isolated single-variable capture or physical cross-remap test:

| Index | Control |
| --- | --- |
| `0x01` | Left Click |
| `0x02` | Right Click |
| `0x03` | Scroll Click |
| `0x04` | Mouse Button 4 |
| `0x05` | Mouse Button 5 |
| `0x09` | Scroll Up |
| `0x0a` | Scroll Down |
| `0x60` | Sensitivity button |

`0x06`–`0x08` were probed and never answered. The space is sparse, so
neighbours are not guessed at.

## Scoping and safety

- Gated per product by `RazerProduct.buttonMapping`, set only on the Viper V3
  Pro pair (`0x00c0`/`0x00c1`) — the class has only ever been exercised there.
- Mappings are read **once per connection** and refreshed from each write's own
  confirmed read-back, mirroring `asymmetric`/`asymmetricKnown`, rather than
  polled on the status timer.
- `readButtonMappings` returns `null` rather than an empty record when no
  control answers, so a transport that does not support the class hides the
  control instead of reporting an empty set. (The cable, `0x00c0`, carries the
  flag but has only ever been tested on the receiver.)
- Every write is write → read back → throw on mismatch. Not a formality here:
  under the wrong transaction id the write reports success and does nothing.

## Not shipped

- **Hypershift layer.** The layer byte is confirmed (`0x00` Standard, `0x01`
  Hypershift, seen in a real Synapse write), but the read does not honour a
  requested layer at all — every attempt to read a Hypershift-side mapping
  returned the Standard value. That breaks the read-back verification every
  write here depends on.
- **Scroll Click.** Index confirmed, but this driver's own write to it has only
  been physically checked against the wrong action, so it has not cleared the
  verification bar.

## Hardware verification

Razer Viper V3 Pro, product id `0x00c1` (HyperSpeed receiver), firmware 1.12,
with Synapse fully closed. Each write was applied through this driver and then
confirmed by physically using the control:

| Write | Physical result |
| --- | --- |
| Mouse Button 4 -> Disabled | button does nothing |
| Mouse Button 4 -> Right Click | button opens the context menu |
| Mouse Button 4 -> Mouse Button 4 | back to its normal action |
| Scroll Down -> Disabled | wheel no longer scrolls down |
| Scroll Down -> Scroll Down | scrolling restored |

The Right Click case is the one that matters: it confirms the cross-control
action reaches the device with the correct transaction id. A read-back alone
cannot establish that, because this write's read-back also changes under the
transaction id that silently no-ops.

The cable (`0x00c0`) was not tested and does not carry the `buttonMapping` flag.

## Tests

20 new tests built from the hardware captures, including one asserting the two
control families share no control names and no option labels — the thing that
would let one family's renderer read the other's state.

429/429 pass.
