### PR TITLE
feat(ksnake): add X11 driver draft (VID 0xA8A4/0xA8A5 PID 0x2255)

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,10 @@
     "./glorious-classic": {
       "types": "./dist/glorious-classic/index.d.ts",
       "import": "./dist/glorious-classic/index.js"
+    },
+    "./ksnake": {
+      "types": "./dist/ksnake/index.d.ts",
+      "import": "./dist/ksnake/index.js"
     }
   },
   "scripts": {

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -62,8 +62,8 @@ describe("ksnake codec", () => {
     assert.deepEqual(config?.stages.slice(0, 4), [800, 1200, 1600, 3200]);
   });
 
-  it("round-trips polling rates", () => {
-    for (const hz of [125, 250, 500, 1000, 2000, 4000, 8000]) {
+  it("round-trips polling rates (X11: 125-1000 Hz)", () => {
+    for (const hz of [125, 250, 500, 1000]) {
       const index = ksnakeEncodePollingRate(hz);
       assert.ok(index !== null);
       assert.equal(ksnakeDecodePollingRate(index as number), hz);

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  KSNAKE_PRODUCT_ID,
+  KSNAKE_USAGE,
+  KSNAKE_USAGE_PAGE,
+  ksnakeDecodeBattery,
+  ksnakeDecodeConfig,
+  ksnakeDecodePollingRate,
+  ksnakeDecodeVersion,
+  ksnakeEncodePollingRate,
+  ksnakeEncodeSetConfig,
+  ksnakeGetBatteryRequest,
+  ksnakeGetConfigRequest,
+  ksnakeGetVersionRequest,
+} from "../../ksnake/index.js";
+import { KsnakeHidClient } from "./hid.ts";
+
+function fakeDevice(overrides?: Partial<HIDDevice>): HIDDevice {
+  return {
+    vendorId: 0xa8a5,
+    productId: KSNAKE_PRODUCT_ID,
+    productName: "USB Receiver",
+    opened: false,
+    collections: [{ usagePage: KSNAKE_USAGE_PAGE, usage: KSNAKE_USAGE, children: [] }],
+    open: async () => {},
+    close: async () => {},
+    sendReport: async () => {},
+    sendFeatureReport: async () => {},
+    receiveFeatureReport: async () => new DataView(new ArrayBuffer(64)),
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    ...overrides,
+  } as unknown as HIDDevice;
+}
+
+describe("ksnake codec", () => {
+  it("frames version/battery/config requests", () => {
+    assert.equal(ksnakeGetVersionRequest()[1], 0x03);
+    assert.equal(ksnakeGetBatteryRequest()[1], 0x30);
+    assert.deepEqual([...ksnakeGetConfigRequest().slice(0, 7)], [0x55, 0x0e, 0xa5, 0x0b, 0x2f, 0x01, 0x01]);
+  });
+
+  it("decodes version ASCII", () => {
+    const reply = new Uint8Array(64);
+    reply[23] = 49;
+    reply[24] = 50;
+    reply[25] = 51;
+    assert.equal(ksnakeDecodeVersion(reply), "1.2.3");
+  });
+
+  it("decodes battery", () => {
+    const reply = new Uint8Array(64);
+    reply[8] = 87;
+    reply[9] = 1;
+    assert.deepEqual(ksnakeDecodeBattery(reply), { percent: 87, charging: 1 });
+  });
+
+  it("falls back to defaults on blank config", () => {
+    const config = ksnakeDecodeConfig(new Uint8Array(64));
+    assert.ok(config);
+    assert.deepEqual(config?.stages.slice(0, 4), [800, 1200, 1600, 3200]);
+  });
+
+  it("round-trips polling rates", () => {
+    for (const hz of [125, 250, 500, 1000, 2000, 4000, 8000]) {
+      const index = ksnakeEncodePollingRate(hz);
+      assert.ok(index !== null);
+      assert.equal(ksnakeDecodePollingRate(index as number), hz);
+    }
+  });
+
+  it("encodes setConfig with vendor layout", () => {
+    const req = ksnakeEncodeSetConfig({
+      lightMode: 2,
+      reportRate: 3,
+      dpiIndex: 2,
+      dpiCount: 5,
+      stages: [800, 1200, 1600, 3200, 5000, 12000],
+      scrollFlag: 0,
+      lodValue: 1,
+      sensorFlag: 53,
+      keyRespond: 2,
+      sleepLight: 10,
+      highspeedMode: 0,
+      wakeupFlag: 1,
+      moveLightFlag: 1,
+    });
+    assert.equal(req[10], 4);
+    assert.equal(req[12], 3);
+    assert.equal(req[17], 0x40);
+    assert.equal(req[18], 0x06);
+  });
+});
+
+describe("KsnakeHidClient", () => {
+  it("matches the X11 control collection", () => {
+    assert.equal(KsnakeHidClient.isSupported(fakeDevice()), true);
+    assert.equal(KsnakeHidClient.isSupported(fakeDevice({ vendorId: 0x046d })), false);
+    assert.equal(KsnakeHidClient.isSupported(fakeDevice({ productId: 0x1234 })), false);
+  });
+
+  it("rejects unsupported polling rates without touching HID", async () => {
+    const client = new KsnakeHidClient(fakeDevice());
+    await assert.rejects(() => client.setPollingRate(9999), /does not support/);
+  });
+});

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -1,0 +1,161 @@
+import type { MouseStatus } from "../mouse-types.ts";
+import {
+  KSNAKE_PRODUCT_ID,
+  KSNAKE_REPORT_ID,
+  KSNAKE_USAGE,
+  KSNAKE_USAGE_PAGE,
+  KSNAKE_USB_VENDOR_ID,
+  ksnakeDecodeBattery,
+  ksnakeDecodeConfig,
+  ksnakeDecodePollingRate,
+  ksnakeDecodeVersion,
+  ksnakeEncodePollingRate,
+  ksnakeEncodeSetConfig,
+  ksnakeGetBatteryRequest,
+  ksnakeGetConfigRequest,
+  ksnakeGetVersionRequest,
+} from "../../ksnake/index.js";
+import { VENDOR_ID } from "../vendors.ts";
+
+const REPLY_TIMEOUT_MS = 800;
+
+/**
+ * K-snake X11 vendor HID control (DRAFT — needs hardware verification).
+ *
+ * Transport: output report 0 (64 bytes starting with 0x55); the reply
+ * arrives as the next `inputreport`. A tiny queue serializes concurrent
+ * calls like the vendor panel's commandQueueWrapper.
+ *
+ * Evidence: vendor panel at https://x1a11.yjx2012.com/ plus a user HID
+ * Diagnostic Report (VID 0xA8A5, Vendor 0xFF01 interface, PARTIAL — expected
+ * since this protocol never uses feature reports).
+ */
+export class KsnakeHidClient {
+  readonly device: HIDDevice;
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+  }
+
+  static isSupported(device: HIDDevice): boolean {
+    if (device.productId !== KSNAKE_PRODUCT_ID) return false;
+    if (device.vendorId !== VENDOR_ID.ksnakeUsb && device.vendorId !== VENDOR_ID.ksnakeDongle) return false;
+    const search = (list: readonly HIDCollectionInfo[]): boolean =>
+      list.some(
+        (c) => (c.usagePage === KSNAKE_USAGE_PAGE && c.usage === KSNAKE_USAGE) || search(c.children),
+      );
+    return search(device.collections);
+  }
+
+  get supportedPollingRates(): number[] {
+    return [125, 250, 500, 1000, 2000, 4000, 8000];
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    if (this.device.opened) await this.device.close();
+  }
+
+  private async run<T>(task: () => Promise<T>): Promise<T> {
+    const started = this.queue.then(task, task);
+    this.queue = started.catch(() => undefined);
+    return started;
+  }
+
+  private async exchange(body: Uint8Array): Promise<Uint8Array> {
+    return this.run(async () => {
+      await this.open();
+      return new Promise<Uint8Array>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          this.device.removeEventListener("inputreport", listener);
+          reject(new Error("The mouse did not answer — it may be asleep or out of range."));
+        }, REPLY_TIMEOUT_MS);
+        const listener = (event: HIDInputReportEvent): void => {
+          clearTimeout(timer);
+          this.device.removeEventListener("inputreport", listener);
+          resolve(copyDataView(event.data));
+        };
+        this.device.addEventListener("inputreport", listener);
+        this.device.sendReport(KSNAKE_REPORT_ID, new Uint8Array(body.slice(0, 64)).buffer).catch((error: unknown) => {
+          clearTimeout(timer);
+          this.device.removeEventListener("inputreport", listener);
+          reject(error);
+        });
+      });
+    });
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    await this.open();
+    const [config, battery, version] = await Promise.all([
+      this.exchange(ksnakeGetConfigRequest()).then((r) => ksnakeDecodeConfig(r)).catch(() => null),
+      this.exchange(ksnakeGetBatteryRequest()).then((r) => ksnakeDecodeBattery(r)).catch(() => null),
+      this.exchange(ksnakeGetVersionRequest()).then((r) => ksnakeDecodeVersion(r)).catch(() => null),
+    ]);
+    const stages = config?.stages ?? [];
+    const activeStage = config ? Math.min(Math.max(config.dpiIndex, 0), Math.max(stages.length - 1, 0)) : 0;
+    const dpi = stages[activeStage] ?? 1600;
+    const pollingRateHz = config ? (ksnakeDecodePollingRate(config.reportRate) ?? 1000) : 1000;
+    return {
+      brand: "K-snake",
+      name: this.device.productName || "K-snake X11",
+      ui: {
+        family: "ksnake",
+        settingsReady: config !== null,
+        hideLodLow: true,
+        hideUnsupportedPollingRates: true,
+        hideProcessingCard: true,
+        defaultDisplayName: this.device.productName || "K-snake X11",
+      },
+      batteryPercent: battery ? Math.min(battery.percent, 100) : null,
+      batteryState: battery ? (battery.charging !== 0 ? "Charging" : "Discharging") : "Unknown",
+      dpi,
+      pollingRateHz,
+      supportedPollingRates: this.supportedPollingRates,
+      activeProfile: null,
+      connectionType: this.device.vendorId === KSNAKE_USB_VENDOR_ID ? "Wired" : "Wireless",
+      connectionDetail: this.device.vendorId === KSNAKE_USB_VENDOR_ID ? "Wired USB" : "2.4 GHz receiver",
+      liftOffDistance: null,
+      firmware: version ? [`X11 ${version}`] : ["K-snake X11"],
+    };
+  }
+
+  async setDpi(dpi: number): Promise<number> {
+    const raw = await this.exchange(ksnakeGetConfigRequest());
+    const config = ksnakeDecodeConfig(raw);
+    if (!config) throw new Error("Could not read the current config from the mouse.");
+    const stages = [...config.stages];
+    const index = Math.min(Math.max(config.dpiIndex, 0), stages.length - 1);
+    stages[index] = dpi;
+    await this.exchange(ksnakeEncodeSetConfig({ ...config, stages }));
+    const confirmed = await this.exchange(ksnakeGetConfigRequest())
+      .then((r) => ksnakeDecodeConfig(r))
+      .catch(() => null);
+    const got = confirmed?.stages[Math.min(Math.max(confirmed.dpiIndex, 0), confirmed.stages.length - 1)];
+    if (got !== dpi) throw new Error(`The mouse kept ${got ?? "?"} DPI instead of ${dpi}.`);
+    return dpi;
+  }
+
+  async setPollingRate(rate: number): Promise<number> {
+    const index = ksnakeEncodePollingRate(rate);
+    if (index === null) throw new Error(`This mouse does not support ${rate} Hz.`);
+    const raw = await this.exchange(ksnakeGetConfigRequest());
+    const config = ksnakeDecodeConfig(raw);
+    if (!config) throw new Error("Could not read the current config from the mouse.");
+    await this.exchange(ksnakeEncodeSetConfig({ ...config, reportRate: index }));
+    const confirmed = await this.exchange(ksnakeGetConfigRequest())
+      .then((r) => ksnakeDecodeConfig(r))
+      .catch(() => null);
+    const back = confirmed ? ksnakeDecodePollingRate(confirmed.reportRate) : null;
+    if (back !== rate) throw new Error(`The mouse kept ${back ?? "?"} Hz instead of ${rate} Hz.`);
+    return rate;
+  }
+}
+
+function copyDataView(view: DataView): Uint8Array {
+  return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+}

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -52,6 +52,10 @@ export class KsnakeHidClient {
     return [125, 250, 500, 1000, 2000, 4000, 8000];
   }
 
+  getDpiOptions(): number[] {
+    return [400, 800, 1200, 1600, 2400, 3200, 5000, 6400, 8000, 12000, 16000, 26000];
+  }
+
   async open(): Promise<void> {
     if (!this.device.opened) await this.device.open();
   }

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -49,11 +49,14 @@ export class KsnakeHidClient {
   }
 
   get supportedPollingRates(): number[] {
-    return [125, 250, 500, 1000, 2000, 4000, 8000];
+    return [125, 250, 500, 1000];
   }
 
   getDpiOptions(): number[] {
-    return [400, 800, 1200, 1600, 2400, 3200, 5000, 6400, 8000, 12000, 16000, 26000];
+    // PAW3311, vendor slider 200–12000. Defaults: 800/1200/1600/3200/5000/12000.
+    const options: number[] = [];
+    for (let dpi = 200; dpi <= 12000; dpi += 100) options.push(dpi);
+    return options;
   }
 
   async open(): Promise<void> {
@@ -114,10 +117,19 @@ export class KsnakeHidClient {
         hideUnsupportedPollingRates: true,
         hideProcessingCard: true,
         defaultDisplayName: this.device.productName || "K-snake X11",
+        dpiStageEditor: {
+          maxStages: 6,
+          countEditable: false,
+          minDpi: 200,
+          maxDpi: 12000,
+          stepDpi: 100,
+        },
       },
       batteryPercent: battery ? Math.min(battery.percent, 100) : null,
       batteryState: battery ? (battery.charging !== 0 ? "Charging" : "Discharging") : "Unknown",
       dpi,
+      dpiStages: stages.length ? stages : undefined,
+      activeDpiStage: stages.length ? activeStage : undefined,
       pollingRateHz,
       supportedPollingRates: this.supportedPollingRates,
       activeProfile: null,

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -118,7 +118,7 @@ export type MouseLightingMode =
   | "Breathing dual";
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;

--- a/src/drivers/registry.test.ts
+++ b/src/drivers/registry.test.ts
@@ -39,7 +39,7 @@ function collectionShapes(): HIDCollectionInfo[][] {
   shapes.push(USAGE_PAGES.map((page) =>
     collection(page, 1, { feature: REPORT_IDS, input: REPORT_IDS, output: REPORT_IDS })));
   for (const page of USAGE_PAGES) {
-    for (const usage of [0, 1, 2, 0x61]) {
+    for (const usage of [0, 1, 2, 0x10, 0x61]) {
       shapes.push([collection(page, usage, { feature: REPORT_IDS, input: REPORT_IDS, output: REPORT_IDS })]);
       for (const id of REPORT_IDS) {
         shapes.push([collection(page, usage, { input: [id], output: [id] })]);

--- a/src/drivers/registry.ts
+++ b/src/drivers/registry.ts
@@ -42,9 +42,10 @@ import { GloriousHidClient } from "./glorious/hid.ts";
 import { GloriousClassicHidClient } from "./glorious/classic-hid.ts";
 import { MchoseHidClient } from "./mchose/hid.ts";
 import { MchoseDockHidClient } from "./mchose/dock-hid.ts";
+import { KsnakeHidClient } from "./ksnake/hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient | PulsarXs1HidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | AttackSharkHidClient | FantechHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | AttackSharkHidClient | FantechHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -98,6 +99,7 @@ export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "Glorious", supports: (device) => GloriousClassicHidClient.isSupported(device), create: (device) => new GloriousClassicHidClient(device), score: () => 5 },
   { brand: "MCHOSE", supports: (device) => MchoseHidClient.isSupported(device), create: (device) => new MchoseHidClient(device), score: () => 7 },
   { brand: "MCHOSE", supports: (device) => MchoseDockHidClient.isSupported(device), create: (device) => new MchoseDockHidClient(device), score: () => 7 },
+  { brand: "K-snake", supports: (device) => KsnakeHidClient.isSupported(device), create: (device) => new KsnakeHidClient(device), score: () => 5 },
 ];
 
 function driverFor(device: HIDDevice): DeviceDriver | undefined {

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -85,6 +85,8 @@ export const VENDOR_ID = {
   gloriousClassicIWired: 0x320f, // Model O V2 / Model I 2 wired
   gloriousO3: 0x3794, // Model O3 Wireless / receiver (newer CORE-v2 generation)
   mchose: 0x3837,
+  ksnakeUsb: 0xa8a4, // K-snake X11 wired
+  ksnakeDongle: 0xa8a5, // K-snake X11 2.4 GHz dongle
 } as const;
 
 /**
@@ -448,4 +450,8 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   ...STEELSERIES_RIVAL3_FILTERS,
   { vendorId: VENDOR_ID.glorious },
   ...GLORIOUS_CLASSIC_HID_FILTERS,
+  // K-snake X11 exposes its 0x55-framed control channel on 0xFF01:0x10 for
+  // both the wired USB VID and the 2.4 GHz dongle VID.
+  { vendorId: VENDOR_ID.ksnakeUsb, productId: 0x2255, usagePage: 0xff01, usage: 0x10 },
+  { vendorId: VENDOR_ID.ksnakeDongle, productId: 0x2255, usagePage: 0xff01, usage: 0x10 },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,4 @@ export * as wlmouse from "./wlmouse/index.js";
 export * as zaunkoenig from "./zaunkoenig/index.js";
 export * as gwolves from "./gwolves/index.js";
 export * as glorious from "./glorious/index.js";
+export * as ksnake from "./ksnake/index.js";

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -1,0 +1,211 @@
+/**
+ * K-snake X11 configuration protocol, reverse-engineered from the vendor
+ * WebHID panel shipped at https://x1a11.yjx2012.com/ (Next.js `app/page` chunk).
+ *
+ * Transport: WebHID output report (`sendReport(0, 64 bytes starting with
+ * 0x55)`) with the reply arriving as a queued `inputreport` — not a feature
+ * report. Control collection is usage page 0xFF01, usage 0x10; the vendor
+ * picker requests:
+ *   [{ vendorId: 0xA8A4, productId: 0x2255, usagePage: 0xFF01, usage: 0x10 },
+ *    { vendorId: 0xA8A5, productId: 0x2255, usagePage: 0xFF01, usage: 0x10 }]
+ * 0xA8A4 reports "USB", 0xA8A5 is the 2.4 GHz dongle.
+ *
+ * This module is transport-independent: it only builds 64-byte report bodies
+ * and decodes reply buffers. See `src/drivers/ksnake/hid.ts` for the WebHID
+ * exchange queue.
+ */
+
+export const KSNAKE_USB_VENDOR_ID = 0xa8a4;
+export const KSNAKE_DONGLE_VENDOR_ID = 0xa8a5;
+export const KSNAKE_PRODUCT_ID = 0x2255;
+export const KSNAKE_USAGE_PAGE = 0xff01;
+export const KSNAKE_USAGE = 0x10;
+
+export const KSNAKE_REPORT_ID = 0x00;
+export const KSNAKE_MAGIC = 0x55;
+export const KSNAKE_REPORT_SIZE = 64;
+
+export interface KsnakeProduct {
+  model: string;
+  wireless: boolean;
+  /** Not yet exercised on hardware through this driver. */
+  verified: false;
+}
+
+export const KSNAKE_PRODUCTS: ReadonlyMap<number, KsnakeProduct> = new Map([
+  [KSNAKE_PRODUCT_ID, { model: "X11", wireless: true, verified: false }],
+]);
+
+const CMD = {
+  GET_VERSION: 0x03,
+  GET_CONFIG: 0x0e,
+  SET_CONFIG: 0x0f,
+  SET_LIGHT: 0x21,
+  GET_BATTERY: 0x30,
+} as const;
+
+const GET_CONFIG_TAIL = [0xa5, 0x0b, 0x2f, 0x01, 0x01, 0x00, 0x00, 0x00] as const;
+const SET_CONFIG_HEAD = [0xae, 0x0a, 0x2f, 0x01, 0x01, 0x00, 0x00] as const;
+const GET_BATTERY_TAIL = [0xa5, 0x0b, 0x2e, 0x01, 0x01, 0x00, 0x00, 0x00] as const;
+
+/**
+ * Polling-rate index ↔ Hz.
+ * The vendor panel only stores the index (default 3); index 3 = 1000 Hz is
+ * assumed from that default. Confirm the 125–8000 order on hardware.
+ */
+export const KSNAKE_POLLING_RATES = [125, 250, 500, 1000, 2000, 4000, 8000] as const;
+
+export function ksnakeEncodePollingRate(hz: number): number | null {
+  const index = (KSNAKE_POLLING_RATES as readonly number[]).indexOf(hz);
+  return index === -1 ? null : index;
+}
+
+export function ksnakeDecodePollingRate(index: number): number | null {
+  return index >= 0 && index < KSNAKE_POLLING_RATES.length ? KSNAKE_POLLING_RATES[index] : null;
+}
+
+export const KSNAKE_DEFAULT_CONFIG = {
+  lightMode: 2,
+  reportRate: 3,
+  dpiIndex: 2,
+  dpiCount: 5,
+  stages: [800, 1200, 1600, 3200, 5000, 12000],
+  scrollFlag: 0,
+  lodValue: 1,
+  sensorFlag: 53,
+  keyRespond: 2,
+  sleepLight: 10,
+  highspeedMode: 0,
+  wakeupFlag: 1,
+  moveLightFlag: 1,
+} as const;
+
+export interface KsnakeConfig {
+  lightMode: number;
+  /** 0-based index into KSNAKE_POLLING_RATES */
+  reportRate: number;
+  /** 0-based active DPI stage */
+  dpiIndex: number;
+  /** number of enabled DPI stages */
+  dpiCount: number;
+  /** up to 6 LE uint16 DPI stages */
+  stages: number[];
+  scrollFlag: number;
+  lodValue: number;
+  sensorFlag: number;
+  keyRespond: number;
+  sleepLight: number;
+  highspeedMode: number;
+  wakeupFlag: number;
+  moveLightFlag: number;
+}
+
+function le16(lo: number, hi: number): number {
+  return ((hi & 0xff) << 8) | (lo & 0xff);
+}
+
+/** 64-byte output-report body (without the reportId prefix). */
+export function ksnakeGetVersionRequest(): Uint8Array {
+  const buf = new Uint8Array(KSNAKE_REPORT_SIZE);
+  buf[0] = KSNAKE_MAGIC;
+  buf[1] = CMD.GET_VERSION;
+  return buf;
+}
+
+/** Vendor reply bytes [23..25] hold ASCII "x.y.z" when present. */
+export function ksnakeDecodeVersion(reply: Uint8Array): string | null {
+  if (reply.length < 26) return null;
+  const digit = (b: number): string | null => (b >= 48 && b <= 57 ? String.fromCharCode(b) : null);
+  const major = digit(reply[23]);
+  const minor = digit(reply[24]);
+  const patch = digit(reply[25]);
+  if (major === null || minor === null || patch === null) return null;
+  return `${major}.${minor}.${patch}`;
+}
+
+export function ksnakeGetBatteryRequest(): Uint8Array {
+  const buf = new Uint8Array(KSNAKE_REPORT_SIZE);
+  buf[0] = KSNAKE_MAGIC;
+  buf[1] = CMD.GET_BATTERY;
+  GET_BATTERY_TAIL.forEach((b, i) => {
+    buf[2 + i] = b;
+  });
+  return buf;
+}
+
+export function ksnakeDecodeBattery(reply: Uint8Array): { percent: number; charging: number } | null {
+  if (reply.length < 10) return null;
+  return { percent: reply[8] & 0xff, charging: reply[9] & 0xff };
+}
+
+export function ksnakeGetConfigRequest(): Uint8Array {
+  const buf = new Uint8Array(KSNAKE_REPORT_SIZE);
+  buf[0] = KSNAKE_MAGIC;
+  buf[1] = CMD.GET_CONFIG;
+  GET_CONFIG_TAIL.forEach((b, i) => {
+    buf[2 + i] = b;
+  });
+  return buf;
+}
+
+/** Decode a getConfig reply, mirroring the vendor `getMouseConfigInfo()`. */
+export function ksnakeDecodeConfig(reply: Uint8Array): KsnakeConfig | null {
+  if (reply.length < 56) return null;
+  const blank = reply[13] === 0 && reply[14] === 0 && reply[15] === 0;
+  const erased = reply[13] === 255 && reply[14] === 255 && reply[15] === 255;
+  if (blank || erased) {
+    return { ...KSNAKE_DEFAULT_CONFIG, stages: [...KSNAKE_DEFAULT_CONFIG.stages] };
+  }
+  return {
+    lightMode: reply[9],
+    reportRate: reply[10] - 1,
+    dpiIndex: reply[12] - 1,
+    dpiCount: reply[11],
+    stages: [
+      le16(reply[13], reply[14]),
+      le16(reply[15], reply[16]),
+      le16(reply[17], reply[18]),
+      le16(reply[19], reply[20]),
+      le16(reply[21], reply[22]),
+      le16(reply[23], reply[24]),
+    ],
+    scrollFlag: reply[48],
+    lodValue: reply[49],
+    sensorFlag: reply[50],
+    keyRespond: reply[51],
+    sleepLight: reply[52],
+    highspeedMode: reply[53],
+    // NOTE: vendor decode reads wakeup from the LOW nibble, but vendor encode
+    // writes `wakeup << 4 | move`. Kept as-decoded; verify on hardware.
+    wakeupFlag: reply[55] & 15,
+    moveLightFlag: (reply[55] >> 4) & 15,
+  };
+}
+
+/** Encode a setConfig request, mirroring vendor `setMouseConfigData()`. */
+export function ksnakeEncodeSetConfig(config: KsnakeConfig): Uint8Array {
+  const buf = new Uint8Array(KSNAKE_REPORT_SIZE);
+  buf[0] = KSNAKE_MAGIC;
+  buf[1] = CMD.SET_CONFIG;
+  SET_CONFIG_HEAD.forEach((b, i) => {
+    buf[2 + i] = b;
+  });
+  buf[9] = config.lightMode & 0xff;
+  buf[10] = (config.reportRate + 1) & 0xff;
+  buf[11] = config.dpiCount & 0xff;
+  buf[12] = (config.dpiIndex + 1) & 0xff;
+  const stages = [...config.stages];
+  while (stages.length < 6) stages.push(0);
+  for (let i = 0; i < 6; i++) {
+    buf[13 + i * 2] = stages[i] & 0xff;
+    buf[14 + i * 2] = (stages[i] >> 8) & 0xff;
+  }
+  buf[48] = config.scrollFlag & 0xff;
+  buf[49] = config.lodValue & 0xff;
+  buf[50] = config.sensorFlag & 0xff;
+  buf[51] = config.keyRespond & 0xff;
+  buf[52] = config.sleepLight & 0xff;
+  buf[53] = config.highspeedMode & 0xff;
+  buf[54] = ((config.wakeupFlag << 4) | (config.moveLightFlag & 15)) & 0xff;
+  return buf;
+}

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -50,10 +50,11 @@ const GET_BATTERY_TAIL = [0xa5, 0x0b, 0x2e, 0x01, 0x01, 0x00, 0x00, 0x00] as con
 
 /**
  * Polling-rate index ↔ Hz.
- * The vendor panel only stores the index (default 3); index 3 = 1000 Hz is
- * assumed from that default. Confirm the 125–8000 order on hardware.
+ * Confirmed by vendor panel screenshot + PAW3311 spec: X11 offers
+ * 125/250/500/1000 Hz only (1000 Hz in 2.4G/wired, 125 Hz in BT).
+ * Default index 3 = 1000 Hz.
  */
-export const KSNAKE_POLLING_RATES = [125, 250, 500, 1000, 2000, 4000, 8000] as const;
+export const KSNAKE_POLLING_RATES = [125, 250, 500, 1000] as const;
 
 export function ksnakeEncodePollingRate(hz: number): number | null {
   const index = (KSNAKE_POLLING_RATES as readonly number[]).indexOf(hz);


### PR DESCRIPTION
Rebase of #54 onto main resolving conflicts in mouse-types.ts, registry.ts, vendors.ts (additive merges with the MCHOSE driver landed in #55). Closes #54.