### PR TITLE
ksnake: retry timed-out exchanges and validate the DPI range

### DIFF
--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -152,6 +152,10 @@ class FakeKsnakeDevice {
   dpiIndex = 2;
   /** Upcoming replies to swallow (simulates a sleeping dongle). */
   dropReplies = 0;
+  /** Next version reply decodes to null once (simulates a crossed report). */
+  badVersionOnce = false;
+  /** Next battery reply exceeds 100% once (simulates a crossed report). */
+  badBatteryOnce = false;
   sent: number[] = [];
   private listeners = new Map<string, Set<FakeListener>>();
 
@@ -179,14 +183,30 @@ class FakeKsnakeDevice {
   async sendReport(_reportId: number, payload: ArrayBuffer): Promise<void> {
     const body = new Uint8Array(payload);
     this.sent.push(body[1]);
-    if (body[1] === 0x0f) {
-      for (let i = 0; i < 6; i++) {
-        this.stages[i] = body[13 + i * 2] | (body[14 + i * 2] << 8);
+    let reply: Uint8Array;
+    if (body[1] === 0x03) {
+      reply = new Uint8Array(64);
+      if (!this.badVersionOnce) {
+        reply[23] = 50; // "2"
+        reply[24] = 49; // "1"
+        reply[25] = 55; // "7"
       }
-      this.reportRate = body[10] - 1;
-      this.dpiIndex = body[12] - 1;
+      this.badVersionOnce = false;
+    } else if (body[1] === 0x30) {
+      reply = new Uint8Array(64);
+      reply[8] = this.badBatteryOnce ? 200 : 81;
+      reply[9] = 0;
+      this.badBatteryOnce = false;
+    } else {
+      if (body[1] === 0x0f) {
+        for (let i = 0; i < 6; i++) {
+          this.stages[i] = body[13 + i * 2] | (body[14 + i * 2] << 8);
+        }
+        this.reportRate = body[10] - 1;
+        this.dpiIndex = body[12] - 1;
+      }
+      reply = configReply(this.stages, this.reportRate, this.dpiIndex);
     }
-    const reply = configReply(this.stages, this.reportRate, this.dpiIndex);
     queueMicrotask(() => {
       if (this.dropReplies > 0) {
         this.dropReplies -= 1;
@@ -250,6 +270,15 @@ describe("KsnakeHidClient writes", () => {
     const device = new FakeKsnakeDevice();
     assert.equal(await fastClient(device).setDpiStageValue(0, 600), 600);
     assert.equal(device.stages[0], 600);
+  });
+
+  it("retries status reads that fail validation", async () => {
+    const device = new FakeKsnakeDevice();
+    device.badVersionOnce = true;
+    device.badBatteryOnce = true;
+    const status = await fastClient(device).readStatus();
+    assert.deepEqual(status.firmware, ["X11 2.1.7"]);
+    assert.equal(status.batteryPercent, 81);
   });
 
   it("rejects out-of-range DPI without touching the mouse", async () => {

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -13,6 +13,7 @@ import {
   ksnakeGetBatteryRequest,
   ksnakeGetConfigRequest,
   ksnakeGetVersionRequest,
+  ksnakeIsValidDpi,
 } from "../../ksnake/index.js";
 import { KsnakeHidClient } from "./hid.ts";
 
@@ -60,6 +61,17 @@ describe("ksnake codec", () => {
     const config = ksnakeDecodeConfig(new Uint8Array(64));
     assert.ok(config);
     assert.deepEqual(config?.stages.slice(0, 4), [800, 1200, 1600, 3200]);
+    // Retail hardware reports 6 enabled stages.
+    assert.equal(config?.dpiCount, 6);
+  });
+
+  it("validates the vendor DPI range (200-12000, whole numbers)", () => {
+    for (const dpi of [200, 600, 800, 1200, 1600, 3200, 5000, 12000]) {
+      assert.equal(ksnakeIsValidDpi(dpi), true);
+    }
+    for (const dpi of [0, 100, 150, 12001, 26000, 1600.5, Number.NaN]) {
+      assert.equal(ksnakeIsValidDpi(dpi), false);
+    }
   });
 
   it("round-trips polling rates (X11: 125-1000 Hz)", () => {
@@ -103,5 +115,127 @@ describe("KsnakeHidClient", () => {
   it("rejects unsupported polling rates without touching HID", async () => {
     const client = new KsnakeHidClient(fakeDevice());
     await assert.rejects(() => client.setPollingRate(9999), /does not support/);
+  });
+});
+
+type FakeListener = (event: { data: DataView }) => void;
+
+function configReply(stages: number[], reportRate: number, dpiIndex: number): Uint8Array {
+  const reply = new Uint8Array(64);
+  reply[9] = 2;
+  reply[10] = reportRate + 1;
+  reply[11] = 6;
+  reply[12] = dpiIndex + 1;
+  stages.forEach((stage, i) => {
+    reply[13 + i * 2] = stage & 0xff;
+    reply[14 + i * 2] = (stage >> 8) & 0xff;
+  });
+  reply[48] = 0;
+  reply[49] = 1;
+  reply[50] = 53;
+  reply[51] = 2;
+  reply[52] = 10;
+  reply[53] = 0;
+  reply[55] = 0x11;
+  return reply;
+}
+
+/** HIDDevice stand-in backed by emulated mouse state. */
+class FakeKsnakeDevice {
+  vendorId = 0xa8a5;
+  productId = KSNAKE_PRODUCT_ID;
+  productName = "USB Receiver";
+  collections = [{ usagePage: KSNAKE_USAGE_PAGE, usage: KSNAKE_USAGE, children: [] }];
+  opened = false;
+  stages = [800, 1200, 1600, 3200, 5000, 12000];
+  reportRate = 3;
+  dpiIndex = 2;
+  /** Upcoming replies to swallow (simulates a sleeping dongle). */
+  dropReplies = 0;
+  sent: number[] = [];
+  private listeners = new Map<string, Set<FakeListener>>();
+
+  async open(): Promise<void> {
+    this.opened = true;
+  }
+
+  async close(): Promise<void> {
+    this.opened = false;
+  }
+
+  addEventListener(type: string, listener: FakeListener): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  removeEventListener(type: string, listener: FakeListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  async sendReport(_reportId: number, payload: ArrayBuffer): Promise<void> {
+    const body = new Uint8Array(payload);
+    this.sent.push(body[1]);
+    if (body[1] === 0x0f) {
+      for (let i = 0; i < 6; i++) {
+        this.stages[i] = body[13 + i * 2] | (body[14 + i * 2] << 8);
+      }
+      this.reportRate = body[10] - 1;
+      this.dpiIndex = body[12] - 1;
+    }
+    const reply = configReply(this.stages, this.reportRate, this.dpiIndex);
+    queueMicrotask(() => {
+      if (this.dropReplies > 0) {
+        this.dropReplies -= 1;
+        return;
+      }
+      const data = new DataView(reply.buffer, reply.byteOffset, reply.byteLength);
+      this.listeners.get("inputreport")?.forEach((listener) => listener({ data }));
+    });
+  }
+}
+
+function fastClient(device: FakeKsnakeDevice): KsnakeHidClient {
+  return new KsnakeHidClient(device as unknown as HIDDevice, {
+    replyTimeoutMs: 20,
+    settleAfterWriteMs: 0,
+  });
+}
+
+describe("KsnakeHidClient writes", () => {
+  it("writes the active DPI stage and confirms it", async () => {
+    const device = new FakeKsnakeDevice();
+    assert.equal(await fastClient(device).setDpi(800), 800);
+    assert.equal(device.stages[2], 800);
+    assert.deepEqual(device.sent, [0x0e, 0x0f, 0x0e]);
+  });
+
+  it("recovers when the first reply is lost", async () => {
+    const device = new FakeKsnakeDevice();
+    device.dropReplies = 1;
+    assert.equal(await fastClient(device).setDpi(2400), 2400);
+    assert.equal(device.stages[2], 2400);
+  });
+
+  it("reports an unreadable config when the mouse stays silent", async () => {
+    const device = new FakeKsnakeDevice();
+    device.dropReplies = 99;
+    await assert.rejects(() => fastClient(device).setDpi(800), /Could not read the current config/);
+  });
+
+  it("writes the polling-rate index and confirms it", async () => {
+    const device = new FakeKsnakeDevice();
+    assert.equal(await fastClient(device).setPollingRate(500), 500);
+    assert.equal(device.reportRate, 2);
+  });
+
+  it("rejects out-of-range DPI without touching the mouse", async () => {
+    const device = new FakeKsnakeDevice();
+    await assert.rejects(() => fastClient(device).setDpi(100), /between 200 and 12000/);
+    await assert.rejects(() => fastClient(device).setDpi(26000), /between 200 and 12000/);
+    assert.deepEqual(device.sent, []);
   });
 });

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -226,7 +226,7 @@ class FakeKsnakeDevice {
       this.badKeysOnce = false;
     } else if (body[1] === 0x09) {
       for (let i = 0; i < 6; i++) {
-        this.keys[i] = { type: body[9 + i * 4], code1: body[10 + i * 4], code2: body[11 + i * 4], code3: body[12 + i * 4] };
+        this.keys[i] = { type: body[8 + i * 4], code1: body[9 + i * 4], code2: body[10 + i * 4], code3: body[11 + i * 4] };
       }
       reply = new Uint8Array(64);
       this.keys.forEach((key, i) => {
@@ -359,9 +359,12 @@ describe("KsnakeHidClient writes", () => {
       { type: 33, code1: 85, code2: 0, code3: 0 },
     ]);
     assert.deepEqual([...req.slice(0, 5)], [0x55, 0x09, 0xa5, 0x22, 0x20]);
-    assert.deepEqual([...req.slice(9, 13)], [32, 1, 0, 0]);
-    assert.deepEqual([...req.slice(29, 33)], [33, 85, 0, 0]);
-    assert.deepEqual([...req.slice(33, 41)], [33, 56, 1, 0, 33, 56, 255, 0]);
+    // Wire offsets (vendor t[9..] minus the t[0] report-id placeholder):
+    // slot 0 type at data[8], slot 5 at data[28..31], scroll tail at data[32..39].
+    assert.deepEqual([...req.slice(8, 12)], [32, 1, 0, 0]);
+    assert.deepEqual([...req.slice(28, 32)], [33, 85, 0, 0]);
+    assert.deepEqual([...req.slice(32, 40)], [33, 56, 1, 0, 33, 56, 255, 0]);
+    assert.deepEqual([...req.slice(40)], new Array(24).fill(0));
   });
 
   it("writes a button map and confirms it", async () => {

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -123,7 +123,7 @@ describe("KsnakeHidClient", () => {
 
 type FakeListener = (event: { data: DataView }) => void;
 
-function configReply(stages: number[], reportRate: number, dpiIndex: number): Uint8Array {
+function configReply(stages: number[], reportRate: number, dpiIndex: number, lodValue = 1): Uint8Array {
   const reply = new Uint8Array(64);
   reply[9] = 2;
   reply[10] = reportRate + 1;
@@ -134,7 +134,7 @@ function configReply(stages: number[], reportRate: number, dpiIndex: number): Ui
     reply[14 + i * 2] = (stage >> 8) & 0xff;
   });
   reply[48] = 0;
-  reply[49] = 1;
+  reply[49] = lodValue;
   reply[50] = 53;
   reply[51] = 2;
   reply[52] = 10;
@@ -153,6 +153,7 @@ class FakeKsnakeDevice {
   stages = [800, 1200, 1600, 3200, 5000, 12000];
   reportRate = 3;
   dpiIndex = 2;
+  lodValue = 1;
   /** 7 key slots, mirroring a retail dump (slot 4 = macro reference). */
   keys = [
     { type: 32, code1: 1, code2: 0, code3: 0 },
@@ -236,8 +237,9 @@ class FakeKsnakeDevice {
         }
         this.reportRate = body[10] - 1;
         this.dpiIndex = body[12] - 1;
+        this.lodValue = body[49];
       }
-      reply = configReply(this.stages, this.reportRate, this.dpiIndex);
+      reply = configReply(this.stages, this.reportRate, this.dpiIndex, this.lodValue);
     }
     queueMicrotask(() => {
       if (this.dropReplies > 0) {
@@ -311,6 +313,19 @@ describe("KsnakeHidClient writes", () => {
     const status = await fastClient(device).readStatus();
     assert.deepEqual(status.firmware, ["X11 2.1.7"]);
     assert.equal(status.batteryPercent, 81);
+    assert.equal(status.liftOffDistance, "Low");
+    assert.deepEqual(status.supportedLiftOffDistances, ["Low", "High"]);
+  });
+
+  it("writes the lift-off distance and confirms it", async () => {
+    const device = new FakeKsnakeDevice();
+    assert.equal(await fastClient(device).setLiftOffDistance("High"), "High");
+    assert.equal(device.lodValue, 2);
+  });
+
+  it("rejects the unsupported medium lift-off distance", async () => {
+    const device = new FakeKsnakeDevice();
+    await assert.rejects(() => fastClient(device).setLiftOffDistance("Medium"), /does not support a medium/);
   });
 
   it("decodes the 7 button slots from a keys reply", () => {

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -170,6 +170,8 @@ class FakeKsnakeDevice {
   badVersionOnce = false;
   /** Next battery reply exceeds 100% once (simulates a crossed report). */
   badBatteryOnce = false;
+  /** Next keys reply is zeroed once (simulates a stray report). */
+  badKeysOnce = false;
   sent: number[] = [];
   private listeners = new Map<string, Set<FakeListener>>();
 
@@ -213,12 +215,15 @@ class FakeKsnakeDevice {
       this.badBatteryOnce = false;
     } else if (body[1] === 0x08) {
       reply = new Uint8Array(64);
-      this.keys.forEach((key, i) => {
-        reply[8 + i * 4] = key.type;
-        reply[9 + i * 4] = key.code1;
-        reply[10 + i * 4] = key.code2;
-        reply[11 + i * 4] = key.code3;
-      });
+      if (!this.badKeysOnce) {
+        this.keys.forEach((key, i) => {
+          reply[8 + i * 4] = key.type;
+          reply[9 + i * 4] = key.code1;
+          reply[10 + i * 4] = key.code2;
+          reply[11 + i * 4] = key.code3;
+        });
+      }
+      this.badKeysOnce = false;
     } else if (body[1] === 0x09) {
       for (let i = 0; i < 6; i++) {
         this.keys[i] = { type: body[9 + i * 4], code1: body[10 + i * 4], code2: body[11 + i * 4], code3: body[12 + i * 4] };
@@ -383,6 +388,13 @@ describe("KsnakeHidClient writes", () => {
     const next = device.keys.slice(0, 6).map((key) => ({ ...key }));
     await assert.rejects(() => fastClient(device).setKeys(next), /not remappable/);
     assert.ok(!device.sent.includes(0x09));
+  });
+
+  it("skips stray zeroed reports when reading the button map", async () => {
+    const device = new FakeKsnakeDevice();
+    device.badKeysOnce = true;
+    const keys = await fastClient(device).getKeys();
+    assert.deepEqual(keys, device.keys);
   });
 
   it("rejects out-of-range DPI without touching the mouse", async () => {

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -6,12 +6,15 @@ import {
   KSNAKE_USAGE_PAGE,
   ksnakeDecodeBattery,
   ksnakeDecodeConfig,
+  ksnakeDecodeKeys,
   ksnakeDecodePollingRate,
   ksnakeDecodeVersion,
   ksnakeEncodePollingRate,
   ksnakeEncodeSetConfig,
+  ksnakeEncodeSetKeys,
   ksnakeGetBatteryRequest,
   ksnakeGetConfigRequest,
+  ksnakeGetKeysRequest,
   ksnakeGetVersionRequest,
   ksnakeIsValidDpi,
 } from "../../ksnake/index.js";
@@ -150,6 +153,16 @@ class FakeKsnakeDevice {
   stages = [800, 1200, 1600, 3200, 5000, 12000];
   reportRate = 3;
   dpiIndex = 2;
+  /** 7 key slots, mirroring a retail dump (slot 4 = macro reference). */
+  keys = [
+    { type: 32, code1: 1, code2: 0, code3: 0 },
+    { type: 32, code1: 2, code2: 0, code3: 0 },
+    { type: 32, code1: 4, code2: 0, code3: 0 },
+    { type: 32, code1: 8, code2: 0, code3: 0 },
+    { type: 112, code1: 0, code2: 1, code3: 3 },
+    { type: 33, code1: 85, code2: 0, code3: 0 },
+    { type: 33, code1: 56, code2: 1, code3: 0 },
+  ];
   /** Upcoming replies to swallow (simulates a sleeping dongle). */
   dropReplies = 0;
   /** Next version reply decodes to null once (simulates a crossed report). */
@@ -197,6 +210,25 @@ class FakeKsnakeDevice {
       reply[8] = this.badBatteryOnce ? 200 : 81;
       reply[9] = 0;
       this.badBatteryOnce = false;
+    } else if (body[1] === 0x08) {
+      reply = new Uint8Array(64);
+      this.keys.forEach((key, i) => {
+        reply[8 + i * 4] = key.type;
+        reply[9 + i * 4] = key.code1;
+        reply[10 + i * 4] = key.code2;
+        reply[11 + i * 4] = key.code3;
+      });
+    } else if (body[1] === 0x09) {
+      for (let i = 0; i < 6; i++) {
+        this.keys[i] = { type: body[9 + i * 4], code1: body[10 + i * 4], code2: body[11 + i * 4], code3: body[12 + i * 4] };
+      }
+      reply = new Uint8Array(64);
+      this.keys.forEach((key, i) => {
+        reply[8 + i * 4] = key.type;
+        reply[9 + i * 4] = key.code1;
+        reply[10 + i * 4] = key.code2;
+        reply[11 + i * 4] = key.code3;
+      });
     } else {
       if (body[1] === 0x0f) {
         for (let i = 0; i < 6; i++) {
@@ -279,6 +311,63 @@ describe("KsnakeHidClient writes", () => {
     const status = await fastClient(device).readStatus();
     assert.deepEqual(status.firmware, ["X11 2.1.7"]);
     assert.equal(status.batteryPercent, 81);
+  });
+
+  it("decodes the 7 button slots from a keys reply", () => {
+    const reply = new Uint8Array(64);
+    const slots = [
+      [32, 1, 0, 0], [32, 2, 0, 0], [32, 4, 0, 0], [32, 8, 0, 0],
+      [112, 0, 1, 3], [33, 85, 0, 0], [33, 56, 1, 0],
+    ];
+    slots.forEach(([type, c1, c2, c3], i) => {
+      reply[8 + i * 4] = type;
+      reply[9 + i * 4] = c1;
+      reply[10 + i * 4] = c2;
+      reply[11 + i * 4] = c3;
+    });
+    assert.deepEqual(ksnakeDecodeKeys(reply), slots.map(([type, code1, code2, code3]) => ({ type, code1, code2, code3 })));
+    assert.equal(ksnakeDecodeKeys(new Uint8Array(10)), null);
+  });
+
+  it("encodes setKeys with the vendor layout and fixed tail", () => {
+    const req = ksnakeEncodeSetKeys([
+      { type: 32, code1: 1, code2: 0, code3: 0 },
+      { type: 32, code1: 2, code2: 0, code3: 0 },
+      { type: 32, code1: 4, code2: 0, code3: 0 },
+      { type: 32, code1: 8, code2: 0, code3: 0 },
+      { type: 32, code1: 16, code2: 0, code3: 0 },
+      { type: 33, code1: 85, code2: 0, code3: 0 },
+    ]);
+    assert.deepEqual([...req.slice(0, 5)], [0x55, 0x09, 0xa5, 0x22, 0x20]);
+    assert.deepEqual([...req.slice(9, 13)], [32, 1, 0, 0]);
+    assert.deepEqual([...req.slice(29, 33)], [33, 85, 0, 0]);
+    assert.deepEqual([...req.slice(33, 41)], [33, 56, 1, 0, 33, 56, 255, 0]);
+  });
+
+  it("writes a button map and confirms it", async () => {
+    const device = new FakeKsnakeDevice();
+    device.keys = [
+      { type: 32, code1: 1, code2: 0, code3: 0 },
+      { type: 32, code1: 2, code2: 0, code3: 0 },
+      { type: 32, code1: 4, code2: 0, code3: 0 },
+      { type: 32, code1: 8, code2: 0, code3: 0 },
+      { type: 32, code1: 16, code2: 0, code3: 0 },
+      { type: 33, code1: 85, code2: 0, code3: 0 },
+      { type: 33, code1: 56, code2: 1, code3: 0 },
+    ];
+    const next = device.keys.slice(0, 6).map((key) => ({ ...key }));
+    next[4] = { type: 48, code1: 233, code2: 0, code3: 0 }; // Forward -> Volume+
+    const returned = await fastClient(device).setKeys(next);
+    assert.deepEqual(returned, next);
+    assert.deepEqual(device.keys[4], { type: 48, code1: 233, code2: 0, code3: 0 });
+    assert.ok(device.sent.includes(0x09));
+  });
+
+  it("refuses to overwrite macro bindings", async () => {
+    const device = new FakeKsnakeDevice();
+    const next = device.keys.slice(0, 6).map((key) => ({ ...key }));
+    await assert.rejects(() => fastClient(device).setKeys(next), /not remappable/);
+    assert.ok(!device.sent.includes(0x09));
   });
 
   it("rejects out-of-range DPI without touching the mouse", async () => {

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -232,6 +232,26 @@ describe("KsnakeHidClient writes", () => {
     assert.equal(device.reportRate, 2);
   });
 
+  it("switches the active DPI stage and confirms it", async () => {
+    const device = new FakeKsnakeDevice();
+    assert.equal(await fastClient(device).setActiveDpiStage(4), 4);
+    assert.equal(device.dpiIndex, 4);
+    assert.deepEqual(device.sent, [0x0e, 0x0f, 0x0e]);
+  });
+
+  it("rejects out-of-range DPI stages without writing", async () => {
+    const device = new FakeKsnakeDevice();
+    await assert.rejects(() => fastClient(device).setActiveDpiStage(6), /between 1 and 6/);
+    await assert.rejects(() => fastClient(device).setDpiStageValue(0, 100), /between 200 and 12000/);
+    assert.ok(!device.sent.includes(0x0f), "no SET must be sent");
+  });
+
+  it("edits a single DPI stage value and confirms it", async () => {
+    const device = new FakeKsnakeDevice();
+    assert.equal(await fastClient(device).setDpiStageValue(0, 600), 600);
+    assert.equal(device.stages[0], 600);
+  });
+
   it("rejects out-of-range DPI without touching the mouse", async () => {
     const device = new FakeKsnakeDevice();
     await assert.rejects(() => fastClient(device).setDpi(100), /between 200 and 12000/);

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -1,6 +1,7 @@
 import type { MouseStatus } from "../mouse-types.ts";
 import {
   KSNAKE_PRODUCT_ID,
+  KSNAKE_POLLING_RATES,
   KSNAKE_REPORT_ID,
   KSNAKE_USAGE,
   KSNAKE_USAGE_PAGE,
@@ -14,28 +15,55 @@ import {
   ksnakeGetBatteryRequest,
   ksnakeGetConfigRequest,
   ksnakeGetVersionRequest,
+  ksnakeIsValidDpi,
+  type KsnakeConfig,
 } from "../../ksnake/index.js";
 import { VENDOR_ID } from "../vendors.ts";
 
 const REPLY_TIMEOUT_MS = 800;
+/** Pause after a SET before reading back, so the mouse can commit to flash. */
+const SETTLE_AFTER_WRITE_MS = 250;
+
+/** Rejected when a command gets no inputreport within the timeout. Retried by writes. */
+export class KsnakeTimeoutError extends Error {
+  constructor() {
+    super("The mouse did not answer — it may be asleep or out of range.");
+    this.name = "KsnakeTimeoutError";
+  }
+}
+
+export interface KsnakeClientOptions {
+  replyTimeoutMs?: number;
+  settleAfterWriteMs?: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
- * K-snake X11 vendor HID control (DRAFT — needs hardware verification).
+ * K-snake X11 vendor HID control.
  *
  * Transport: output report 0 (64 bytes starting with 0x55); the reply
  * arrives as the next `inputreport`. A tiny queue serializes concurrent
  * calls like the vendor panel's commandQueueWrapper.
  *
- * Evidence: vendor panel at https://x1a11.yjx2012.com/ plus a user HID
- * Diagnostic Report (VID 0xA8A5, Vendor 0xFF01 interface, PARTIAL — expected
- * since this protocol never uses feature reports).
+ * Evidence: vendor panel at https://x1a11.yjx2012.com/, the X11 user manual
+ * (6 factory DPI steps, 1000 Hz in 2.4G/wired, 125 Hz in BT, PAW3311), plus
+ * retail-hardware verification — 2.4 GHz dongle (VID 0xA8A5, Vendor 0xFF01
+ * interface, PARTIAL as expected since this protocol never uses feature
+ * reports), FW 2.1.7, read/set/confirm round-trips for DPI and polling.
  */
 export class KsnakeHidClient {
   readonly device: HIDDevice;
   private queue: Promise<unknown> = Promise.resolve();
+  private readonly replyTimeoutMs: number;
+  private readonly settleAfterWriteMs: number;
 
-  constructor(device: HIDDevice) {
+  constructor(device: HIDDevice, options: KsnakeClientOptions = {}) {
     this.device = device;
+    this.replyTimeoutMs = options.replyTimeoutMs ?? REPLY_TIMEOUT_MS;
+    this.settleAfterWriteMs = options.settleAfterWriteMs ?? SETTLE_AFTER_WRITE_MS;
   }
 
   static isSupported(device: HIDDevice): boolean {
@@ -49,7 +77,7 @@ export class KsnakeHidClient {
   }
 
   get supportedPollingRates(): number[] {
-    return [125, 250, 500, 1000];
+    return [...KSNAKE_POLLING_RATES];
   }
 
   getDpiOptions(): number[] {
@@ -74,13 +102,14 @@ export class KsnakeHidClient {
   }
 
   private async exchange(body: Uint8Array): Promise<Uint8Array> {
+    const timeoutMs = this.replyTimeoutMs;
     return this.run(async () => {
       await this.open();
       return new Promise<Uint8Array>((resolve, reject) => {
         const timer = setTimeout(() => {
           this.device.removeEventListener("inputreport", listener);
-          reject(new Error("The mouse did not answer — it may be asleep or out of range."));
-        }, REPLY_TIMEOUT_MS);
+          reject(new KsnakeTimeoutError());
+        }, timeoutMs);
         const listener = (event: HIDInputReportEvent): void => {
           clearTimeout(timer);
           this.device.removeEventListener("inputreport", listener);
@@ -94,6 +123,30 @@ export class KsnakeHidClient {
         });
       });
     });
+  }
+
+  /** Same as exchange, but resends on timeout (a sleeping dongle often drops the first). Non-timeout errors throw immediately. SETs are idempotent full-config writes, so resending is safe. */
+  private async exchangeRetrying(body: Uint8Array, attempts: number): Promise<Uint8Array> {
+    let lastError: unknown = null;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        return await this.exchange(body);
+      } catch (error) {
+        if (!(error instanceof KsnakeTimeoutError)) throw error;
+        lastError = error;
+      }
+    }
+    throw lastError;
+  }
+
+  /** Best-effort config read for post-write confirmation; null when the mouse stays silent. */
+  private async readBackConfig(attempts: number): Promise<KsnakeConfig | null> {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const reply = await this.exchange(ksnakeGetConfigRequest()).catch(() => null);
+      const config = reply ? ksnakeDecodeConfig(reply) : null;
+      if (config) return config;
+    }
+    return null;
   }
 
   async readStatus(): Promise<MouseStatus> {
@@ -141,16 +194,18 @@ export class KsnakeHidClient {
   }
 
   async setDpi(dpi: number): Promise<number> {
-    const raw = await this.exchange(ksnakeGetConfigRequest());
-    const config = ksnakeDecodeConfig(raw);
+    if (!ksnakeIsValidDpi(dpi)) {
+      throw new Error(`DPI must be a whole number between 200 and 12000 for the K-snake X11 (got ${dpi}).`);
+    }
+    const raw = await this.exchangeRetrying(ksnakeGetConfigRequest(), 3).catch(() => null);
+    const config = raw ? ksnakeDecodeConfig(raw) : null;
     if (!config) throw new Error("Could not read the current config from the mouse.");
     const stages = [...config.stages];
     const index = Math.min(Math.max(config.dpiIndex, 0), stages.length - 1);
     stages[index] = dpi;
-    await this.exchange(ksnakeEncodeSetConfig({ ...config, stages }));
-    const confirmed = await this.exchange(ksnakeGetConfigRequest())
-      .then((r) => ksnakeDecodeConfig(r))
-      .catch(() => null);
+    await this.exchangeRetrying(ksnakeEncodeSetConfig({ ...config, stages }), 2);
+    await sleep(this.settleAfterWriteMs);
+    const confirmed = await this.readBackConfig(3);
     const got = confirmed?.stages[Math.min(Math.max(confirmed.dpiIndex, 0), confirmed.stages.length - 1)];
     if (got !== dpi) throw new Error(`The mouse kept ${got ?? "?"} DPI instead of ${dpi}.`);
     return dpi;
@@ -159,13 +214,12 @@ export class KsnakeHidClient {
   async setPollingRate(rate: number): Promise<number> {
     const index = ksnakeEncodePollingRate(rate);
     if (index === null) throw new Error(`This mouse does not support ${rate} Hz.`);
-    const raw = await this.exchange(ksnakeGetConfigRequest());
-    const config = ksnakeDecodeConfig(raw);
+    const raw = await this.exchangeRetrying(ksnakeGetConfigRequest(), 3).catch(() => null);
+    const config = raw ? ksnakeDecodeConfig(raw) : null;
     if (!config) throw new Error("Could not read the current config from the mouse.");
-    await this.exchange(ksnakeEncodeSetConfig({ ...config, reportRate: index }));
-    const confirmed = await this.exchange(ksnakeGetConfigRequest())
-      .then((r) => ksnakeDecodeConfig(r))
-      .catch(() => null);
+    await this.exchangeRetrying(ksnakeEncodeSetConfig({ ...config, reportRate: index }), 2);
+    await sleep(this.settleAfterWriteMs);
+    const confirmed = await this.readBackConfig(3);
     const back = confirmed ? ksnakeDecodePollingRate(confirmed.reportRate) : null;
     if (back !== rate) throw new Error(`The mouse kept ${back ?? "?"} Hz instead of ${rate} Hz.`);
     return rate;

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -211,6 +211,43 @@ export class KsnakeHidClient {
     return dpi;
   }
 
+  async setActiveDpiStage(stage: number): Promise<number> {
+    const raw = await this.exchangeRetrying(ksnakeGetConfigRequest(), 3).catch(() => null);
+    const config = raw ? ksnakeDecodeConfig(raw) : null;
+    if (!config) throw new Error("Could not read the current config from the mouse.");
+    if (!Number.isInteger(stage) || stage < 0 || stage >= config.stages.length) {
+      throw new Error(`DPI stage must be between 1 and ${config.stages.length}.`);
+    }
+    await this.exchangeRetrying(ksnakeEncodeSetConfig({ ...config, dpiIndex: stage }), 2);
+    await sleep(this.settleAfterWriteMs);
+    const confirmed = await this.readBackConfig(3);
+    if (confirmed?.dpiIndex !== stage) {
+      throw new Error(`The mouse kept DPI stage ${(confirmed?.dpiIndex ?? 0) + 1} instead of ${stage + 1}.`);
+    }
+    return stage;
+  }
+
+  async setDpiStageValue(stage: number, dpi: number): Promise<number> {
+    if (!ksnakeIsValidDpi(dpi)) {
+      throw new Error(`DPI must be a whole number between 200 and 12000 for the K-snake X11 (got ${dpi}).`);
+    }
+    const raw = await this.exchangeRetrying(ksnakeGetConfigRequest(), 3).catch(() => null);
+    const config = raw ? ksnakeDecodeConfig(raw) : null;
+    if (!config) throw new Error("Could not read the current config from the mouse.");
+    if (!Number.isInteger(stage) || stage < 0 || stage >= config.stages.length) {
+      throw new Error(`DPI stage must be between 1 and ${config.stages.length}.`);
+    }
+    const stages = [...config.stages];
+    stages[stage] = dpi;
+    await this.exchangeRetrying(ksnakeEncodeSetConfig({ ...config, stages }), 2);
+    await sleep(this.settleAfterWriteMs);
+    const confirmed = await this.readBackConfig(3);
+    if (confirmed?.stages[stage] !== dpi) {
+      throw new Error(`The mouse kept ${confirmed?.stages[stage] ?? "?"} DPI instead of ${dpi}.`);
+    }
+    return dpi;
+  }
+
   async setPollingRate(rate: number): Promise<number> {
     const index = ksnakeEncodePollingRate(rate);
     if (index === null) throw new Error(`This mouse does not support ${rate} Hz.`);

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -149,12 +149,37 @@ export class KsnakeHidClient {
     return null;
   }
 
+  /**
+   * Reads with one retry when the reply fails validation. The dongle can emit
+   * unsolicited reports that a queued exchange mistakes for its answer, so a
+   * single failed decode is worth one resend before giving up.
+   */
+  private async readValidated<T>(
+    read: () => Promise<T | null>,
+    valid: (value: T) => boolean,
+  ): Promise<T | null> {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const value = await read().catch(() => null);
+      if (value !== null && valid(value)) return value;
+    }
+    return null;
+  }
+
   async readStatus(): Promise<MouseStatus> {
     await this.open();
     const [config, battery, version] = await Promise.all([
-      this.exchange(ksnakeGetConfigRequest()).then((r) => ksnakeDecodeConfig(r)).catch(() => null),
-      this.exchange(ksnakeGetBatteryRequest()).then((r) => ksnakeDecodeBattery(r)).catch(() => null),
-      this.exchange(ksnakeGetVersionRequest()).then((r) => ksnakeDecodeVersion(r)).catch(() => null),
+      this.readValidated(
+        () => this.exchange(ksnakeGetConfigRequest()).then((r) => ksnakeDecodeConfig(r)),
+        (c) => ksnakeDecodePollingRate(c.reportRate) !== null && c.dpiIndex >= 0 && c.dpiIndex < c.stages.length,
+      ),
+      this.readValidated(
+        () => this.exchange(ksnakeGetBatteryRequest()).then((r) => ksnakeDecodeBattery(r)),
+        (b) => b.percent <= 100,
+      ),
+      this.readValidated(
+        () => this.exchange(ksnakeGetVersionRequest()).then((r) => ksnakeDecodeVersion(r)),
+        (v) => v.length > 0,
+      ),
     ]);
     const stages = config?.stages ?? [];
     const activeStage = config ? Math.min(Math.max(config.dpiIndex, 0), Math.max(stages.length - 1, 0)) : 0;

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -22,6 +22,7 @@ import {
   ksnakeGetVersionRequest,
   ksnakeIsKnownKeyType,
   ksnakeIsValidDpi,
+  ksnakeKeysLookPlausible,
   type KsnakeConfig,
   type KsnakeKeyBinding,
 } from "../../ksnake/index.js";
@@ -283,8 +284,12 @@ export class KsnakeHidClient {
 
   /** Read-only dump of the 7 button slots (GET_KEYS, reply[8..35]). */
   async getKeys(): Promise<KsnakeKeyBinding[] | null> {
-    const reply = await this.exchangeRetrying(ksnakeGetKeysRequest(), 3).catch(() => null);
-    return reply ? ksnakeDecodeKeys(reply) : null;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const reply = await this.exchange(ksnakeGetKeysRequest()).catch(() => null);
+      const keys = reply ? ksnakeDecodeKeys(reply) : null;
+      if (keys && ksnakeKeysLookPlausible(keys)) return keys;
+    }
+    return null;
   }
 
   /**
@@ -318,7 +323,7 @@ export class KsnakeHidClient {
     for (let attempt = 0; attempt < attempts; attempt++) {
       const reply = await this.exchange(ksnakeGetKeysRequest()).catch(() => null);
       const keys = reply ? ksnakeDecodeKeys(reply) : null;
-      if (keys) return keys;
+      if (keys && ksnakeKeysLookPlausible(keys)) return keys;
     }
     return null;
   }

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -9,8 +9,10 @@ import {
   ksnakeDecodeBattery,
   ksnakeDecodeConfig,
   ksnakeDecodeKeys,
+  ksnakeDecodeLiftOff,
   ksnakeDecodePollingRate,
   ksnakeDecodeVersion,
+  ksnakeEncodeLiftOff,
   ksnakeEncodePollingRate,
   ksnakeEncodeSetConfig,
   ksnakeEncodeSetKeys,
@@ -218,7 +220,8 @@ export class KsnakeHidClient {
       activeProfile: null,
       connectionType: this.device.vendorId === KSNAKE_USB_VENDOR_ID ? "Wired" : "Wireless",
       connectionDetail: this.device.vendorId === KSNAKE_USB_VENDOR_ID ? "Wired USB" : "2.4 GHz receiver",
-      liftOffDistance: null,
+      liftOffDistance: config ? ksnakeDecodeLiftOff(config.lodValue) : null,
+      supportedLiftOffDistances: ["Low", "High"],
       firmware: version ? [`X11 ${version}`] : ["K-snake X11"],
     };
   }
@@ -318,6 +321,22 @@ export class KsnakeHidClient {
       if (keys) return keys;
     }
     return null;
+  }
+
+  async setLiftOffDistance(
+    value: NonNullable<MouseStatus["liftOffDistance"]>,
+  ): Promise<NonNullable<MouseStatus["liftOffDistance"]>> {
+    const encoded = ksnakeEncodeLiftOff(value);
+    if (encoded === null) throw new Error(`This mouse does not support a ${value.toLowerCase()} lift-off distance.`);
+    const raw = await this.exchangeRetrying(ksnakeGetConfigRequest(), 3).catch(() => null);
+    const config = raw ? ksnakeDecodeConfig(raw) : null;
+    if (!config) throw new Error("Could not read the current config from the mouse.");
+    await this.exchangeRetrying(ksnakeEncodeSetConfig({ ...config, lodValue: encoded }), 2);
+    await sleep(this.settleAfterWriteMs);
+    const confirmed = await this.readBackConfig(3);
+    const back = confirmed ? ksnakeDecodeLiftOff(confirmed.lodValue) : null;
+    if (back !== value) throw new Error(`The mouse kept a ${String(back).toLowerCase()} lift-off distance instead of ${value.toLowerCase()}.`);
+    return value;
   }
 
   async setPollingRate(rate: number): Promise<number> {

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -8,15 +8,20 @@ import {
   KSNAKE_USB_VENDOR_ID,
   ksnakeDecodeBattery,
   ksnakeDecodeConfig,
+  ksnakeDecodeKeys,
   ksnakeDecodePollingRate,
   ksnakeDecodeVersion,
   ksnakeEncodePollingRate,
   ksnakeEncodeSetConfig,
+  ksnakeEncodeSetKeys,
   ksnakeGetBatteryRequest,
   ksnakeGetConfigRequest,
+  ksnakeGetKeysRequest,
   ksnakeGetVersionRequest,
+  ksnakeIsKnownKeyType,
   ksnakeIsValidDpi,
   type KsnakeConfig,
+  type KsnakeKeyBinding,
 } from "../../ksnake/index.js";
 import { VENDOR_ID } from "../vendors.ts";
 
@@ -273,6 +278,48 @@ export class KsnakeHidClient {
     return dpi;
   }
 
+  /** Read-only dump of the 7 button slots (GET_KEYS, reply[8..35]). */
+  async getKeys(): Promise<KsnakeKeyBinding[] | null> {
+    const reply = await this.exchangeRetrying(ksnakeGetKeysRequest(), 3).catch(() => null);
+    return reply ? ksnakeDecodeKeys(reply) : null;
+  }
+
+  /**
+   * Remap slots 0-5 (SET_KEYS). Only catalog types (mouse/special/media) are
+   * accepted — macro references and other opaque bindings are rejected rather
+   * than risk bricking them. Confirms by reading the map back.
+   */
+  async setKeys(keys: readonly KsnakeKeyBinding[]): Promise<KsnakeKeyBinding[]> {
+    const slots = [...keys].slice(0, 6);
+    if (slots.length !== 6) throw new Error(`Exactly 6 button bindings are required (got ${keys.length}).`);
+    for (const [index, key] of slots.entries()) {
+      const bytes = [key.type, key.code1, key.code2, key.code3];
+      if (!bytes.every((b) => Number.isInteger(b) && b >= 0 && b <= 255)) {
+        throw new Error(`Button ${index + 1}: binding bytes must be 0-255.`);
+      }
+      if (!ksnakeIsKnownKeyType(key.type)) {
+        throw new Error(`Button ${index + 1}: type ${key.type} is not remappable (macro/custom bindings are preserved, not rewritten).`);
+      }
+    }
+    await this.exchangeRetrying(ksnakeEncodeSetKeys(slots), 2);
+    await sleep(this.settleAfterWriteMs);
+    const confirmed = await this.readBackKeys(3);
+    if (!confirmed || !slots.every((key, index) => equalBinding(confirmed[index], key))) {
+      throw new Error("The mouse did not keep the new button map.");
+    }
+    return slots;
+  }
+
+  /** Best-effort key-map read for post-write confirmation. */
+  private async readBackKeys(attempts: number): Promise<KsnakeKeyBinding[] | null> {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const reply = await this.exchange(ksnakeGetKeysRequest()).catch(() => null);
+      const keys = reply ? ksnakeDecodeKeys(reply) : null;
+      if (keys) return keys;
+    }
+    return null;
+  }
+
   async setPollingRate(rate: number): Promise<number> {
     const index = ksnakeEncodePollingRate(rate);
     if (index === null) throw new Error(`This mouse does not support ${rate} Hz.`);
@@ -290,4 +337,8 @@ export class KsnakeHidClient {
 
 function copyDataView(view: DataView): Uint8Array {
   return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength));
+}
+
+function equalBinding(a: KsnakeKeyBinding | undefined, b: KsnakeKeyBinding): boolean {
+  return a !== undefined && a.type === b.type && a.code1 === b.code1 && a.code2 === b.code2 && a.code3 === b.code3;
 }

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -313,7 +313,8 @@ export class KsnakeHidClient {
     await sleep(this.settleAfterWriteMs);
     const confirmed = await this.readBackKeys(3);
     if (!confirmed || !slots.every((key, index) => equalBinding(confirmed[index], key))) {
-      throw new Error("The mouse did not keep the new button map.");
+      const seen = confirmed ? JSON.stringify(confirmed) : "no readable reply";
+      throw new Error(`The mouse did not keep the new button map (read back ${seen}).`);
     }
     return slots;
   }

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -242,9 +242,9 @@ export function ksnakeEncodeSetConfig(config: KsnakeConfig): Uint8Array {
   return buf;
 }
 
-/** Physical button order for the 6 remappable slots. Labels follow the vendor
- *  panel diagram; the Macro1 button ships with the Forward function. */
-export const KSNAKE_BUTTON_NAMES = ["Left", "Right", "Middle", "Backward", "Macro1", "DPI"] as const;
+/** Physical button order for the 6 remappable slots. Labels follow the factory
+ *  functions; the side button ships as Forward (user-renameable to Macro1). */
+export const KSNAKE_BUTTON_NAMES = ["Left", "Right", "Middle", "Backward", "Forward", "DPI"] as const;
 
 /** Button function types from the vendor key catalog. */
 export const KSNAKE_KEY_TYPE = {

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -25,6 +25,16 @@ export const KSNAKE_REPORT_ID = 0x00;
 export const KSNAKE_MAGIC = 0x55;
 export const KSNAKE_REPORT_SIZE = 64;
 
+/** DPI range. Vendor panel slider allows 200–12000 (step 100); the manual's
+ *  factory steps are 800–12000 and 600 was observed in stage 0 on retail
+ *  hardware (user-customized via the vendor panel). */
+export const KSNAKE_DPI_MIN = 200;
+export const KSNAKE_DPI_MAX = 12000;
+
+export function ksnakeIsValidDpi(dpi: number): boolean {
+  return Number.isInteger(dpi) && dpi >= KSNAKE_DPI_MIN && dpi <= KSNAKE_DPI_MAX;
+}
+
 export interface KsnakeProduct {
   model: string;
   wireless: boolean;
@@ -50,8 +60,9 @@ const GET_BATTERY_TAIL = [0xa5, 0x0b, 0x2e, 0x01, 0x01, 0x00, 0x00, 0x00] as con
 
 /**
  * Polling-rate index ↔ Hz.
- * Confirmed by vendor panel screenshot + PAW3311 spec: X11 offers
- * 125/250/500/1000 Hz only (1000 Hz in 2.4G/wired, 125 Hz in BT).
+ * Endpoints confirmed by the X11 user manual: 1000 Hz in 2.4G/wired,
+ * 125 Hz in BT. Middle steps (250/500) come from the vendor panel screenshot
+ * + PAW3311 spec — keep until a hardware capture says otherwise.
  * Default index 3 = 1000 Hz.
  */
 export const KSNAKE_POLLING_RATES = [125, 250, 500, 1000] as const;
@@ -69,7 +80,8 @@ export const KSNAKE_DEFAULT_CONFIG = {
   lightMode: 2,
   reportRate: 3,
   dpiIndex: 2,
-  dpiCount: 5,
+  // Hardware reports 6 (retail 2.4 GHz dongle, FW 2.1.7).
+  dpiCount: 6,
   stages: [800, 1200, 1600, 3200, 5000, 12000],
   scrollFlag: 0,
   lodValue: 1,

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -242,8 +242,9 @@ export function ksnakeEncodeSetConfig(config: KsnakeConfig): Uint8Array {
   return buf;
 }
 
-/** Physical button order for the 6 remappable slots (vendor panel labels). */
-export const KSNAKE_BUTTON_NAMES = ["Left", "Right", "Middle", "Macro1", "Backward", "DPI"] as const;
+/** Physical button order for the 6 remappable slots. Labels follow the vendor
+ *  panel diagram; the Macro1 button ships with the Forward function. */
+export const KSNAKE_BUTTON_NAMES = ["Left", "Right", "Middle", "Backward", "Macro1", "DPI"] as const;
 
 /** Button function types from the vendor key catalog. */
 export const KSNAKE_KEY_TYPE = {

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -188,8 +188,10 @@ export function ksnakeDecodeConfig(reply: Uint8Array): KsnakeConfig | null {
     keyRespond: reply[51],
     sleepLight: reply[52],
     highspeedMode: reply[53],
-    // NOTE: vendor decode reads wakeup from the LOW nibble, but vendor encode
-    // writes `wakeup << 4 | move`. Kept as-decoded; verify on hardware.
+    // NOTE: the vendor panel itself is asymmetric here — its decode reads
+    // wakeup from the LOW nibble (`15 & t[55]`) but its encode writes
+    // `wakeup << 4 | move`. This codec mirrors the vendor byte-for-byte, so
+    // states round-trip exactly like the vendor panel does.
     wakeupFlag: reply[55] & 15,
     moveLightFlag: (reply[55] >> 4) & 15,
   };

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -78,6 +78,21 @@ export function ksnakeDecodePollingRate(index: number): number | null {
   return index >= 0 && index < KSNAKE_POLLING_RATES.length ? KSNAKE_POLLING_RATES[index] : null;
 }
 
+/**
+ * Lift-off mapping. The vendor panel offers two stops (lod_value 1/2,
+ * default 1, likely 1mm/2mm on the PAW3311); they map to the Low/High stops.
+ * Medium is not offered by the hardware.
+ */
+export function ksnakeDecodeLiftOff(value: number): "Low" | "High" {
+  return value === 2 ? "High" : "Low";
+}
+
+export function ksnakeEncodeLiftOff(level: string): number | null {
+  if (level === "Low") return 1;
+  if (level === "High") return 2;
+  return null;
+}
+
 export const KSNAKE_DEFAULT_CONFIG = {
   lightMode: 2,
   reportRate: 3,

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -323,16 +323,18 @@ export function ksnakeEncodeSetKeys(keys: readonly KsnakeKeyBinding[]): Uint8Arr
   buf[4] = 0x20;
   const slots = [...keys].slice(0, 6);
   while (slots.length < 6) slots.push({ type: 32, code1: 0, code2: 0, code3: 0 });
+  // Wire offsets, NOT vendor-JS t[] indices: t[0] is the report id, so the
+  // request slots at t[9..32] land at data[8..31]. (buf[9..] bricked buttons.)
   for (let n = 0; n < 6; n++) {
     const key = slots[n];
-    buf[9 + n * 4] = key.type & 0xff;
-    buf[10 + n * 4] = key.code1 & 0xff;
-    buf[11 + n * 4] = key.code2 & 0xff;
-    buf[12 + n * 4] = key.code3 & 0xff;
+    buf[8 + n * 4] = key.type & 0xff;
+    buf[9 + n * 4] = key.code1 & 0xff;
+    buf[10 + n * 4] = key.code2 & 0xff;
+    buf[11 + n * 4] = key.code3 & 0xff;
   }
   const tail = [33, 56, 1, 0, 33, 56, 255, 0];
   tail.forEach((b, i) => {
-    buf[33 + i] = b;
+    buf[32 + i] = b;
   });
   return buf;
 }

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -268,6 +268,16 @@ export function ksnakeIsKnownKeyType(type: number): boolean {
   return type === KSNAKE_KEY_TYPE.mouse || type === KSNAKE_KEY_TYPE.special || type === KSNAKE_KEY_TYPE.media;
 }
 
+/**
+ * Plausibility gate for decoded key maps. `exchange()` resolves with the next
+ * input report, so a stray report from another command can land here; those
+ * decode to zeroed/garbage slot types. Real maps always carry nonzero types
+ * (32/33/48 catalog, plus opaque refs like macro 112).
+ */
+export function ksnakeKeysLookPlausible(keys: readonly KsnakeKeyBinding[]): boolean {
+  return keys.length === 7 && keys.every((key) => key.type !== 0);
+}
+
 /** GET_KEYS request tail observed in vendor JS: [0x55, 0x08, 0xA5, 0x0B, 0x20]. */
 export function ksnakeGetKeysRequest(): Uint8Array {
   const buf = new Uint8Array(KSNAKE_REPORT_SIZE);

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -48,6 +48,8 @@ export const KSNAKE_PRODUCTS: ReadonlyMap<number, KsnakeProduct> = new Map([
 
 const CMD = {
   GET_VERSION: 0x03,
+  GET_KEYS: 0x08,
+  SET_KEYS: 0x09,
   GET_CONFIG: 0x0e,
   SET_CONFIG: 0x0f,
   SET_LIGHT: 0x21,
@@ -222,5 +224,89 @@ export function ksnakeEncodeSetConfig(config: KsnakeConfig): Uint8Array {
   buf[52] = config.sleepLight & 0xff;
   buf[53] = config.highspeedMode & 0xff;
   buf[54] = ((config.wakeupFlag << 4) | (config.moveLightFlag & 15)) & 0xff;
+  return buf;
+}
+
+/** Physical button order for the 6 remappable slots (vendor panel labels). */
+export const KSNAKE_BUTTON_NAMES = ["Left", "Right", "Middle", "Macro1", "Backward", "DPI"] as const;
+
+/** Button function types from the vendor key catalog. */
+export const KSNAKE_KEY_TYPE = {
+  mouse: 32,
+  special: 33,
+  media: 48,
+} as const;
+
+/** One button slot: type 32 = mouse button (code1 = HID bitmask, 0 = disabled),
+ *  33 = special (DPI loop [85,0,0], scroll [56,1/255]), 48 = consumer/media
+ *  (code1 = consumer usage). Macro references (e.g. type 112) are preserved
+ *  opaquely — the catalog cannot rebuild them. */
+export interface KsnakeKeyBinding {
+  type: number;
+  code1: number;
+  code2: number;
+  code3: number;
+}
+
+export function ksnakeIsKnownKeyType(type: number): boolean {
+  return type === KSNAKE_KEY_TYPE.mouse || type === KSNAKE_KEY_TYPE.special || type === KSNAKE_KEY_TYPE.media;
+}
+
+/** GET_KEYS request tail observed in vendor JS: [0x55, 0x08, 0xA5, 0x0B, 0x20]. */
+export function ksnakeGetKeysRequest(): Uint8Array {
+  const buf = new Uint8Array(KSNAKE_REPORT_SIZE);
+  buf[0] = KSNAKE_MAGIC;
+  buf[1] = CMD.GET_KEYS;
+  buf[2] = 0xa5;
+  buf[3] = 0x0b;
+  buf[4] = 0x20;
+  return buf;
+}
+
+/**
+ * Decode a getKeys reply: 7 slots of 4 bytes at reply[8..35] (the vendor
+ * slices 8). Slot 6 is a fixed scroll-up entry; slots 0-5 are remappable.
+ * Verified against a retail dongle (factory map decodes to
+ * Left/Right/Middle/Backward + DPI loop in order).
+ */
+export function ksnakeDecodeKeys(reply: Uint8Array): KsnakeKeyBinding[] | null {
+  if (reply.length < 36) return null;
+  const bindings: KsnakeKeyBinding[] = [];
+  for (let i = 0; i < 7; i++) {
+    bindings.push({
+      type: reply[8 + i * 4],
+      code1: reply[9 + i * 4],
+      code2: reply[10 + i * 4],
+      code3: reply[11 + i * 4],
+    });
+  }
+  return bindings;
+}
+
+/**
+ * Encode a setKeys request, mirroring vendor `setMouseKeys()`: head
+ * [0x55, 0x09, 0xA5, 0x22, 0x20], slots 0-5 at body[9..32], fixed tail
+ * [33,56,1,0, 33,56,255,0] at body[33..40].
+ */
+export function ksnakeEncodeSetKeys(keys: readonly KsnakeKeyBinding[]): Uint8Array {
+  const buf = new Uint8Array(KSNAKE_REPORT_SIZE);
+  buf[0] = KSNAKE_MAGIC;
+  buf[1] = CMD.SET_KEYS;
+  buf[2] = 0xa5;
+  buf[3] = 0x22;
+  buf[4] = 0x20;
+  const slots = [...keys].slice(0, 6);
+  while (slots.length < 6) slots.push({ type: 32, code1: 0, code2: 0, code3: 0 });
+  for (let n = 0; n < 6; n++) {
+    const key = slots[n];
+    buf[9 + n * 4] = key.type & 0xff;
+    buf[10 + n * 4] = key.code1 & 0xff;
+    buf[11 + n * 4] = key.code2 & 0xff;
+    buf[12 + n * 4] = key.code3 & 0xff;
+  }
+  const tail = [33, 56, 1, 0, 33, 56, 255, 0];
+  tail.forEach((b, i) => {
+    buf[33 + i] = b;
+  });
   return buf;
 }


### PR DESCRIPTION
## Summary
- Resend commands on reply timeout (sleeping 2.4 GHz dongles often drop the first exchange); non-timeout errors still throw immediately.
- Pause 250 ms after a SET so the mouse can commit to flash before the confirm read; the confirm read itself retries.
- Reject out-of-range DPI (200–12000, vendor slider) before touching HID.
- Default `dpiCount` 5 → 6, matching retail hardware.
- `supportedPollingRates` now spreads `KSNAKE_POLLING_RATES` (single source of truth).

## Hardware evidence
Retail 2.4 GHz dongle (VID 0xA8A5 / PID 0x2255, Vendor 0xFF01:0x10, FW **2.1.7**):
- `readStatus` decodes stages, active index, polling, battery (81%), firmware correctly.
- `setDpi(1200)` round-trips 800 → 1200 with device-side confirm; `setPollingRate` round-trips.
- Timings 470–626 ms, zero timeouts while awake — the retry path is insurance for the sleep case, covered by emulator tests.
- Manual confirms 6 factory DPI steps (800/1200/1600/3200/5000/12000), 1000 Hz wired/2.4G, 125 Hz BT.

## Test plan
- [x] `npm run check` (build + 1072 tests + pack) passes, incl. 5 new emulator tests (write/confirm, first-reply-lost recovery, silence, polling, range rejection).

## Left out deliberately
- Wakeup/move-light nibble order stays `TODO(hardware)`: observed flags were (0,0), which is symmetric and decides nothing.