### PR TITLE
Recognize G502 X LIGHTSPEED direct-USB PID (0xc098)

### DIFF
--- a/src/drivers/logitech/hidpp.test.ts
+++ b/src/drivers/logitech/hidpp.test.ts
@@ -29,6 +29,7 @@ const G403_HERO = 0xc08f;
 const G703 = 0xc087;
 const G502 = 0xc07d;
 const G502_X_PLUS = 0xc095;
+const G502_X_LIGHTSPEED = 0xc098;
 const G502_X = 0xc099;
 const LIGHTSPEED_RECEIVER = 0xc54d;
 const SUPERSTRIKE_USB = 0xc0a8;
@@ -52,6 +53,7 @@ test("runtime probing alone classifies direct and receiver connections", () => {
 test("the G502 family direct USB interfaces are recognized", () => {
   assert.equal(isDirectConnectProduct(G502), true);
   assert.equal(isDirectConnectProduct(G502_X_PLUS), true);
+  assert.equal(isDirectConnectProduct(G502_X_LIGHTSPEED), true);
   assert.equal(isDirectConnectProduct(G502_X), true);
   assert.equal(isDirectConnectProduct(LIGHTSPEED_RECEIVER), false);
 });

--- a/src/logitech/index.ts
+++ b/src/logitech/index.ts
@@ -43,6 +43,7 @@ export const BOLT_PAIRING_SLOTS = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06] as const;
  * - 0xc08e — G903 HERO (wired)
  * - 0xc08f — G403 HERO (wired)
  * - 0xc095 — G502 X PLUS (USB cable)
+ * - 0xc098 — G502 X LIGHTSPEED (USB cable, direct-connect mode)
  * - 0xc099 — G502 X (wired)
  *
  * G Pro X Superlight generation:
@@ -61,7 +62,7 @@ export const LOGITECH_DIRECT_PRODUCT_IDS = [
   // G Pro X Superlight generation
   0xc094,
   // G502 X generation
-  0xc095, 0xc099,
+  0xc095, 0xc098, 0xc099,
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- `lsusb` showed a G502 X LIGHTSPEED enumerating directly as `046d:c098` when connected by USB cable, distinct from its Lightspeed dongle connection.
- That PID was missing from `LOGITECH_DIRECT_PRODUCT_IDS`, so a cable-connected G502 X LIGHTSPEED wouldn't be recognized as a direct HID++ endpoint.
- Added `0xc098` to the direct-connect PID list and its doc comment, plus test coverage in `hidpp.test.ts`.

## Cross-check against Solaar
Checked Solaar's `descriptors.py`: it has no static PID entry for the G502 X family either (G502 X, X PLUS, X LIGHTSPEED all rely on runtime HID++ 2.0 feature-table probing rather than a hardcoded quirks entry), which matches this driver's approach — no further special-casing needed for core features (DPI, buttons, battery, onboard profiles). Solaar's only model-specific carve-out is an RGB NVConfig color allowlist scoped to G502 X PLUS's modelId specifically; this codebase has no equivalent allowlist to update.

## Testing
- `npm test` — 818/818 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PAJakuepDJB8rZVc5ZFyy

---
_Generated by [Claude Code](https://claude.ai/code/session_016PAJakuepDJB8rZVc5ZFyy)_