### PR TITLE
corsair: add read-only NIGHTSWORD RGB driver (VID 0x1b1c, PID 0x1b5c)

### DIFF
--- a/captures/corsair-nightsword/PROTOCOL.md
+++ b/captures/corsair-nightsword/PROTOCOL.md
@@ -1,0 +1,192 @@
+# Corsair NIGHTSWORD RGB — protocol notes for OpenMouse
+
+**VID/PID:** `0x1B1C` / `0x1B5C`
+**Verified on:** firmware 3.41, bootloader 3.08, Windows 11, Chrome WebHID, 2026‑09‑05
+**Protocol origin:** ckb-next NXP protocol (`src/daemon/nxp_proto.h`, `dpi.c`, `device_mouse.c`, `firmware.c`), with two corrections found on real hardware (byte order, no ack on SET).
+
+## Interfaces (Windows enumeration)
+
+| Interface | Collections | Role |
+|---|---|---|
+| `MI_00` | COL01 mouse, COL02 consumer control, COL03–05 vendor-defined | HID input / Corsair key events |
+| `MI_01` | one collection, usage page `0xFFC2`, usage `0x04` | **Config channel** |
+
+`MI_01` report descriptor: input 64 B (ID 0), output 64 B (ID 0), feature 64 B (ID 0).
+
+**Picker gotcha:** `MI_00` also carries an `0xFFC2` collection (usage `3`, input report ID 14 only), plus `0xFFC1`/`0xFFC3` vendor collections. A WebHID filter on `usagePage: 0xffc2` alone matches both interfaces and the chooser shows two identical "CORSAIR NIGHTSWORD RGB Gaming Mouse" entries. Filter on `usagePage: 0xffc2, usage: 4`, and have `isSupported()` require a collection with usage 4 that declares a feature report on ID 0.
+
+## Transport — CONFIRMED
+
+- 64-byte packets, report ID 0, zero-padded.
+- **Feature reports.** `sendFeatureReport(0, pkt)` to send, then `receiveFeatureReport(0)` to read the reply. Interrupt `sendReport` is accepted but the device does not answer on `inputreport` for this firmware.
+- Chrome on Windows returns the feature buffer **without** a report-ID prefix — byte 0 is the command echo.
+- ~20 ms between send and receive was sufficient; ckb-next uses 6–10 ms between packets. Serialise all traffic.
+- GET replies echo request bytes 0–3; use that as the match check.
+- **SET commands produce no reply.** `receiveFeatureReport` after a SET returns the stale buffer from the previous GET. Confirm writes by issuing the corresponding GET.
+- iCUE's background service holds `MI_01` open. `open()` still succeeds (shared mode) but every transfer throws `NotAllowedError: Failed to write the feature report`. Stop `Corsair Service` and kill `iCUE*`; the service auto-restarts on device arrival, so `Set-Service "Corsair Service" -StartupType Manual` during development. The driver should surface this error as "close iCUE".
+  - **Corrected 2026‑09‑06 (Chrome 152, iCUE app + service running and actively applying its profile).** Probed both granted interfaces from the same page: `sendFeatureReport(0, 0e 13 02 00)` on MI_00 (`0xffc2` usage 3, no feature report) throws exactly `NotAllowedError: Failed to write the feature report.`; the same call on MI_01 (`0xffc2` usage 4, feature 0) returns `0e 13 02 00 02 09 60 09 60` (stage 2, 2400 = iCUE's profile). The OpenMouse driver also completed a 130 s session of successful reads with iCUE up. So the error was the wrong picker entry, not iCUE holding the interface; iCUE and a WebHID reader coexist in shared mode. The `usagePage: 0xffc2, usage: 4` filter prevents the wrong interface from being selected. The driver keeps the "close iCUE" mapping only as a fallback for a real `NotAllowedError`.
+
+## Packet layout
+
+```
+byte 0  command   0x0e = GET, 0x07 = SET
+byte 1  field
+byte 2  subcommand (for FIELD_MOUSE 0x13)
+byte 3  profile flag — see below
+byte 4+ payload
+```
+
+### Profile flag (byte 3) — CONFIRMED
+
+| Value | Meaning | Result on Nightsword fw 3.41 |
+|---|---|---|
+| `0` | live / software settings | **populated** — use this |
+| `1` | stored hardware profile | returns zeros for DPI fields; ckb-next disables hwload for this device (file-based profile format, field `0x17` + bulk `0xff`, not implemented here) |
+
+**Persistence — CONFIRMED:** writes with byte 3 = 0 are volatile. After unplug/replug the mouse boots from its onboard profile and live changes are gone (stage 1 set to 1000 → read back 1500 after replug). iCUE re-applies its software profile on every connect, which is why settings appear to persist with iCUE running. Persisting to onboard memory requires the file-based profile format (out of scope for phase 1/2).
+
+Fields used:
+
+| Field | Value | R/W |
+|---|---|---|
+| `FIELD_IDENT` | `0x01` | R |
+| `FIELD_POLLRATE` | `0x0a` | W |
+| `FIELD_MOUSE` | `0x13` | R/W (subcommand) |
+| `FIELD_M_PROFID` | `0x15` | R/W |
+| `FIELD_M_PROFNM` | `0x16` | R/W, UTF‑16LE |
+
+`FIELD_MOUSE` subcommands:
+
+| Sub | Value | Meaning |
+|---|---|---|
+| `MOUSE_DPI` | `0x02` | current DPI stage index (+ current X/Y in reply) |
+| `MOUSE_LIFT` | `0x03` | lift-off height |
+| `MOUSE_SNAP` | `0x04` | angle snap (0/1) |
+| `MOUSE_DPIMASK` | `0x05` | enabled-stage bitmask |
+| `MOUSE_DPIPROF` | `0xd0 \| stage` | per-stage DPI X/Y + RGB |
+
+**Stage count:** 6 slots (`d0`–`d5`). Observed mask `0x0f` = 4 enabled.
+
+**Slot meaning — CONFIRMED against the iCUE DPI panel (2026‑09‑06):** `d0` is the **Sniper** stage (held-button DPI; iCUE indicator colour yellow `ff ff 00`), and iCUE's numbered *Stage 1/2/3* are `d1`/`d2`/`d3` (indicator cyan `00 bf ff`). `MOUSE_DPI` byte 4 is the slot index, so "current stage 2" = iCUE Stage 2. Factory profile colours for `d1`/`d2` are `00 bf ff` (read live via the OpenMouse diagnostics log).
+
+## Byte order — CONFIRMED (asymmetric)
+
+- **GET replies present DPI X/Y big-endian**: `03 20` = 800, `09 60` = 2400, `16 44` = 5700.
+- **SET takes DPI X/Y little-endian**: writing `20 03` stores 800 (reads back `03 20`); writing `06 40` stores 0x4006 = 16390 (reads back `40 06`).
+- ckb-next encodes SET LE (correct) and decodes GET LE (wrong for this firmware). Parse reads BE, write LE.
+- **A `MOUSE_DPIPROF` write without bytes 9–11 zeroes the stage colour.** Always read the stage first and write RGB back, or require RGB in the API.
+
+Identity fields (`FIELD_IDENT`) are little-endian (`41 03` = 0x0341, `1c 1b` = 0x1B1C) — confirmed.
+
+## Read-only commands — CONFIRMED
+
+### Identify / firmware / poll rate
+```
+TX: 0e 01 00
+RX: 0e 01 00 00 01 01 00 01 | @8 fw u16 LE | @10 bl u16 LE | @12 VID u16 LE | @14 PID u16 LE | @16 poll ms
+Observed: fw 0x0341, bl 0x0308, VID 0x1b1c, PID 0x1b5c, poll 1 (=1000 Hz)
+Bytes 39 and 46 changed between sessions (02/55 → 01/aa) — likely profile/stage status; not decoded.
+```
+
+### DPI / sensor state (byte 3 = 0)
+```
+TX: 0e 13 05 00        RX byte 4 = enabled bitmask            (obs: 0f)
+TX: 0e 13 02 00        RX byte 4 = current stage, @5 X u16 BE, @7 Y u16 BE   (obs: 02, 2400, 2400)
+TX: 0e 13 03 00        RX byte 4 = lift height                (obs: 05)
+TX: 0e 13 04 00        RX byte 4 = angle snap                 (obs: 00)
+TX: 0e 13 (d0|n) 00    RX @5 X u16 BE, @7 Y u16 BE, @9 R, @10 G, @11 B
+Observed (iCUE-loaded live profile): 0=400 (ff ff 00), 1=800 (00 bf ff), 2=2400 (00 bf ff), 3=5700 (00 bf ff), 4–5 zero, stage 2 active
+Observed (factory onboard profile, after replug with iCUE stopped): 0=800 (ff ff 00), 1=1500, 2=3000, 3=6000 (00 bf ff), 4–5 zero, mask 0f, lift 5, snap 0, stage 1 active
+```
+
+### Profile ID
+```
+TX: 0e 15 01
+RX: 0e 15 00 00 5c 1b 00 00 02 00 … @20 01   (contents not yet interpreted)
+```
+
+## Write commands (phase 2)
+
+```
+Select stage:      07 13 02 00 <stage>
+Enabled mask:      07 13 05 00 <mask>
+Stage values:      07 13 (d0|n) 00 <xyIndependent 0/1> <xLo> <xHi> <yLo> <yHi> <r> <g> <b>   (LE; RGB required)
+Lift height:       07 13 03 00 <height>
+Angle snap:        07 13 04 00 <0/1> 05          ← trailing 0x05 in ckb-next; unverified
+Poll rate:         07 0a 00 00 <interval ms: 1|2|4|8>
+```
+
+No reply on SET; read back with GET to confirm. Byte 3 = 0 writes are live/non-persistent (survive until power cycle at most). Persisting to the hardware profile uses the file-based format and is out of scope.
+
+**Poll-rate caveat:** ckb-next notes the device re-enumerates after `FIELD_POLLRATE`; the driver must handle the WebHID device closing and reconnect.
+
+## Still to confirm
+
+1. Whether `07 13 02 00 <n>` switches stage live (cursor speed changes).
+3. `MOUSE_SNAP` trailing `0x05` byte.
+4. Poll-rate write and reconnect behaviour.
+5. Profile-ID reply layout (optional).
+
+A USBPcap capture of iCUE is now only needed if any of the above misbehave, or for phase 3 (hardware-profile persistence via `0x17` / `0xff`).
+
+## WebHID probe (working)
+
+```js
+const [d] = await navigator.hid.requestDevice({ filters: [{ vendorId: 0x1b1c, productId: 0x1b5c, usagePage: 0xffc2, usage: 4 }] });
+// or from getDevices(): pick the one whose collection is usagePage 0xffc2, usage 4, with a feature report
+await d.open();
+const hex = b => Array.from(b).map(x => x.toString(16).padStart(2,'0')).join(' ');
+async function q(...bytes) {
+  const p = new Uint8Array(64); p.set(bytes);
+  await d.sendFeatureReport(0, p);
+  await new Promise(r => setTimeout(r, 20));
+  return new Uint8Array((await d.receiveFeatureReport(0)).buffer);
+}
+console.log(hex(await q(0x0e,0x01)));           // ident
+console.log(hex(await q(0x0e,0x13,0x02,0)));    // current stage + dpi
+```
+
+## mouse-protocol codec sketch (feature-report transport, BE DPI)
+
+```ts
+const MSG = 64;
+const CMD_GET = 0x0e, CMD_SET = 0x07;
+const F_IDENT = 0x01, F_POLL = 0x0a, F_MOUSE = 0x13;
+const M_DPI = 0x02, M_LIFT = 0x03, M_SNAP = 0x04, M_MASK = 0x05, M_PROF = 0xd0;
+const LIVE = 0; // byte 3: live/software settings
+
+const pkt = (...b: number[]) => { const p = new Uint8Array(MSG); p.set(b); return p; };
+const u16le = (b: Uint8Array, i: number) => b[i] | (b[i + 1] << 8);
+const u16be = (b: Uint8Array, i: number) => (b[i] << 8) | b[i + 1];
+
+export const encode = {
+  ident:       ()          => pkt(CMD_GET, F_IDENT, 0),
+  dpiMask:     ()          => pkt(CMD_GET, F_MOUSE, M_MASK, LIVE),
+  dpiStage:    ()          => pkt(CMD_GET, F_MOUSE, M_DPI, LIVE),
+  lift:        ()          => pkt(CMD_GET, F_MOUSE, M_LIFT, LIVE),
+  snap:        ()          => pkt(CMD_GET, F_MOUSE, M_SNAP, LIVE),
+  stage:       (n: number) => pkt(CMD_GET, F_MOUSE, M_PROF | n, LIVE),
+  setStage:    (n: number) => pkt(CMD_SET, F_MOUSE, M_DPI, LIVE, n),
+  // SET is little-endian; RGB must be supplied or the stage colour is cleared.
+  setStageDpi: (n: number, x: number, y: number, rgb: readonly [number, number, number]) =>
+    pkt(CMD_SET, F_MOUSE, M_PROF | n, LIVE, x !== y ? 1 : 0, x & 0xff, x >> 8, y & 0xff, y >> 8, ...rgb),
+  setPollMs:   (ms: 1|2|4|8) => pkt(CMD_SET, F_POLL, 0, 0, ms),
+};
+
+export const decode = {
+  isEcho: (req: Uint8Array, r: Uint8Array) =>
+    r[0] === req[0] && r[1] === req[1] && r[2] === req[2] && r[3] === req[3],
+  ident: (r: Uint8Array) => ({
+    fw: u16le(r, 8), bootloader: u16le(r, 10),
+    vid: u16le(r, 12), pid: u16le(r, 14), pollMs: r[16],
+  }),
+  byte4: (r: Uint8Array) => r[4],
+  dpiStage: (r: Uint8Array) => ({ stage: r[4], x: u16be(r, 5), y: u16be(r, 7) }),
+  stage: (r: Uint8Array) => ({
+    x: u16be(r, 5), y: u16be(r, 7), rgb: [r[9], r[10], r[11]] as const,
+  }),
+};
+
+// Transport contract for the client: GET = sendFeatureReport → delay → receiveFeatureReport,
+// verify decode.isEcho; SET = sendFeatureReport only (no reply), then GET to confirm.
+```

--- a/captures/corsair-nightsword/PROTOCOL.md
+++ b/captures/corsair-nightsword/PROTOCOL.md
@@ -108,24 +108,34 @@ RX: 0e 15 00 00 5c 1b 00 00 02 00 … @20 01   (contents not yet interpreted)
 ## Write commands (phase 2)
 
 ```
-Select stage:      07 13 02 00 <stage>
+Select stage:      07 13 02 00 <stage>                  CONFIRMED live (cursor speed changes)
 Enabled mask:      07 13 05 00 <mask>
 Stage values:      07 13 (d0|n) 00 <xyIndependent 0/1> <xLo> <xHi> <yLo> <yHi> <r> <g> <b>   (LE; RGB required)
-Lift height:       07 13 03 00 <height>
-Angle snap:        07 13 04 00 <0/1> 05          ← trailing 0x05 in ckb-next; unverified
+Lift height:       07 13 03 00 <height>                 CONFIRMED, 1–5 all accepted
+Angle snap:        07 13 04 00 <0/1> [05]               CONFIRMED with and without the trailing 0x05
 Poll rate:         07 0a 00 00 <interval ms: 1|2|4|8>
 ```
 
 No reply on SET; read back with GET to confirm. Byte 3 = 0 writes are live/non-persistent (survive until power cycle at most). Persisting to the hardware profile uses the file-based format and is out of scope.
 
+### Write probe — 2026‑09‑06, iCUE app + service running
+
+Run from the OpenMouse origin in Chrome 152 against the usage‑4 interface (`write-probe.txt` has the raw log):
+
+- `07 13 02 00 01` → `0e 13 02 00 01 03 20 03 20`: slot 1 (800) selected, cursor noticeably slower for the 10 s hold; iCUE did not override it in that window. `07 13 02 00 02` restored slot 2 (2400).
+- `07 13 04 00 01 05` → snap reads `01`; `07 13 04 00 00` (no trailing byte) → reads `00`. The ckb-next trailing `0x05` is harmless and not required.
+- `07 13 03 00 h` for h = 1…5 → each reads back as written. Mapping of raw height to iCUE's Surface Calibration lift-off labels still to be recorded.
+
 **Poll-rate caveat:** ckb-next notes the device re-enumerates after `FIELD_POLLRATE`; the driver must handle the WebHID device closing and reconnect.
 
 ## Still to confirm
 
-1. Whether `07 13 02 00 <n>` switches stage live (cursor speed changes).
-3. `MOUSE_SNAP` trailing `0x05` byte.
+1. ~~Whether `07 13 02 00 <n>` switches stage live~~ — confirmed 2026‑09‑06.
+2. Raw lift height (1–5) → iCUE Surface Calibration lift-off label mapping.
+3. ~~`MOUSE_SNAP` trailing `0x05` byte~~ — confirmed optional 2026‑09‑06.
 4. Poll-rate write and reconnect behaviour.
 5. Profile-ID reply layout (optional).
+6. `MOUSE_DPIMASK` and `MOUSE_DPIPROF` writes (encoded and unit-tested, not yet sent to hardware).
 
 A USBPcap capture of iCUE is now only needed if any of the above misbehave, or for phase 3 (hardware-profile persistence via `0x17` / `0xff`).
 

--- a/captures/corsair-nightsword/README.md
+++ b/captures/corsair-nightsword/README.md
@@ -1,0 +1,26 @@
+# Corsair NIGHTSWORD RGB fixtures
+
+Hardware-verified reference material for `src/corsair/` and
+`src/drivers/corsair/`. Everything here was read from a NIGHTSWORD RGB
+(VID `0x1b1c`, PID `0x1b5c`) on firmware 3.41 / bootloader 3.08 over Chrome
+WebHID on Windows 11, 2026-09-05. No serial numbers or personal data are
+included.
+
+| File | What it is |
+|---|---|
+| `PROTOCOL.md` | The protocol write-up: interfaces and picker filter, feature-report transport, packet layout, profile flag, the asymmetric DPI byte order, read-only and write commands, open questions, and the codec sketch the code follows. |
+| `ident.hex` | Reply to `0e 01 00` (identify): firmware `0x0341`, bootloader `0x0308`, VID/PID little-endian, poll interval 1 ms. |
+| `dpi-mask.hex` | Reply to `0e 13 05 00`: enabled-stage bitmask `0x0f` (stages 0–3). |
+| `dpi-current.hex` | Reply to `0e 13 02 00`: active stage 2, X/Y 2400 big-endian (`09 60`). |
+| `lift.hex` | Reply to `0e 13 03 00`: lift-off height 5. |
+| `snap.hex` | Reply to `0e 13 04 00`: angle snapping off. |
+| `stages-icue.hex` | Replies to `0e 13 d0..d5 00` with iCUE's software profile loaded: d0 = Sniper 400 (yellow), d1–d3 = iCUE Stage 1–3 at 800 / 2400 / 5700 (cyan), d4–d5 empty. |
+| `stages-factory.hex` | Replies to `0e 13 d0..d5 00` after replug with iCUE stopped (onboard profile): d0 = Sniper 800, d1–d3 = 1500 / 3000 / 6000. Slot 1 (Stage 1) was active, mask `0x0f`, lift 5, snap 0. |
+
+Each `.hex` file holds one reply per line as spaced hex, request bytes 0–3
+echoed at the front, trailing zeros of the 64-byte buffer omitted. Lines
+starting with `#` are comments. The tests in `src/corsair/index.test.ts` and
+`src/drivers/corsair/hid.test.ts` carry these same bytes inline.
+
+Not captured: the profile-ID reply (`0e 15 01`) is listed in `PROTOCOL.md`
+but not interpreted, and no SET command has a reply to record.

--- a/captures/corsair-nightsword/README.md
+++ b/captures/corsair-nightsword/README.md
@@ -16,6 +16,7 @@ included.
 | `snap.hex` | Reply to `0e 13 04 00`: angle snapping off. |
 | `stages-icue.hex` | Replies to `0e 13 d0..d5 00` with iCUE's software profile loaded: d0 = Sniper 400 (yellow), d1–d3 = iCUE Stage 1–3 at 800 / 2400 / 5700 (cyan), d4–d5 empty. |
 | `stages-factory.hex` | Replies to `0e 13 d0..d5 00` after replug with iCUE stopped (onboard profile): d0 = Sniper 800, d1–d3 = 1500 / 3000 / 6000. Slot 1 (Stage 1) was active, mask `0x0f`, lift 5, snap 0. |
+| `write-probe.txt` | Live SET probe with read-backs: stage select (`07 13 02`) switches live, angle snap (`07 13 04`) works with and without the trailing `0x05`, lift height (`07 13 03`) accepts 1–5. All restored afterwards. |
 
 Each `.hex` file holds one reply per line as spaced hex, request bytes 0–3
 echoed at the front, trailing zeros of the 64-byte buffer omitted. Lines

--- a/captures/corsair-nightsword/dpi-current.hex
+++ b/captures/corsair-nightsword/dpi-current.hex
@@ -1,0 +1,2 @@
+# GET 0e 13 02 00 -> current stage index, X u16 BE, Y u16 BE
+0e 13 02 00 02 09 60 09 60

--- a/captures/corsair-nightsword/dpi-mask.hex
+++ b/captures/corsair-nightsword/dpi-mask.hex
@@ -1,0 +1,2 @@
+# GET 0e 13 05 00 -> enabled stage bitmask
+0e 13 05 00 0f

--- a/captures/corsair-nightsword/ident.hex
+++ b/captures/corsair-nightsword/ident.hex
@@ -1,0 +1,2 @@
+# GET ident: 0e 01 00 -> fw 3.41, bl 3.08, VID 1b1c, PID 1b5c, poll 1 ms
+0e 01 00 00 01 01 00 01 41 03 08 03 1c 1b 5c 1b 01

--- a/captures/corsair-nightsword/lift.hex
+++ b/captures/corsair-nightsword/lift.hex
@@ -1,0 +1,2 @@
+# GET 0e 13 03 00 -> lift-off height
+0e 13 03 00 05

--- a/captures/corsair-nightsword/snap.hex
+++ b/captures/corsair-nightsword/snap.hex
@@ -1,0 +1,2 @@
+# GET 0e 13 04 00 -> angle snapping
+0e 13 04 00 00

--- a/captures/corsair-nightsword/stages-factory.hex
+++ b/captures/corsair-nightsword/stages-factory.hex
@@ -1,0 +1,9 @@
+# GET 0e 13 (d0|n) 00 after replug with iCUE stopped: factory onboard profile (stage 1 active)
+# d0 = Sniper slot (yellow); d1-d3 = iCUE Stage 1-3 (cyan). d1/d2 colours confirmed 00 bf ff from the live diagnostics log (2026-09-06)
+# @5 X u16 BE, @7 Y u16 BE, @9 R, @10 G, @11 B
+0e 13 d0 00 00 03 20 03 20 ff ff 00
+0e 13 d1 00 00 05 dc 05 dc 00 bf ff
+0e 13 d2 00 00 0b b8 0b b8 00 bf ff
+0e 13 d3 00 00 17 70 17 70 00 bf ff
+0e 13 d4 00
+0e 13 d5 00

--- a/captures/corsair-nightsword/stages-icue.hex
+++ b/captures/corsair-nightsword/stages-icue.hex
@@ -1,0 +1,8 @@
+# GET 0e 13 (d0|n) 00 with the iCUE software profile loaded (stage 2 active)
+# @5 X u16 BE, @7 Y u16 BE, @9 R, @10 G, @11 B
+0e 13 d0 00 00 01 90 01 90 ff ff 00
+0e 13 d1 00 00 03 20 03 20 00 bf ff
+0e 13 d2 00 00 09 60 09 60 00 bf ff
+0e 13 d3 00 00 16 44 16 44 00 bf ff
+0e 13 d4 00
+0e 13 d5 00

--- a/captures/corsair-nightsword/write-probe.txt
+++ b/captures/corsair-nightsword/write-probe.txt
@@ -1,0 +1,24 @@
+# Live SET probe, 2026-09-06, fw 3.41, Chrome 152, iCUE app + service running.
+# Each SET was followed by the matching GET after ~20 ms; only the GET replies are
+# listed (first 12 bytes). Writes use profile byte 0 (live) and were restored.
+
+stageBefore     0e 13 02 00 02 09 60 09 60 00 00 00
+snapBefore      0e 13 04 00 00 00 00 00 00 00 00 00
+liftBefore      0e 13 03 00 05 00 00 00 00 00 00 00
+
+# SET 07 13 02 00 01  (select slot 1) -> cursor noticeably slower for the 10 s hold
+stageAfterSet1  0e 13 02 00 01 03 20 03 20 00 00 00
+# SET 07 13 02 00 02  (restore slot 2)
+stageRestored   0e 13 02 00 02 09 60 09 60 00 00 00
+
+# SET 07 13 04 00 01 05  (angle snap on, ckb-next trailing byte)
+snapOnWith05    0e 13 04 00 01 00 00 00 00 00 00 00
+# SET 07 13 04 00 00     (angle snap off, no trailing byte)
+snapOffNo05     0e 13 04 00 00 00 00 00 00 00 00 00
+
+# SET 07 13 03 00 <h> for h = 1..5, each read back
+lift1           0e 13 03 00 01 00 00 00 00 00 00 00
+lift2           0e 13 03 00 02 00 00 00 00 00 00 00
+lift3           0e 13 03 00 03 00 00 00 00 00 00 00
+lift4           0e 13 03 00 04 00 00 00 00 00 00 00
+lift5           0e 13 03 00 05 00 00 00 00 00 00 00

--- a/package.json
+++ b/package.json
@@ -109,6 +109,10 @@
       "types": "./dist/zaunkoenig/index.d.ts",
       "import": "./dist/zaunkoenig/index.js"
     },
