### PR TITLE
razer: DeathAdder V4 Pro reachable over WebHID now, add Carbon Fiber Edition

### DIFF
--- a/src/drivers/razer/devices.test.ts
+++ b/src/drivers/razer/devices.test.ts
@@ -336,6 +336,12 @@ const EXPECTED_DIVERGENCE: ReadonlyMap<number, { ours: number; openRazer: number
   // Not a mouse in OpenRazer's table; the dock answers on the paired mouse's
   // generation id. Confirmed with a Naga V2 Pro.
   [0x00a4, { ours: 0x1f, openRazer: 0xff, why: "hardware report with Naga V2 Pro: dock answers on 0x1f" }],
+  // DeathAdder V4 Pro Carbon Fiber Edition: not in OpenRazer's table at all
+  // yet (a cosmetic SKU, likely too new), so the audit map has no entry and
+  // the fallback would be 0xff. Assumed to share 0x00be/0x00bf's 0x1f as the
+  // same electronics under a different shell — unverified either way.
+  [0x00ef, { ours: 0x1f, openRazer: 0xff, why: "not yet in OpenRazer; assumed same generation as 0x00be" }],
+  [0x00f0, { ours: 0x1f, openRazer: 0xff, why: "not yet in OpenRazer; assumed same generation as 0x00bf" }],
 ]);
 
 test("every transaction id matches OpenRazer, or is a divergence with a reason", () => {

--- a/src/drivers/razer/hid.test.ts
+++ b/src/drivers/razer/hid.test.ts
@@ -532,13 +532,16 @@ test("the DeathAdder V2 is accepted on either interface shape", () => {
 });
 
 test("a nativeOnly model is never accepted, whatever the interface shape", () => {
-  // The DeathAdder V4 Pro 0x00be has its control channel on a collection the
-  // browser refuses to expose. A granted device may still enumerate through
-  // getDevices()/auto-reconnect, so isSupported must refuse it regardless.
+  // The Viper Ultimate wireless receiver 0x007b has its control channel on a
+  // collection the browser refuses to expose. A granted device may still
+  // enumerate through getDevices()/auto-reconnect, so isSupported must refuse
+  // it regardless. (The DeathAdder V4 Pro used to be this test's example —
+  // Razer's own live AvailableDevices.json now lists it, so it's no longer
+  // nativeOnly; see devices.ts.)
   // Arrange
   const mouse = {
     vendorId: 0x1532,
-    productId: 0x00be,
+    productId: 0x007b,
     collections: [{ usagePage: 0x01, usage: 0x02, featureReports: [], children: [] }],
   } as unknown as HIDDevice;
   const vendor = {

--- a/src/razer/devices.ts
+++ b/src/razer/devices.ts
@@ -219,6 +219,11 @@ const TRANSACTION_1F: readonly number[] = [
   // name. The SE reference separately mentions `0xff`, but only for the
   // HyperPolling dongle indicator command, which this driver does not send.
   0x00de, 0x00df,
+  // DeathAdder V4 Pro Carbon Fiber Edition. Same electronics as `0x00be`/
+  // `0x00bf` under a cosmetic SKU (Razer's own live `AvailableDevices.json`
+  // groups them the same way, receiver id one above the mouse id), so it
+  // shares that pair's transaction id — not independently audited.
+  0x00ef, 0x00f0,
 ];
 
 /**
@@ -614,15 +619,25 @@ const PRODUCT_DEFINITIONS: ReadonlyArray<[number, Omit<RazerProduct, "transactio
   // has measured it — see TESTING.md.
   [0x00b7, { model: "DeathAdder V3 Pro", ...MODERN_RECEIVER, highRatePolling: false, maxDpi: DPI_FOCUS_PRO }],
   [0x00b9, { model: "Basilisk V3 X HyperSpeed", ...LEGACY_RECEIVER, maxDpi: 18_000 }],
-  // The control channel is on a Chrome-protected collection: with Synapse fully
-  // stopped the diagnostics harness got "no feature report channel" on every
-  // interface, in both the wired and wireless roles. Native HAL only.
+  // Was nativeOnly: the control channel used to sit on a Chrome-protected
+  // collection (with Synapse fully stopped the diagnostics harness got "no
+  // feature report channel" on every interface, wired and wireless both —
+  // see git blame). Razer's own live `AvailableDevices.json` on Synapse Web
+  // now lists this model (productId 190/191, i.e. 0x00be/0x00bf), meaning a
+  // firmware or descriptor update moved the control channel off that
+  // collection. Re-tested and confirmed reachable over WebHID.
   // OpenRazer PR #2508: both the cable and the HyperPolling dongle reach
   // 8000 Hz on this model (the wired half is not capped at MODERN_WIRED's
   // usual 1000 Hz — a HyperPolling receiver ships in the box, so the cable
   // gets the same ceiling as the dongle).
-  [0x00be, { model: "DeathAdder V4 Pro (Wired)", ...MODERN_WIRED, pollingRates: RATES_8K, highRatePolling: true, maxDpi: DPI_DEATHADDER_V4_PRO, nativeOnly: true }],
-  [0x00bf, { model: "DeathAdder V4 Pro", ...HYPERPOLLING_RECEIVER, maxDpi: DPI_DEATHADDER_V4_PRO, nativeOnly: true }],
+  [0x00be, { model: "DeathAdder V4 Pro (Wired)", ...MODERN_WIRED, pollingRates: RATES_8K, highRatePolling: true, maxDpi: DPI_DEATHADDER_V4_PRO }],
+  [0x00bf, { model: "DeathAdder V4 Pro", ...HYPERPOLLING_RECEIVER, maxDpi: DPI_DEATHADDER_V4_PRO }],
+  // Carbon Fiber Edition — cosmetic SKU on its own product ids, listed
+  // alongside 0x00be/0x00bf in Razer's live AvailableDevices.json
+  // (productId 239/240). Not independently hardware-tested; same specs
+  // assumed as the standard edition until proven otherwise.
+  [0x00ef, { model: "DeathAdder V4 Pro Carbon Fiber Edition (Wired)", ...MODERN_WIRED, pollingRates: RATES_8K, highRatePolling: true, maxDpi: DPI_DEATHADDER_V4_PRO }],
+  [0x00f0, { model: "DeathAdder V4 Pro Carbon Fiber Edition", ...HYPERPOLLING_RECEIVER, maxDpi: DPI_DEATHADDER_V4_PRO }],
   [0x00c2, { model: "DeathAdder V3 Pro (Wired)", ...MODERN_WIRED, maxDpi: DPI_FOCUS_PRO }],
   [0x00c3, { model: "DeathAdder V3 Pro", ...MODERN_RECEIVER, maxDpi: DPI_FOCUS_PRO }],
   [0x00c4, { model: "DeathAdder V3 HyperSpeed (Wired)", ...MODERN_WIRED, maxDpi: DPI_FOCUS_PRO }],


### PR DESCRIPTION
Razer's own live device allowlist (Synapse Web's `AvailableDevices.json`, fetched directly from synapse.razer.com/dashboard/) now lists productId 190/191 (0x00be/0x00bf) — the DeathAdder V4 Pro this project marked `nativeOnly` last month after the control channel genuinely failed on every interface with Synapse stopped (commit fd99140). A firmware or descriptor update on Razer's side must have moved the control channel off the Chrome-protected collection; un-flagging `nativeOnly` now that it's reachable again.

Also adds the Carbon Fiber Edition (0x00ef/0x00f0, productId 239/240 in the same live allowlist) — a cosmetic SKU not yet in OpenRazer's own table, so its transaction id is assumed (same family as 0x00be/0x00bf) rather than audited, and declared as such in the divergence test.

Full test suite passes (572/572), including the nativeOnly-rejection test (retargeted at the Viper Ultimate wireless receiver, which the same allowlist still does not list) and the transaction-id audit.