### PR TITLE
feat(pulsar): name the X3 M dongle instead of the generic 1K Dongle

### DIFF
--- a/src/drivers/pulsar/pulsar-xs1-hid.test.ts
+++ b/src/drivers/pulsar/pulsar-xs1-hid.test.ts
@@ -129,7 +129,7 @@ test("reads the X3 status from the feature interface", async () => {
   const status = await client.readStatus();
 
   assert.equal(status.brand, "Pulsar");
-  assert.equal(status.name, "Pulsar X3 Medium 1K Dongle");
+  assert.equal(status.name, "Pulsar X3 M");
   assert.equal(status.connectionType, "Wireless");
   assert.equal(status.connectionDetail, "XS-1 feature-report interface");
   assert.equal(status.dpi, 1600);

--- a/src/drivers/pulsar/pulsar-xs1-hid.ts
+++ b/src/drivers/pulsar/pulsar-xs1-hid.ts
@@ -25,6 +25,12 @@ const RESPONSE_ATTEMPTS = 5;
 const RESPONSE_DELAY_MS = 25;
 const DPI_VALUE_OFFSET = 7;
 
+// The X3 family dongles report a generic "1K Dongle" product name from WebHID,
+// which is useless in the UI. Known product ids map to the paired model name.
+const XS1_PRODUCT_NAMES: ReadonlyMap<number, string> = new Map([
+  [0x5402, "Pulsar X3 M"],
+]);
+
 const LIFT_OFF_DISTANCES: ReadonlyArray<readonly [number, LiftOffDistance]> = [
   [0x07, "Low"],
   [0x0a, "Medium"],
@@ -124,7 +130,7 @@ export class PulsarXs1HidClient {
     const pollingRate = await this.query(QUERY.pollingRate).catch(() => null);
     return this.lastStatus = {
       brand: "Pulsar",
-      name: this.device.productName || "Pulsar X3",
+      name: XS1_PRODUCT_NAMES.get(this.device.productId) ?? (this.device.productName || "Pulsar X3"),
       ui: {
         family: "pulsar",
         hideUnsupportedPollingRates: true,


### PR DESCRIPTION
The X3 family dongles report a generic product name, so map the known 0x5402 dongle product id to the paired Pulsar X3 M model name.