+    "./corsair": {
+      "types": "./dist/corsair/index.d.ts",
+      "import": "./dist/corsair/index.js"
+    },
     "./drivers": {
       "types": "./dist/drivers/index.d.ts",
       "import": "./dist/drivers/index.js"

--- a/src/corsair/index.test.ts
+++ b/src/corsair/index.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CORSAIR_CONFIG_USAGE,
+  CORSAIR_NIGHTSWORD_PRODUCT_ID,
+  CORSAIR_PRODUCTS,
+  CORSAIR_USAGE_PAGE,
+  CORSAIR_VENDOR_ID,
+  corsairDecode as decode,
+  corsairEnabledStages,
+  corsairEncode as encode,
+  corsairFormatVersion,
+  corsairIsEcho,
+  corsairRgbHex,
+} from "./index.ts";
+
+/** Parse a spaced-hex capture line into a zero-padded 64-byte reply. */
+function reply(hex: string): Uint8Array {
+  const bytes = hex.trim().split(/\s+/).map((byte) => Number.parseInt(byte, 16));
+  const packet = new Uint8Array(64);
+  packet.set(bytes);
+  return packet;
+}
+
+function head(packet: Uint8Array, count: number): number[] {
+  return [...packet.subarray(0, count)];
+}
+
+// Fixtures from captures/corsair-nightsword/PROTOCOL.md (fw 3.41, bl 3.08).
+const IDENT = reply("0e 01 00 00 01 01 00 01 41 03 08 03 1c 1b 5c 1b 01");
+const MASK = reply("0e 13 05 00 0f");
+const CURRENT_STAGE = reply("0e 13 02 00 02 09 60 09 60");
+const LIFT = reply("0e 13 03 00 05");
+const SNAP = reply("0e 13 04 00 00");
+
+// Live profile as loaded by iCUE: 400 / 800 / 2400 / 5700, stage 2 active.
+const ICUE_STAGES = [
+  reply("0e 13 d0 00 00 01 90 01 90 ff ff 00"),
+  reply("0e 13 d1 00 00 03 20 03 20 00 bf ff"),
+  reply("0e 13 d2 00 00 09 60 09 60 00 bf ff"),
+  reply("0e 13 d3 00 00 16 44 16 44 00 bf ff"),
+];
+
+// Factory onboard profile after replug with iCUE stopped: 800 / 1500 / 3000 / 6000.
+// d1/d2 colours confirmed 00 bf ff from the live diagnostics log (2026-09-06).
+const FACTORY_STAGES = [
+  reply("0e 13 d0 00 00 03 20 03 20 ff ff 00"),
+  reply("0e 13 d1 00 00 05 dc 05 dc 00 bf ff"),
+  reply("0e 13 d2 00 00 0b b8 0b b8 00 bf ff"),
+  reply("0e 13 d3 00 00 17 70 17 70 00 bf ff"),
+];
+
+test("catalog pins the NIGHTSWORD RGB on the usage-4 config collection", () => {
+  assert.equal(CORSAIR_VENDOR_ID, 0x1b1c);
+  assert.equal(CORSAIR_USAGE_PAGE, 0xffc2);
+  assert.equal(CORSAIR_CONFIG_USAGE, 4);
+  assert.deepEqual(CORSAIR_PRODUCTS.get(CORSAIR_NIGHTSWORD_PRODUCT_ID), {
+    name: "NIGHTSWORD RGB",
+    dpiMax: 18_000,
+    dpiStep: 1,
+    stages: 6,
+    verifiedFirmware: "3.41",
+  });
+});
+
+test("GET requests are 64-byte packets addressing the live profile", () => {
+  for (const packet of [encode.ident(), encode.dpiMask(), encode.dpiStage(), encode.lift(), encode.snap(), encode.stage(3)]) {
+    assert.equal(packet.length, 64);
+    assert.ok(packet.subarray(4).every((byte) => byte === 0));
+  }
+  assert.deepEqual(head(encode.ident(), 4), [0x0e, 0x01, 0x00, 0x00]);
+  assert.deepEqual(head(encode.dpiMask(), 4), [0x0e, 0x13, 0x05, 0x00]);
+  assert.deepEqual(head(encode.dpiStage(), 4), [0x0e, 0x13, 0x02, 0x00]);
+  assert.deepEqual(head(encode.lift(), 4), [0x0e, 0x13, 0x03, 0x00]);
+  assert.deepEqual(head(encode.snap(), 4), [0x0e, 0x13, 0x04, 0x00]);
+  assert.deepEqual(head(encode.stage(0), 4), [0x0e, 0x13, 0xd0, 0x00]);
+  assert.deepEqual(head(encode.stage(5), 4), [0x0e, 0x13, 0xd5, 0x00]);
+  assert.throws(() => encode.stage(6), /0–5/);
+  assert.throws(() => encode.stage(-1), /0–5/);
+});
+
+test("decodes the identity packet little-endian", () => {
+  const ident = decode.ident(IDENT);
+  assert.deepEqual(ident, {
+    firmware: 0x0341,
+    bootloader: 0x0308,
+    vendorId: 0x1b1c,
+    productId: 0x1b5c,
+    pollIntervalMs: 1,
+    pollingRateHz: 1000,
+  });
+  assert.equal(corsairFormatVersion(ident.firmware), "3.41");
+  assert.equal(corsairFormatVersion(ident.bootloader), "3.08");
+  assert.throws(() => decode.ident(IDENT.subarray(0, 16)), /shorter than 17/);
+});
+
+test("decodes the enabled-stage mask, lift height, and angle snap", () => {
+  assert.equal(decode.dpiMask(MASK), 0x0f);
+  assert.deepEqual(corsairEnabledStages(0x0f), [0, 1, 2, 3]);
+  assert.deepEqual(corsairEnabledStages(0x25), [0, 2, 5]);
+  assert.deepEqual(corsairEnabledStages(0), []);
+  assert.equal(decode.lift(LIFT), 5);
+  assert.equal(decode.snap(SNAP), false);
+  assert.equal(decode.snap(reply("0e 13 04 00 01")), true);
+});
+
+test("decodes the current stage reply with big-endian DPI", () => {
+  // "09 60" is 2400 only when read big-endian; little-endian would give 24585.
+  assert.deepEqual(decode.dpiStage(CURRENT_STAGE), { stage: 2, x: 2400, y: 2400 });
+  assert.notEqual(decode.dpiStage(CURRENT_STAGE).x, 0x6009);
+  assert.throws(() => decode.dpiStage(CURRENT_STAGE.subarray(0, 8)), /shorter than 9/);
+});
+
+test("decodes the iCUE-loaded stages d0–d3 big-endian with their colours", () => {
+  assert.deepEqual(ICUE_STAGES.map((stage) => decode.stage(stage)), [
+    { x: 400, y: 400, rgb: [0xff, 0xff, 0x00] },
+    { x: 800, y: 800, rgb: [0x00, 0xbf, 0xff] },
+    { x: 2400, y: 2400, rgb: [0x00, 0xbf, 0xff] },
+    { x: 5700, y: 5700, rgb: [0x00, 0xbf, 0xff] },
+  ]);
+  assert.equal(corsairRgbHex(decode.stage(ICUE_STAGES[0]!).rgb), "#ffff00");
+});
+
+test("decodes the factory onboard stages d0–d3", () => {
+  assert.deepEqual(FACTORY_STAGES.map((stage) => decode.stage(stage)), [
+    { x: 800, y: 800, rgb: [0xff, 0xff, 0x00] },
+    { x: 1500, y: 1500, rgb: [0x00, 0xbf, 0xff] },
+    { x: 3000, y: 3000, rgb: [0x00, 0xbf, 0xff] },
+    { x: 6000, y: 6000, rgb: [0x00, 0xbf, 0xff] },
+  ]);
+  const unused = reply("0e 13 d4 00");
+  assert.deepEqual(decode.stage(unused), { x: 0, y: 0, rgb: [0, 0, 0] });
+});
+
+test("setStageDpi writes DPI little-endian and always carries RGB", () => {
+  // 800 read back as "03 20" must be sent as "20 03".
+  const packet = encode.setStageDpi(1, 800, 800, [0x00, 0xbf, 0xff]);
+  assert.deepEqual(head(packet, 12), [0x07, 0x13, 0xd1, 0x00, 0x00, 0x20, 0x03, 0x20, 0x03, 0x00, 0xbf, 0xff]);
+  assert.equal(packet.length, 64);
+  // Hardware check from the capture: LE "06 40" stores 0x4006 = 16390.
+  const high = encode.setStageDpi(0, 16_390, 16_390, [0xff, 0xff, 0x00]);
+  assert.deepEqual(head(high, 12), [0x07, 0x13, 0xd0, 0x00, 0x00, 0x06, 0x40, 0x06, 0x40, 0xff, 0xff, 0x00]);
+  // Independent axes set byte 4.
+  assert.deepEqual(head(encode.setStageDpi(2, 1600, 800, [1, 2, 3]), 12),
+    [0x07, 0x13, 0xd2, 0x00, 0x01, 0x40, 0x06, 0x20, 0x03, 1, 2, 3]);
+  assert.throws(() => encode.setStageDpi(0, 70_000, 70_000, [0, 0, 0]), /0 to 65535/);
+  assert.throws(() => encode.setStageDpi(0, 800, 800, [0, 0] as unknown as [number, number, number]), /triple/);
+  assert.throws(() => encode.setStageDpi(0, 800, 800, [0, 0, 256]), /out of range/);
+});
+
+test("encode then decode round-trips DPI across the asymmetric byte order", () => {
+  for (const dpi of [1, 400, 800, 2400, 5700, 16_390, 18_000]) {
+    const written = encode.setStageDpi(0, dpi, dpi, [0, 0, 0]);
+    // A GET reply would present the same value big-endian.
+    const asRead = reply(`0e 13 d0 00 00 ${hex(dpi >> 8)} ${hex(dpi & 0xff)} ${hex(dpi >> 8)} ${hex(dpi & 0xff)} 00 00 00`);
+    assert.equal(written[5], dpi & 0xff);
+    assert.equal(written[6], dpi >> 8);
+    assert.equal(decode.stage(asRead).x, dpi);
+  }
+});
+
+test("remaining SET packets follow the ckb-next layout", () => {
+  assert.deepEqual(head(encode.setStage(3), 5), [0x07, 0x13, 0x02, 0x00, 0x03]);
+  assert.deepEqual(head(encode.setDpiMask(0x0f), 5), [0x07, 0x13, 0x05, 0x00, 0x0f]);
+  assert.throws(() => encode.setDpiMask(0x40), /0x3f/);
+  assert.deepEqual(head(encode.setLift(5), 5), [0x07, 0x13, 0x03, 0x00, 0x05]);
+  assert.deepEqual(head(encode.setSnap(true), 6), [0x07, 0x13, 0x04, 0x00, 0x01, 0x05]);
+  assert.deepEqual(head(encode.setPollMs(1), 5), [0x07, 0x0a, 0x00, 0x00, 0x01]);
+  assert.deepEqual(head(encode.setPollMs(8), 5), [0x07, 0x0a, 0x00, 0x00, 0x08]);
+  assert.throws(() => encode.setPollMs(3 as 1), /1, 2, 4, or 8/);
+});
+
+test("isEcho matches on the first four request bytes only", () => {
+  assert.equal(corsairIsEcho(encode.ident(), IDENT), true);
+  assert.equal(corsairIsEcho(encode.dpiStage(), CURRENT_STAGE), true);
+  assert.equal(corsairIsEcho(encode.stage(2), ICUE_STAGES[2]!), true);
+  assert.equal(corsairIsEcho(encode.stage(1), ICUE_STAGES[2]!), false);
+  // A stale buffer from the previous GET must not pass for a new request.
+  assert.equal(corsairIsEcho(encode.dpiMask(), CURRENT_STAGE), false);
+  assert.equal(corsairIsEcho(encode.ident(), new Uint8Array(3)), false);
+});
+
+function hex(value: number): string {
+  return value.toString(16).padStart(2, "0");
+}

