### PR TITLE
endgame: stop identifying the XM2w 4K v2 as an OP1w 4K v2

### DIFF
--- a/src/drivers/endgame/egg-op1-hid.ts
+++ b/src/drivers/endgame/egg-op1-hid.ts
@@ -99,7 +99,7 @@ export class EggOp1HidClient {
 
   constructor(device: HIDDevice) {
     this.device = device;
-    this.profile = eggProfileForPid(device.productId);
+    this.profile = eggProfileForPid(device.productId, device.productName);
   }
 
   static isSupported(device: HIDDevice): boolean {

--- a/src/drivers/endgame/egg-op1-protocol.test.ts
+++ b/src/drivers/endgame/egg-op1-protocol.test.ts
@@ -14,6 +14,7 @@ import {
   eggIsValidCpi,
   eggLodOptions,
   eggNormalizeFeatureReport,
+  eggProfileForPid,
   eggReadUint16LE,
   eggWriteEnabledCpiStages,
 } from "@openmouse/protocol/endgame-gear-op1";
@@ -38,6 +39,15 @@ test("OP1w 4K v2 wireless models are capped at 4000 Hz while wired 8K models kee
   assert.equal(op1v2.maxPollingHz, 8000);
   assert.equal(EGG_DEVICE_PROFILES.get(0x1984)!.maxPollingHz, 4000);
   assert.equal(EGG_DEVICE_PROFILES.get(0x1970)!.maxPollingHz, 4000);
+});
+
+test("the shared 4K v2 dongle PIDs resolve to XM2w by the mouse's own reported name, not OP1w by default", () => {
+  assert.equal(eggProfileForPid(0x1970).name, "Endgame Gear OP1w 4K v2");
+  assert.equal(eggProfileForPid(0x1984).name, "Endgame Gear OP1w 4K v2");
+  assert.equal(eggProfileForPid(0x1970, "Endgame Gear XM2w 4K v2").name, "Endgame Gear XM2w 4K v2");
+  assert.equal(eggProfileForPid(0x1984, "Endgame Gear XM2w 4K v2").name, "Endgame Gear XM2w 4K v2");
+  // A wired-model PID is never reinterpreted, even if a name happened to mention "xm2".
+  assert.equal(eggProfileForPid(0x1978, "xm2").name, "Endgame Gear OP1 8K v2");
 });
 
 test("CPI ranges and quantization follow each sensor generation", () => {

--- a/src/endgame-gear/op1.ts
+++ b/src/endgame-gear/op1.ts
@@ -116,7 +116,11 @@ export const EGG_DEVICE_PROFILES: ReadonlyMap<number, EggDeviceProfile> = new Ma
   // OP1w 4K v2: first wireless model on the OP1-8K v2 config protocol. The
   // dongle's own USB PID (0x1970) is reused from the older, unrelated OP1we
   // (see egg-we-hid.ts) — descriptor-based detection there keeps the two
-  // drivers from both claiming it. See issue #107.
+  // drivers from both claiming it. See issue #107. That same dongle PID (and
+  // its 0x1984 successor) is also reused across the OP1w and XM2w 4K v2
+  // mice — the receiver hardware doesn't distinguish them, only the mouse's
+  // own reported name does, so `eggProfileForPid` takes the device name and
+  // resolves to `EGG_XM2W_4K_V2_PIDS` below when it mentions "xm2".
   [0x1984, {
     pid: 0x1984,
     name: "Endgame Gear OP1w 4K v2",
@@ -146,6 +150,14 @@ export const EGG_DEVICE_PROFILES: ReadonlyMap<number, EggDeviceProfile> = new Ma
     maxPollingHz: 4000,
   }],
 ]);
+
+/** PIDs whose dongle is shared between an OP1w and an XM2w 4K v2 mouse. */
+const EGG_XM2W_4K_V2_PIDS = new Set([0x1970, 0x1984]);
+
+const EGG_XM2W_4K_V2_PROFILE: EggDeviceProfile = {
+  ...EGG_DEVICE_PROFILES.get(0x1984)!,
+  name: "Endgame Gear XM2w 4K v2",
+};
 
 export const EGG_REPORT = {
   config: 0xa0,
@@ -221,7 +233,8 @@ export function eggNormalizeFeatureReport(
   return result;
 }
 
-export function eggProfileForPid(pid: number): EggDeviceProfile {
+export function eggProfileForPid(pid: number, productName = ""): EggDeviceProfile {
+  if (EGG_XM2W_4K_V2_PIDS.has(pid) && productName.toLowerCase().includes("xm2")) return EGG_XM2W_4K_V2_PROFILE;
   const profile = EGG_DEVICE_PROFILES.get(pid);
   if (!profile) throw new Error(`Unsupported Endgame Gear product 0x${pid.toString(16)}.`);
   return profile;


### PR DESCRIPTION
## What this fixes

Reported: the Endgame Gear XM2w 4K v2 was showing up as an "OP1w 4K v2".

The OP1w and XM2w 4K v2 mice share the same wireless dongle USB PID (0x1970/0x1984) — the receiver hardware doesn't distinguish the paired mouse, only the mouse's own reported name does. `eggProfileForPid` only ever did a PID-keyed lookup into a table that hardcodes the OP1w 4K v2 name for both PID entries, so every XM2w 4K v2 behind that dongle reported itself as an OP1w 4K v2.

`egg-we-hid.ts` already solved this exact problem for the older OP1we/XM2we pair (which reuse PID 0x1970 too) by checking `device.productName`. This applies the same fix to `eggProfileForPid`: it now takes an optional product name and resolves the shared-PID case to an "Endgame Gear XM2w 4K v2" profile when the name mentions "xm2".