### PR TITLE
logitech: refuse format-7 profile writes on the original Pro X Superlight

### DIFF
--- a/docs/logitech-onboard-profiles.md
+++ b/docs/logitech-onboard-profiles.md
@@ -574,6 +574,17 @@ stages them into a single pending-change group for the same reason.
 layout, so it is the Superstrike; a Superlight 2 is most likely 7, but that is a
 guess until read from hardware.
 
+**The original G Pro X Superlight (PID `0xc094`, wpid `4093` — "PRO X Wireless"
+in Logitech's/Solaar's naming) reports format 7 but is not the Superlight 2 this
+layout was verified on.** Live reports show it returning HID++ error `0x05`
+("Logitech internal error") when the format-7 write sequence used for LOD,
+debounce and angle-snap is applied — the device rejects an offset that is valid
+on the Superlight 2. This matches the unresolved DPI-stage-offset report below.
+`onboard-profiles.ts` refuses profile-content writes for this specific PID via
+`isProfileWritableForProduct` even though format 7 is otherwise trusted; lift
+that once a profile dump from a real `0xc094` device confirms (or corrects) the
+layout it actually uses.
+
 **Names for format ids 7 and 8**, and the meaning of the extra
 component-specific prototype fields (for example `dpi_v6` carries
 `0, 1, 2, 5, 5, 0, 2, 4` after offset and size — plausibly stage count, stride

--- a/src/drivers/logitech/hidpp.ts
+++ b/src/drivers/logitech/hidpp.ts
@@ -94,6 +94,7 @@ import {
   decodeOnboardProfile,
   describeProfileFormat,
   dpiStageCapabilitiesForOptions,
+  isProfileWritableForProduct,
   encodeDpiStages,
   encodeButtonAssignment,
   encodeMacroButtonAssignment,
@@ -742,8 +743,7 @@ export class LogitechHidppClient {
     // only change once that format is verified and actually carries a
     // report-rate field. Anything else stays read-only.
     const profileRateWritable = this.isDirectConnect
-      && this.profileFormatId !== null
-      && describeProfileFormat(this.profileFormatId).writable
+      && isProfileWritableForProduct(this.profileFormatId, this.device.productId)
       && capabilitiesForFormat(this.profileFormatId).reportRates !== null;
     const liftOffDistance = decodeLiftOffLevel(dpiState.lod, this.lodCapabilities);
     const hasLiveLiftOffControl = !dpiFeature.legacy && dpiCapabilities.liftOff;
@@ -1316,8 +1316,12 @@ export class LogitechHidppClient {
     }
     const info = parseProfilesInfo(await this.request(feature.index, PROFILE_FN.getInfo));
     const format = describeProfileFormat(info.profileFormatId);
-    if (!format.writable) {
-      throw new Error(`Profile format ${format.id} profile-content writes have not been verified on hardware.`);
+    if (!isProfileWritableForProduct(format.id, this.device.productId)) {
+      throw new Error(
+        format.writable
+          ? `Profile format ${format.id} writes have not been verified on this device (PID 0x${this.device.productId.toString(16)}).`
+          : `Profile format ${format.id} profile-content writes have not been verified on hardware.`,
+      );
     }
 
     // A profile can be edited without the mouse being switched to it, so the

--- a/src/drivers/logitech/onboard-profiles.test.ts
+++ b/src/drivers/logitech/onboard-profiles.test.ts
@@ -16,6 +16,7 @@ import {
   decodeLiftOffLevel,
   describeProfileFormat,
   dpiStageCapabilitiesForOptions,
+  isProfileWritableForProduct,
   encodeDpiStages,
   encodeButtonAssignment,
   encodeMacroButtonAssignment,
@@ -1113,4 +1114,20 @@ test("G502 keyboard shortcuts and consumer keys use direct four-byte HID binding
   const media = encodeButtonAssignment(keyboard, 2, "g-shift", 5, { kind: "consumer", usage: 0x00cd });
   assert.deepEqual([...media.slice(0x60 + 5 * 4, 0x60 + 6 * 4)], [0x80, 0x03, 0x00, 0xcd]);
   assert.equal(profileCrc(media), storedCrc(media));
+});
+
+test("format 7 writes are refused on the original G Pro X Superlight (PID 0xc094)", () => {
+  // Format 7's layout was only confirmed against a Pro X Superlight 2 dump;
+  // the original Superlight reports the same format id on a different board
+  // and rejects the write on hardware (HID++ error 0x05). It stays read-only
+  // until a dump from that PID confirms the layout.
+  assert.equal(describeProfileFormat(7).writable, true);
+  assert.equal(isProfileWritableForProduct(7, 0xc094), false);
+  // Other format-7 devices (e.g. the Superlight 2) are unaffected.
+  assert.equal(isProfileWritableForProduct(7, 0xc099), true);
+  assert.equal(isProfileWritableForProduct(7, null), true);
+  assert.equal(isProfileWritableForProduct(7, undefined), true);
+  // Unwritable formats stay refused regardless of product id.
+  assert.equal(isProfileWritableForProduct(6, 0xc099), false);
+  assert.equal(isProfileWritableForProduct(null, 0xc099), false);
 });

--- a/src/drivers/logitech/onboard-profiles.ts
+++ b/src/drivers/logitech/onboard-profiles.ts
@@ -58,6 +58,31 @@ const WRITABLE_FORMATS = new Set([2, 3, 4, 7]);
 const PROFILE_WRITE_PROBE_FORMATS = new Set([2, 3, 4]);
 const FACTORY_RESET_FORMATS = new Set([7]);
 
+/**
+ * Format 7's layout was recovered from a Pro X Superlight 2 dump; the original
+ * G Pro X Superlight (PID 0xc094, wpid 4093 — Logitech's "PRO X Wireless" in
+ * its own tooling) reports the same format id but is a different, older
+ * board. docs/logitech-onboard-profiles.md records an unresolved report of a
+ * differently-shifted DPI stage layout on what is likely this device, and
+ * live reports show it returning HID++ error 0x05 ("Logitech internal error")
+ * when the format-7 write sequence is applied — the device rejects an offset
+ * that is valid for the Superlight 2. Until a dump from this specific PID
+ * confirms (or corrects) the layout, refuse writes on it even though the
+ * format id is otherwise trusted.
+ */
+const UNVERIFIED_WRITE_PRODUCT_IDS = new Set([0xc094]);
+
+/** Whether profile-content writes for `profileFormatId` are trusted on this specific device. */
+export function isProfileWritableForProduct(
+  profileFormatId: number | null | undefined,
+  productId: number | null | undefined,
+): boolean {
+  if (profileFormatId === null || profileFormatId === undefined) return false;
+  if (!WRITABLE_FORMATS.has(profileFormatId)) return false;
+  if (productId !== null && productId !== undefined && UNVERIFIED_WRITE_PRODUCT_IDS.has(productId)) return false;
+  return true;
+}
+
 /** Whether this format has a reversible guided write probe. */
 export function supportsProfileWriteProbe(profileFormatId: number | null | undefined): boolean {
   return profileFormatId !== null


### PR DESCRIPTION
## Bug report

Users connecting the original **Logitech G Pro X Superlight** (not the 2) hit `Connection failed — The mouse rejected that setting (Logitech internal error).` when the app tries to write a live setting (LOD/debounce/angle-snap), even though the mouse connects and shows up fine.

## Root cause

The onboard-profile **format 7** write layout used for that path was recovered from a **Pro X Superlight 2** dump (see `docs/logitech-onboard-profiles.md`). The original G Pro X Superlight — PID `0xc094`, wpid `4093`, called "PRO X Wireless" by Logitech/Solaar — reports the same format id (7) but is different, older hardware. `docs/logitech-onboard-profiles.md` already carried an unresolved note about an account reporting differently-offset DPI stage fields; this appears to be that device. The device firmware rejects the write with HID++ error `0x05` ("Logitech internal error") because the offset that's valid on the Superlight 2 isn't valid on this board.

## Fix

Writes were previously gated only on `profileFormatId` (deliberately, so any device on a known format inherits its limits without a per-model check). That assumption breaks here because two different devices share format id 7 with (apparently) different memory layouts.

Added `isProfileWritableForProduct(profileFormatId, productId)` in `onboard-profiles.ts`, which adds a narrow, explicit product-id exception for PID `0xc094` on top of the existing format-writable check. Wired it into both places `hidpp.ts` decides writability:
- the direct-connect report-rate writable flag
- `openActiveProfile`, the single choke point every profile-content write (LOD, debounce, angle-snap, DPI stages, bunny hop, etc.) goes through

Reads/decoding are untouched — the Superlight 1 still shows its onboard profile, it just can't be edited until a real dump confirms the correct layout for that PID.

Added a regression test and a documentation note recording the finding for whoever eventually captures a Superlight 1 dump.

## Testing
- `npm run build` — clean
- `npm test` — 825/825 passing (824 existing + 1 new)