--- a/src/corsair/index.ts
+++ b/src/corsair/index.ts
@@ -1,0 +1,255 @@
+/**
+ * Corsair NXP-family configuration protocol as spoken by the NIGHTSWORD RGB
+ * (firmware 3.41), reconstructed from ckb-next's `nxp_proto.h` / `dpi.c` and
+ * corrected against real hardware. The full trace lives in
+ * `captures/corsair-nightsword/PROTOCOL.md`.
+ *
+ * Transport: 64-byte feature reports on report id 0 over the interface whose
+ * collection is usage page 0xffc2, usage 4. A GET is `sendFeatureReport` then
+ * `receiveFeatureReport`; the reply echoes request bytes 0–3. A SET produces
+ * no reply at all — the driver confirms it with the matching GET.
+ *
+ * Byte order is asymmetric on this firmware: DPI X/Y arrive big-endian in GET
+ * replies but must be sent little-endian in SET payloads. Identity fields are
+ * little-endian. Nothing here transports bytes; the WebHID client lives in
+ * `src/drivers/corsair/hid.ts`.
+ */
+export const CORSAIR_VENDOR_ID = 0x1b1c;
+export const CORSAIR_USAGE_PAGE = 0xffc2;
+/** Usage of the config collection. MI_00 also carries an 0xffc2 collection with usage 3 that never answers. */
+export const CORSAIR_CONFIG_USAGE = 4;
+export const CORSAIR_REPORT_ID = 0;
+export const CORSAIR_PACKET_SIZE = 64;
+export const CORSAIR_NIGHTSWORD_PRODUCT_ID = 0x1b5c;
+
+export interface CorsairDeviceDefinition {
+  name: string;
+  dpiMax: number;
+  dpiStep: number;
+  /** Number of `MOUSE_DPIPROF` slots (d0–d5 on the NIGHTSWORD). */
+  stages: number;
+  /** Firmware the protocol was exercised on. */
+  verifiedFirmware: string;
+}
+
+export const CORSAIR_PRODUCTS: ReadonlyMap<number, CorsairDeviceDefinition> = new Map([
+  [CORSAIR_NIGHTSWORD_PRODUCT_ID, {
+    name: "NIGHTSWORD RGB",
+    dpiMax: 18_000,
+    dpiStep: 1,
+    stages: 6,
+    verifiedFirmware: "3.41",
+  }],
+]);
+
+export const CORSAIR_PRODUCT_IDS: readonly number[] = [...CORSAIR_PRODUCTS.keys()];
+
+export const CORSAIR_COMMAND = {
+  get: 0x0e,
+  set: 0x07,
+} as const;
+
+export const CORSAIR_FIELD = {
+  ident: 0x01,
+  pollRate: 0x0a,
+  mouse: 0x13,
+  profileId: 0x15,
+  profileName: 0x16,
+} as const;
+
+/** `FIELD_MOUSE` subcommands (packet byte 2). */
+export const CORSAIR_MOUSE = {
+  dpi: 0x02,
+  lift: 0x03,
+  snap: 0x04,
+  dpiMask: 0x05,
+  /** OR'd with the stage index: d0–d5. */
+  dpiProfile: 0xd0,
+} as const;
+
+/**
+ * Packet byte 3. Zero addresses the live/software settings; 1 would address the
+ * stored hardware profile, which returns zeros on the NIGHTSWORD. Live writes
+ * do not survive a power cycle.
+ */
+export const CORSAIR_LIVE_PROFILE = 0;
+export const CORSAIR_STAGE_COUNT = 6;
+/**
+ * Slot d0 is iCUE's "Sniper" stage (held-button DPI, yellow indicator); iCUE's
+ * numbered stages 1–5 are slots d1–d5. `MOUSE_DPI` reports the slot index, so
+ * a current stage of 2 means iCUE's Stage 2. Confirmed against the iCUE DPI
+ * panel on fw 3.41.
+ */
+export const CORSAIR_SNIPER_STAGE = 0;
+export const CORSAIR_POLL_INTERVALS_MS = [1, 2, 4, 8] as const;
+export type CorsairPollIntervalMs = (typeof CORSAIR_POLL_INTERVALS_MS)[number];
+
+export type CorsairRgb = readonly [number, number, number];
+
+export interface CorsairIdent {
+  firmware: number;
+  bootloader: number;
+  vendorId: number;
+  productId: number;
+  /** USB polling interval in milliseconds: 1 = 1000 Hz, 8 = 125 Hz. */
+  pollIntervalMs: number;
+  pollingRateHz: number;
+}
+
+export interface CorsairDpiStage {
+  x: number;
+  y: number;
+  rgb: CorsairRgb;
+}
+
+export interface CorsairCurrentDpi {
+  stage: number;
+  x: number;
+  y: number;
+}
+
+export function corsairDevice(productId: number): CorsairDeviceDefinition {
+  const definition = CORSAIR_PRODUCTS.get(productId);
+  if (!definition) throw new Error(`Unsupported Corsair product id 0x${productId.toString(16)}.`);
+  return definition;
+}
+
+/** A zero-padded 64-byte packet with `bytes` at the front. */
+export function corsairPacket(...bytes: number[]): Uint8Array {
+  if (bytes.length > CORSAIR_PACKET_SIZE) throw new Error("Corsair packet payload exceeds 64 bytes.");
+  const packet = new Uint8Array(CORSAIR_PACKET_SIZE);
+  packet.set(bytes.map(byteValue));
+  return packet;
+}
+
+/** `0x0341` → "3.41", matching how iCUE and ckb-next print the version. */
+export function corsairFormatVersion(word: number): string {
+  return `${(word >> 8) & 0xff}.${(word & 0xff).toString(16).padStart(2, "0")}`;
+}
+
+/** Slot indices whose bit is set in the `MOUSE_DPIMASK` byte. */
+export function corsairEnabledStages(mask: number, stages = CORSAIR_STAGE_COUNT): number[] {
+  const enabled: number[] = [];
+  for (let stage = 0; stage < stages; stage += 1) {
+    if (mask & (1 << stage)) enabled.push(stage);
+  }
+  return enabled;
+}
+
+export const corsairEncode = {
+  ident: (): Uint8Array => corsairPacket(CORSAIR_COMMAND.get, CORSAIR_FIELD.ident, 0),
+  dpiMask: (): Uint8Array => corsairPacket(CORSAIR_COMMAND.get, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.dpiMask, CORSAIR_LIVE_PROFILE),
+  dpiStage: (): Uint8Array => corsairPacket(CORSAIR_COMMAND.get, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.dpi, CORSAIR_LIVE_PROFILE),
+  lift: (): Uint8Array => corsairPacket(CORSAIR_COMMAND.get, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.lift, CORSAIR_LIVE_PROFILE),
+  snap: (): Uint8Array => corsairPacket(CORSAIR_COMMAND.get, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.snap, CORSAIR_LIVE_PROFILE),
+  stage: (stage: number): Uint8Array =>
+    corsairPacket(CORSAIR_COMMAND.get, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.dpiProfile | stageIndex(stage), CORSAIR_LIVE_PROFILE),
+
+  // Phase-2 writes. Encoded here so the byte layout is tested, but the
+  // read-only driver never sends them. None of these get a reply.
+  setStage: (stage: number): Uint8Array =>
+    corsairPacket(CORSAIR_COMMAND.set, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.dpi, CORSAIR_LIVE_PROFILE, stageIndex(stage)),
+  setDpiMask: (mask: number): Uint8Array => {
+    if (!Number.isInteger(mask) || mask < 0 || mask >= 1 << CORSAIR_STAGE_COUNT) {
+      throw new Error(`Corsair DPI stage mask must be 0x00–0x${((1 << CORSAIR_STAGE_COUNT) - 1).toString(16)}.`);
+    }
+    return corsairPacket(CORSAIR_COMMAND.set, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.dpiMask, CORSAIR_LIVE_PROFILE, mask);
+  },
+  /**
+   * SET payloads carry DPI little-endian. RGB is mandatory: a stage write
+   * without bytes 9–11 clears the stage colour, so a caller must read the stage
+   * first and pass its colour back.
+   */
+  setStageDpi: (stage: number, x: number, y: number, rgb: CorsairRgb): Uint8Array => {
+    dpiValue(x);
+    dpiValue(y);
+    if (rgb.length !== 3) throw new Error("Corsair stage colour must be an [r, g, b] triple.");
+    return corsairPacket(
+      CORSAIR_COMMAND.set, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.dpiProfile | stageIndex(stage), CORSAIR_LIVE_PROFILE,
+      x !== y ? 1 : 0,
+      x & 0xff, x >> 8,
+      y & 0xff, y >> 8,
+      ...rgb,
+    );
+  },
+  setLift: (height: number): Uint8Array =>
+    corsairPacket(CORSAIR_COMMAND.set, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.lift, CORSAIR_LIVE_PROFILE, byteValue(height)),
+  /** Trailing 0x05 mirrors ckb-next; unverified on hardware. */
+  setSnap: (enabled: boolean): Uint8Array =>
+    corsairPacket(CORSAIR_COMMAND.set, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.snap, CORSAIR_LIVE_PROFILE, enabled ? 1 : 0, 0x05),
+  /** The device re-enumerates after this; the WebHID handle closes. */
+  setPollMs: (intervalMs: CorsairPollIntervalMs): Uint8Array => {
+    if (!CORSAIR_POLL_INTERVALS_MS.includes(intervalMs)) throw new Error("Corsair polling interval must be 1, 2, 4, or 8 ms.");
+    return corsairPacket(CORSAIR_COMMAND.set, CORSAIR_FIELD.pollRate, 0, 0, intervalMs);
+  },
+} as const;
+
+/** True when a GET reply echoes the request's command, field, subcommand, and profile bytes. */
+export function corsairIsEcho(request: Uint8Array, reply: Uint8Array): boolean {
+  if (reply.length < 4 || request.length < 4) return false;
+  return reply[0] === request[0] && reply[1] === request[1] && reply[2] === request[2] && reply[3] === request[3];
+}
+
+export const corsairDecode = {
+  ident: (reply: Uint8Array): CorsairIdent => {
+    requireLength(reply, 17, "identity");
+    const pollIntervalMs = reply[16]!;
+    return {
+      firmware: u16le(reply, 8),
+      bootloader: u16le(reply, 10),
+      vendorId: u16le(reply, 12),
+      productId: u16le(reply, 14),
+      pollIntervalMs,
+      pollingRateHz: pollIntervalMs > 0 ? Math.round(1000 / pollIntervalMs) : 0,
+    };
+  },
+  byte4: (reply: Uint8Array): number => {
+    requireLength(reply, 5, "single-byte");
+    return reply[4]!;
+  },
+  dpiMask: (reply: Uint8Array): number => corsairDecode.byte4(reply),
+  lift: (reply: Uint8Array): number => corsairDecode.byte4(reply),
+  snap: (reply: Uint8Array): boolean => corsairDecode.byte4(reply) !== 0,
+  /** GET replies carry DPI big-endian. */
+  dpiStage: (reply: Uint8Array): CorsairCurrentDpi => {
+    requireLength(reply, 9, "current-DPI");
+    return { stage: reply[4]!, x: u16be(reply, 5), y: u16be(reply, 7) };
+  },
+  stage: (reply: Uint8Array): CorsairDpiStage => {
+    requireLength(reply, 12, "DPI-stage");
+    return { x: u16be(reply, 5), y: u16be(reply, 7), rgb: [reply[9]!, reply[10]!, reply[11]!] };
+  },
+} as const;
+
+export function corsairRgbHex(rgb: CorsairRgb): string {
+  return `#${rgb.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function stageIndex(stage: number): number {
+  if (!Number.isInteger(stage) || stage < 0 || stage >= CORSAIR_STAGE_COUNT) {
+    throw new Error(`Corsair DPI stage must be 0–${CORSAIR_STAGE_COUNT - 1}.`);
+  }
+  return stage;
+}
+
+function dpiValue(dpi: number): number {
+  if (!Number.isInteger(dpi) || dpi < 0 || dpi > 0xffff) throw new Error("Corsair DPI must be an integer from 0 to 65535.");
+  return dpi;
+}
+
+function byteValue(value: number): number {
+  if (!Number.isInteger(value) || value < 0 || value > 0xff) throw new Error(`Corsair packet byte ${value} is out of range.`);
+  return value;
+}
+
+function requireLength(reply: Uint8Array, length: number, what: string): void {
+  if (reply.length < length) throw new Error(`Corsair ${what} reply is shorter than ${length} bytes.`);
+}
+
+function u16le(bytes: Uint8Array, offset: number): number {
+  return bytes[offset]! | (bytes[offset + 1]! << 8);
+}
+
+function u16be(bytes: Uint8Array, offset: number): number {
+  return (bytes[offset]! << 8) | bytes[offset + 1]!;
+}

--- a/src/corsair/index.ts
+++ b/src/corsair/index.ts
@@ -174,7 +174,7 @@ export const corsairEncode = {
   },
   setLift: (height: number): Uint8Array =>
     corsairPacket(CORSAIR_COMMAND.set, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.lift, CORSAIR_LIVE_PROFILE, byteValue(height)),
-  /** Trailing 0x05 mirrors ckb-next; unverified on hardware. */
+  /** Trailing 0x05 mirrors ckb-next; hardware accepts the write with or without it. */
   setSnap: (enabled: boolean): Uint8Array =>
     corsairPacket(CORSAIR_COMMAND.set, CORSAIR_FIELD.mouse, CORSAIR_MOUSE.snap, CORSAIR_LIVE_PROFILE, enabled ? 1 : 0, 0x05),
   /** The device re-enumerates after this; the WebHID handle closes. */

--- a/src/drivers/corsair/hid.test.ts
+++ b/src/drivers/corsair/hid.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CORSAIR_NIGHTSWORD_PRODUCT_ID, CORSAIR_VENDOR_ID } from "../../corsair/index.ts";
+import { CorsairHidClient, corsairTransferError } from "./hid.ts";
+
+function packet(hex: string): Uint8Array {
+  const bytes = hex.trim().split(/\s+/).map((byte) => Number.parseInt(byte, 16));
+  const out = new Uint8Array(64);
+  out.set(bytes);
+  return out;
+}
+
+function key(bytes: Uint8Array): string {
+  return [...bytes.subarray(0, 4)].map((byte) => byte.toString(16).padStart(2, "0")).join(" ");
+}
+
+// Canned GET replies from captures/corsair-nightsword/PROTOCOL.md, keyed by
+// the request's first four bytes. The iCUE-loaded live profile.
+const REPLIES: ReadonlyMap<string, Uint8Array> = new Map([
+  ["0e 01 00 00", packet("0e 01 00 00 01 01 00 01 41 03 08 03 1c 1b 5c 1b 01")],
+  ["0e 13 05 00", packet("0e 13 05 00 0f")],
+  ["0e 13 02 00", packet("0e 13 02 00 02 09 60 09 60")],
+  ["0e 13 03 00", packet("0e 13 03 00 05")],
+  ["0e 13 04 00", packet("0e 13 04 00 00")],
+  ["0e 13 d0 00", packet("0e 13 d0 00 00 01 90 01 90 ff ff 00")],
+  ["0e 13 d1 00", packet("0e 13 d1 00 00 03 20 03 20 00 bf ff")],
+  ["0e 13 d2 00", packet("0e 13 d2 00 00 09 60 09 60 00 bf ff")],
+  ["0e 13 d3 00", packet("0e 13 d3 00 00 16 44 16 44 00 bf ff")],
+  ["0e 13 d4 00", packet("0e 13 d4 00")],
+  ["0e 13 d5 00", packet("0e 13 d5 00")],
+]);
+
+interface FakeOptions {
+  collections?: HIDCollectionInfo[];
+  /** Replace the reply for a request key; `null` makes the device stay silent (stale buffer). */
+  overrides?: Map<string, Uint8Array | null>;
+  /** Throw this from every transfer. */
+  transferError?: Error;
+  /** Return the previous buffer this many times before the fresh reply. */
+  staleReads?: number;
+}
+
+function collection(usage: number, feature: boolean): HIDCollectionInfo {
+  return {
+    usagePage: 0xffc2,
+    usage,
+    type: 1,
+    children: [],
+    inputReports: feature ? [{ reportId: 0, items: [] }] : [{ reportId: 14, items: [] }],
+    outputReports: feature ? [{ reportId: 0, items: [] }] : [],
+    featureReports: feature ? [{ reportId: 0, items: [] }] : [],
+  } as unknown as HIDCollectionInfo;
+}
+
+function fakeDevice(options: FakeOptions = {}) {
+  const sent: Array<{ reportId: number; payload: Uint8Array }> = [];
+  const received: number[] = [];
+  let buffer = new Uint8Array(64);
+  let staleLeft = 0;
+  let lastKey = "";
+  let opened = false;
+  const device = {
+    vendorId: CORSAIR_VENDOR_ID,
+    productId: CORSAIR_NIGHTSWORD_PRODUCT_ID,
+    productName: "CORSAIR NIGHTSWORD RGB Gaming Mouse",
+    get opened() { return opened; },
+    collections: options.collections ?? [collection(4, true)],
+    open: async () => { opened = true; },
+    close: async () => { opened = false; },
+    sendFeatureReport: async (reportId: number, source: BufferSource) => {
+      if (options.transferError) throw options.transferError;
+      const view = ArrayBuffer.isView(source)
+        ? new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
+        : new Uint8Array(source);
+      const payload = new Uint8Array(view);
+      sent.push({ reportId, payload });
+      const requestKey = key(payload);
+      const override = options.overrides?.get(requestKey);
+      const reply = override === undefined ? REPLIES.get(requestKey) : override;
+      // A fresh request answers stale first; a retry of the same request answers fresh.
+      staleLeft = requestKey === lastKey ? staleLeft : (options.staleReads ?? 0);
+      lastKey = requestKey;
+      // A GET refreshes the feature buffer; a SET or an unknown request leaves it stale.
+      if (reply && payload[0] === 0x0e) buffer = reply;
+    },
+    receiveFeatureReport: async (reportId: number) => {
+      if (options.transferError) throw options.transferError;
+      received.push(reportId);
+      if (staleLeft > 0) {
+        staleLeft -= 1;
+        return new DataView(new Uint8Array(64).buffer);
+      }
+      return new DataView(new Uint8Array(buffer).buffer);
+    },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  return { device: device as unknown as HIDDevice, sent, received };
+}
+
+test("claims only the usage-4 config collection with a feature report on id 0", () => {
+  assert.equal(CorsairHidClient.isSupported(fakeDevice().device), true);
+  // MI_00's 0xffc2 collection (usage 3, input report 14 only) must be rejected.
+  assert.equal(CorsairHidClient.isSupported(fakeDevice({ collections: [collection(3, false)] }).device), false);
+  assert.equal(CorsairHidClient.isSupported(fakeDevice({ collections: [collection(4, false)] }).device), false);
+  assert.equal(CorsairHidClient.isSupported(fakeDevice({ collections: [] }).device), false);
+  assert.equal(CorsairHidClient.isSupported({ ...fakeDevice().device, productId: 0x1b3c } as HIDDevice), false);
+  assert.equal(CorsairHidClient.isSupported({ ...fakeDevice().device, vendorId: 0x1532 } as HIDDevice), false);
+  // Nested collections still count.
+  const nested = { ...collection(1, false), usagePage: 0x01, children: [collection(4, true)] } as HIDCollectionInfo;
+  assert.equal(CorsairHidClient.isSupported(fakeDevice({ collections: [nested] }).device), true);
+});
+
+test("reads identity, mask, current stage, each enabled stage, lift, and snap in order", async () => {
+  const { device, sent, received } = fakeDevice();
+  const status = await new CorsairHidClient(device).readStatus();
+
+  assert.deepEqual(sent.map(({ payload }) => key(payload)), [
+    "0e 01 00 00",
+    "0e 13 05 00",
+    "0e 13 02 00",
+    "0e 13 d0 00",
+    "0e 13 d1 00",
+    "0e 13 d2 00",
+    "0e 13 d3 00",
+    "0e 13 03 00",
+    "0e 13 04 00",
+  ]);
+  assert.ok(sent.every(({ reportId, payload }) => reportId === 0 && payload.length === 64));
+  assert.ok(received.every((reportId) => reportId === 0));
+  assert.equal(received.length, sent.length);
+  // Only the live profile is ever addressed.
+  assert.ok(sent.every(({ payload }) => payload[3] === 0));
+
+  assert.equal(status.brand, "Corsair");
+  assert.equal(status.name, "NIGHTSWORD RGB");
+  assert.equal(status.dpi, 2400);
+  assert.equal(status.dpiY, 2400);
+  assert.equal(status.pollingRateHz, 1000);
+  // Slot 0 is the Sniper stage; iCUE's Stage 1–3 are slots 1–3, and the
+  // device's "current stage 2" is iCUE's Stage 2.
+  assert.deepEqual(status.dpiStages, [800, 2400, 5700]);
+  assert.equal(status.activeDpiStage, 1);
+  assert.equal(status.angleSnapping, false);
+  assert.equal(status.liftOffDistance, null);
+  assert.equal(status.connectionType, "Wired");
+  assert.deepEqual(status.firmware, [
+    "Firmware 3.41",
+    "Bootloader 3.08",
+    "Sniper 400 #ffff00",
+    "DPI stages 1: 800 #00bfff, 2: 2400 #00bfff, 3: 5700 #00bfff",
+    "Lift-off height 5",
+  ]);
+  assert.equal(status.ui?.settingsReady, false);
+  assert.equal(status.ui?.valuesVerified, true);
+  assert.equal(status.ui?.pollingReadOnly, true);
+  assert.equal(status.ui?.defaultDisplayName, "Corsair NIGHTSWORD RGB");
+});
+
+test("exposes no setters and no DPI options", async () => {
+  const client = new CorsairHidClient(fakeDevice().device);
+  assert.deepEqual(client.getDpiOptions(), []);
+  assert.equal(await client.startNotifications(), false);
+  for (const name of ["setDpi", "setPollingRate", "setLiftOffDistance", "setAngleSnapping", "setDpiStages"]) {
+    assert.equal(name in client, false, `${name} must not exist on the read-only client`);
+  }
+});
+
+test("retries when the feature buffer is still the previous reply", async () => {
+  const { device, sent } = fakeDevice({ staleReads: 1 });
+  const status = await new CorsairHidClient(device).readStatus();
+  assert.equal(status.dpi, 2400);
+  // Every request went out twice: once answered stale, once answered fresh.
+  assert.equal(sent.length, 18);
+});
+
+test("degrades to identity only when the DPI reads fail", async () => {
+  const { device, sent } = fakeDevice({ overrides: new Map([["0e 13 02 00", null]]) });
+  const status = await new CorsairHidClient(device).readStatus();
+  assert.equal(status.name, "NIGHTSWORD RGB");
+  assert.equal(status.pollingRateHz, 1000);
+  assert.equal(status.dpi, 0);
+  assert.deepEqual(status.dpiStages, []);
+  assert.equal(status.activeDpiStage, undefined);
+  assert.equal(status.angleSnapping, null);
+  assert.deepEqual(status.firmware, ["Firmware 3.41", "Bootloader 3.08"]);
+  assert.equal(status.ui?.valuesVerified, false);
+  assert.match(status.ui?.statusNote ?? "", /could not be read/);
+  // Lift and snap are skipped once the DPI block fails, after the retries on the stage read.
+  assert.ok(!sent.some(({ payload }) => key(payload) === "0e 13 03 00"));
+});
+
+test("a silent identity read fails loudly", async () => {
+  const { device } = fakeDevice({ overrides: new Map([["0e 01 00 00", null]]) });
+  await assert.rejects(new CorsairHidClient(device).readStatus(), /did not answer command 0x01\/0x00/);
+});
+
+test("maps NotAllowedError to the wrong-interface / close-iCUE guidance", async () => {
+  const held = new Error("Failed to write the feature report.");
+  held.name = "NotAllowedError";
+  const { device } = fakeDevice({ transferError: held });
+  await assert.rejects(new CorsairHidClient(device).readStatus(), /usage 4/);
+  assert.match(corsairTransferError(held).message, /close iCUE/);
+  assert.match(corsairTransferError(held).message, /Corsair Service/);
+  // Other errors pass through untouched.
+  const other = new Error("The device is not open.");
+  assert.equal(corsairTransferError(other), other);
+});
+
+test("serialises overlapping status reads through one queue", async () => {
+  const { device, sent } = fakeDevice();
+  const client = new CorsairHidClient(device);
+  const [first, second] = await Promise.all([client.readStatus(), client.readStatus()]);
+  assert.equal(first.dpi, 2400);
+  assert.equal(second.dpi, 2400);
+  // Two complete, non-interleaved sequences.
+  const keys = sent.map(({ payload }) => key(payload));
+  assert.deepEqual(keys.slice(0, 9), keys.slice(9));
+});

--- a/src/drivers/corsair/hid.ts
+++ b/src/drivers/corsair/hid.ts
@@ -1,0 +1,260 @@
+import type { MouseStatus } from "../mouse-types.ts";
+import {
+  CORSAIR_CONFIG_USAGE,
+  CORSAIR_PRODUCTS,
+  CORSAIR_REPORT_ID,
+  CORSAIR_SNIPER_STAGE,
+  CORSAIR_USAGE_PAGE,
+  CORSAIR_VENDOR_ID,
+  type CorsairDpiStage,
+  type CorsairIdent,
+  corsairDecode,
+  corsairDevice,
+  corsairEnabledStages,
+  corsairEncode,
+  corsairFormatVersion,
+  corsairIsEcho,
+  corsairRgbHex,
+} from "@openmouse/protocol/corsair";
+
+/**
+ * Corsair NIGHTSWORD RGB — read-only WebHID client (phase 1).
+ *
+ * Talks to the config interface (usage page 0xffc2, usage 4) through 64-byte
+ * feature reports on report id 0. Every GET is send → short wait → receive,
+ * and the reply must echo the request's first four bytes; a stale buffer from
+ * the previous GET fails that check and the request is retried. All traffic
+ * goes through one queue because the device has a single reply buffer.
+ *
+ * Reads are best-effort past identity: if the DPI fields cannot be read the
+ * status still identifies the mouse (`ui.settingsReady = false` either way —
+ * nothing here writes). Live values are the software profile iCUE would show;
+ * they reset to the onboard profile on power cycle.
+ *
+ * iCUE's service keeps this interface open too. Reads have been observed to
+ * coexist with it (shared mode, iCUE actively re-applying its profile). If
+ * Chrome ever refuses a transfer with a bare `NotAllowedError`, that is mapped
+ * to a "close iCUE" message; the more common cause of that error is being
+ * granted MI_00's usage-3 collection, which `isSupported()` now rejects.
+ */
+
+const PRODUCT_IDS = new Set<number>(CORSAIR_PRODUCTS.keys());
+/** Gap between sendFeatureReport and receiveFeatureReport; ~20 ms was reliable on fw 3.41. */
+const REPLY_DELAY_MS = 20;
+const REQUEST_ATTEMPTS = 3;
+const SUPPORTED_POLLING_RATES = [1000, 500, 250, 125] as const;
+
+interface CorsairDpiState {
+  mask: number;
+  current: { stage: number; x: number; y: number };
+  stages: Map<number, CorsairDpiStage>;
+}
+
+export class CorsairHidClient {
+  readonly canDisableSleep = false;
+  readonly device: HIDDevice;
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+  }
+
+  /**
+   * Corsair VID, a catalogued product id, and the usage-4 config collection
+   * with a feature report on id 0. MI_00 exposes an 0xffc2 collection too
+   * (usage 3, input report 14 only) that must not be claimed.
+   */
+  static isSupported(device: HIDDevice): boolean {
+    if (device.vendorId !== CORSAIR_VENDOR_ID || !PRODUCT_IDS.has(device.productId)) return false;
+    return hasConfigCollection(device.collections);
+  }
+
+  get pollIntervalMs(): number { return 30_000; }
+
+  /** Read-only: nothing to offer the DPI picker. */
+  getDpiOptions(): number[] { return []; }
+
+  getSupportedPollingRates(): number[] { return [...SUPPORTED_POLLING_RATES]; }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    if (this.device.opened) await this.device.close();
+  }
+
+  async startNotifications(_onChange?: () => void): Promise<boolean> { return false; }
+
+  async readStatus(): Promise<MouseStatus> {
+    return await this.run(async () => {
+      await this.open();
+      return await this.readStatusDirect();
+    });
+  }
+
+  private async readStatusDirect(): Promise<MouseStatus> {
+    const definition = corsairDevice(this.device.productId);
+    const ident = corsairDecode.ident(await this.request(corsairEncode.ident()));
+    const dpi = await this.readDpi().catch(() => null);
+    const lift = dpi ? await this.request(corsairEncode.lift()).then(corsairDecode.lift, () => null) : null;
+    const snap = dpi ? await this.request(corsairEncode.snap()).then(corsairDecode.snap, () => null) : null;
+
+    const enabled = dpi ? corsairEnabledStages(dpi.mask, definition.stages) : [];
+    // Slot 0 is the held-button Sniper stage; the numbered stages iCUE shows are slots 1+.
+    const numbered = enabled.filter((slot) => slot !== CORSAIR_SNIPER_STAGE);
+    const stageList = numbered.map((slot) => dpi!.stages.get(slot)).filter((stage): stage is CorsairDpiStage => !!stage);
+    const activeIndex = dpi ? numbered.indexOf(dpi.current.stage) : -1;
+    const displayName = `Corsair ${definition.name}`;
+
+    return {
+      brand: "Corsair",
+      name: definition.name,
+      batteryPercent: null,
+      batteryState: "Unknown",
+      dpi: dpi?.current.x ?? 0,
+      dpiY: dpi?.current.y ?? 0,
+      supportsSeparateDpiAxes: true,
+      pollingRateHz: ident.pollingRateHz,
+      supportedPollingRates: [...SUPPORTED_POLLING_RATES],
+      activeProfile: null,
+      connectionType: "Wired",
+      connectionDetail: "USB",
+      dpiStages: stageList.map((stage) => stage.x),
+      activeDpiStage: activeIndex >= 0 ? activeIndex : undefined,
+      liftOffDistance: null,
+      angleSnapping: snap,
+      motionSync: null,
+      rippleControl: null,
+      firmware: firmwareLines(ident, dpi, enabled, lift),
+      ui: {
+        family: "corsair",
+        settingsReady: false,
+        valuesVerified: dpi !== null,
+        pollingReadOnly: true,
+        hideUnsupportedPollingRates: true,
+        hideMotionSync: true,
+        hideRippleControl: true,
+        hideSleepCard: true,
+        hideSignalCard: true,
+        statusNote: dpi
+          ? "Read-only for now: live DPI stages, polling rate, lift-off height, and angle snapping are shown but cannot be changed."
+          : "Identified the mouse but its DPI settings could not be read. Unplug and reconnect the mouse, then add it again.",
+        defaultDisplayName: displayName,
+      },
+    };
+  }
+
+  /** Mask → current stage → each enabled stage. Any failure aborts the whole DPI read. */
+  private async readDpi(): Promise<CorsairDpiState> {
+    const definition = corsairDevice(this.device.productId);
+    const mask = corsairDecode.dpiMask(await this.request(corsairEncode.dpiMask()));
+    const current = corsairDecode.dpiStage(await this.request(corsairEncode.dpiStage()));
+    const stages = new Map<number, CorsairDpiStage>();
+    for (const stage of corsairEnabledStages(mask, definition.stages)) {
+      stages.set(stage, corsairDecode.stage(await this.request(corsairEncode.stage(stage))));
+    }
+    return { mask, current, stages };
+  }
+
+  /**
+   * One GET exchange: send, wait, receive, and require the echo. Chrome hands
+   * back the feature buffer without a report-id prefix for id 0; a 65-byte
+   * reply with a leading zero is tolerated by stripping it.
+   */
+  private async request(packet: Uint8Array): Promise<Uint8Array> {
+    for (let attempt = 0; attempt < REQUEST_ATTEMPTS; attempt += 1) {
+      await this.transfer(() => this.device.sendFeatureReport(CORSAIR_REPORT_ID, buffer(packet)));
+      await delay(REPLY_DELAY_MS);
+      const view = await this.transfer(() => this.device.receiveFeatureReport(CORSAIR_REPORT_ID));
+      const reply = stripReportId(new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength)), packet);
+      if (corsairIsEcho(packet, reply)) return reply;
+    }
+    throw new Error(
+      `The Corsair mouse did not answer command 0x${packet[1]!.toString(16).padStart(2, "0")}/0x${packet[2]!.toString(16).padStart(2, "0")}.`,
+    );
+  }
+
+  /** Wraps a transfer so iCUE holding the interface reads as a fix, not a bare Chrome error. */
+  private async transfer<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      throw corsairTransferError(error);
+    }
+  }
+
+  private async run<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.queue.then(operation, operation);
+    this.queue = result.then(() => undefined, () => undefined);
+    return await result;
+  }
+}
+
+/**
+ * Chrome reports a refused feature-report transfer as a `NotAllowedError`
+ * whose message is only "Failed to write the feature report." Verified on
+ * hardware: that is what MI_00's usage-3 collection answers (it has no feature
+ * report), while the usage-4 interface keeps working with iCUE running. So the
+ * likely fix is picking the other interface; closing iCUE is the fallback.
+ */
+export function corsairTransferError(error: unknown): Error {
+  const name = error instanceof Error ? error.name : "";
+  const detail = error instanceof Error ? error.message : String(error);
+  if (name !== "NotAllowedError") return error instanceof Error ? error : new Error(detail);
+  return new Error(
+    "Chrome refused the Corsair mouse's feature report. Remove the device and add it again, choosing the "
+      + "entry that lists usage 4 (the config interface). If that entry was already selected, close iCUE "
+      + "and stop the \"Corsair Service\" Windows service, then reconnect. "
+      + `(${detail})`,
+  );
+}
+
+function firmwareLines(
+  ident: CorsairIdent,
+  dpi: CorsairDpiState | null,
+  enabled: number[],
+  lift: number | null,
+): string[] {
+  const lines = [
+    `Firmware ${corsairFormatVersion(ident.firmware)}`,
+    `Bootloader ${corsairFormatVersion(ident.bootloader)}`,
+  ];
+  if (dpi) {
+    const describe = (slot: number): string => {
+      const stage = dpi.stages.get(slot);
+      if (!stage) return "?";
+      const value = stage.x === stage.y ? `${stage.x}` : `${stage.x}×${stage.y}`;
+      return `${value} ${corsairRgbHex(stage.rgb)}`;
+    };
+    const sniper = enabled.includes(CORSAIR_SNIPER_STAGE) ? [`Sniper ${describe(CORSAIR_SNIPER_STAGE)}`] : [];
+    const stages = enabled
+      .filter((slot) => slot !== CORSAIR_SNIPER_STAGE)
+      .map((slot) => `${slot}: ${describe(slot)}`);
+    lines.push(...sniper);
+    if (stages.length > 0) lines.push(`DPI stages ${stages.join(", ")}`);
+  }
+  if (lift !== null) lines.push(`Lift-off height ${lift}`);
+  return lines;
+}
+
+function hasConfigCollection(items: readonly HIDCollectionInfo[]): boolean {
+  return items.some((collection) =>
+    (collection.usagePage === CORSAIR_USAGE_PAGE
+      && collection.usage === CORSAIR_CONFIG_USAGE
+      && collection.featureReports.some((report) => report.reportId === CORSAIR_REPORT_ID))
+    || hasConfigCollection(collection.children));
+}
+
+function stripReportId(reply: Uint8Array, request: Uint8Array): Uint8Array {
+  if (reply.length === 65 && reply[0] === CORSAIR_REPORT_ID && reply[1] === request[0]) return reply.subarray(1);
+  return reply;
+}
+
+function buffer(payload: Uint8Array): ArrayBuffer {
+  return new Uint8Array(payload).buffer;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -144,7 +144,7 @@ export interface AtkReceiverInfo {
 }
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "Corsair";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;

--- a/src/drivers/registry.test.ts
+++ b/src/drivers/registry.test.ts
@@ -12,7 +12,9 @@ import { ORBITAL_DEVICES } from "@openmouse/protocol/orbital";
 const DEVICES_DIR = dirname(fileURLToPath(import.meta.url));
 
 const REPORT_IDS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 0x0f, 0x10, 0x11, 0x20, 0xa1, 0xb3, 0xb4];
-const USAGE_PAGES = [0x01, 0x0c, 0xff, 0xff00, 0xff01, 0xff02, 0xff05, 0xff0a, 0xff1c, 0xff43, 0xff55, 0xff60, 0xffa0, 0xffc1, 0xffff];
+const USAGE_PAGES = [0x01, 0x0c, 0xff, 0xff00, 0xff01, 0xff02, 0xff05, 0xff0a, 0xff1c, 0xff43, 0xff55, 0xff60, 0xffa0, 0xffc1, 0xffc2, 0xffff];
+// Usage 4 is the Corsair config collection; 0x61 is VIA raw HID.
+const USAGES = [0, 1, 2, 4, 0x10, 0x61];
 
 function report(reportId: number, byteLength = 16): HIDReportInfo {
   return { reportId, items: [{ reportSize: 8, reportCount: byteLength }] } as unknown as HIDReportInfo;
@@ -39,7 +41,7 @@ function collectionShapes(): HIDCollectionInfo[][] {
   shapes.push(USAGE_PAGES.map((page) =>
     collection(page, 1, { feature: REPORT_IDS, input: REPORT_IDS, output: REPORT_IDS })));
   for (const page of USAGE_PAGES) {
-    for (const usage of [0, 1, 2, 0x10, 0x61]) {
+    for (const usage of USAGES) {
       shapes.push([collection(page, usage, { feature: REPORT_IDS, input: REPORT_IDS, output: REPORT_IDS })]);
       for (const id of REPORT_IDS) {
         shapes.push([collection(page, usage, { input: [id], output: [id] })]);

--- a/src/drivers/registry.ts
+++ b/src/drivers/registry.ts
@@ -28,6 +28,7 @@ import { WallhackMouseHidClient } from "./wallhack/mouse-hid.ts";
 import { WLMouseHidClient } from "./wlmouse/hid.ts";
 import { WootingHidClient } from "./wooting/hid.ts";
 import { ZaunkoenigHidClient } from "./zaunkoenig/hid.ts";
+import { CorsairHidClient } from "./corsair/hid.ts";
 import { GWolvesHidClient } from "./gwolves/hid.ts";
 import { SteelSeriesRival3HidClient } from "./steelseries/hid.ts";
 import { SteelSeriesAerox3HidClient } from "./steelseries/aerox3-hid.ts";
@@ -47,7 +48,7 @@ import { MchoseDockHidClient } from "./mchose/dock-hid.ts";
 import { KsnakeHidClient } from "./ksnake/hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient | PulsarXs1HidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | AttackSharkHidClient | FantechHidClient | LingbaoHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | LingbaoHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -58,6 +59,7 @@ export interface DeviceDriver {
 
 export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "Zaunkoenig", supports: (device) => ZaunkoenigHidClient.isSupported(device), create: (device) => new ZaunkoenigHidClient(device), score: () => 10 },
+  { brand: "Corsair", supports: (device) => CorsairHidClient.isSupported(device), create: (device) => new CorsairHidClient(device), score: () => 8 },
   { brand: "Finalmouse", supports: (device) => FinalmouseHidClient.isSupported(device), create: (device) => new FinalmouseHidClient(device), score: () => 10 },
   { brand: "Endgame Gear", supports: (device) => EggOp1HidClient.isSupported(device), create: (device) => new EggOp1HidClient(device), score: () => 10 },
   { brand: "Endgame Gear", supports: eggWeIsSupported, create: eggWeCreate, score: eggWeSupportScore },

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -35,6 +35,12 @@ import {
   ZAUNKOENIG_VENDOR_ID,
 } from "@openmouse/protocol/zaunkoenig";
 import {
+  CORSAIR_CONFIG_USAGE,
+  CORSAIR_PRODUCT_IDS,
+  CORSAIR_USAGE_PAGE,
+  CORSAIR_VENDOR_ID,
+} from "@openmouse/protocol/corsair";
+import {
   TEEVOLUTION_LCD_USAGE,
   TEEVOLUTION_LCD_USAGE_PAGE,
 } from "@openmouse/protocol/teevolution";
@@ -80,6 +86,7 @@ export const VENDOR_ID = {
   ninjutsoLegacy: NINJUTSO_LEGACY_VENDOR_ID,
   ninjutso: NINJUTSO_VENDOR_ID,
   zaunkoenig: ZAUNKOENIG_VENDOR_ID,
+  corsair: CORSAIR_VENDOR_ID,
   fantech: 0x3151,
   wooting: WOOTING_VENDOR_ID,
   wallhack: WALLHACK_VENDOR_ID,
@@ -426,12 +433,24 @@ export const LINGBAO_HID_FILTERS: HIDDeviceFilter[] = [...LINGBAO_PRODUCTS.keys(
   (productId) => ({ vendorId: LINGBAO_VENDOR_ID, productId, usagePage: 0xffff, usage: 0x02 }),
 );
 
+// Corsair NXP-family mice answer on the interface whose collection is usage
+// page 0xffc2, usage 4 (64-byte feature reports on id 0). MI_00 also carries
+// an 0xffc2 collection (usage 3) that never answers, so the usage is required
+// or the picker lists the same mouse twice.
+export const CORSAIR_HID_FILTERS: HIDDeviceFilter[] = CORSAIR_PRODUCT_IDS.map((productId) => ({
+  vendorId: CORSAIR_VENDOR_ID,
+  productId,
+  usagePage: CORSAIR_USAGE_PAGE,
+  usage: CORSAIR_CONFIG_USAGE,
+}));
+
 export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   ...ZAUNKOENIG_PRODUCT_IDS.map((productId) => ({
     vendorId: ZAUNKOENIG_VENDOR_ID,
     productId,
     usagePage: ZAUNKOENIG_USAGE_PAGE,
   })),
+  ...CORSAIR_HID_FILTERS,
   { vendorId: VENDOR_ID.finalmouse, productId: 0x0100, usagePage: 0xff00, usage: 0x0001 },
   { vendorId: VENDOR_ID.pulsar },
   ...PULSAR_XS1_HID_FILTERS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * as teevolution from "./teevolution/index.js";
 export * as vgn from "./vgn/index.js";
 export * as wlmouse from "./wlmouse/index.js";
 export * as zaunkoenig from "./zaunkoenig/index.js";
+export * as corsair from "./corsair/index.js";
 export * as gwolves from "./gwolves/index.js";
 export * as glorious from "./glorious/index.js";
 export * as ksnake from "./ksnake/index.js";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,8 @@
       "@openmouse/protocol/wallhack": ["./src/wallhack/index.ts"],
       "@openmouse/protocol/wlmouse": ["./src/wlmouse/index.ts"],
       "@openmouse/protocol/wooting": ["./src/wooting/index.ts"],
-      "@openmouse/protocol/zaunkoenig": ["./src/zaunkoenig/index.ts"]
+      "@openmouse/protocol/zaunkoenig": ["./src/zaunkoenig/index.ts"],
+      "@openmouse/protocol/corsair": ["./src/corsair/index.ts"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
Merge of #63 onto current main, resolving additive brand-union conflicts against #65's Microsoft Intellimouse driver (mouse-types.ts, registry.ts, vendors.ts). Closes #63.