### PR TITLE
ksnake: button remapping, LOD flag, read robustness

### DIFF
--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -415,10 +415,43 @@ describe("KsnakeHidClient writes", () => {
     assert.deepEqual(keys, device.keys);
   });
 
-  it("publishes the button map on readStatus", async () => {
+  it("publishes the generic button map on readStatus", async () => {
     const status = await fastClient(new FakeKsnakeDevice()).readStatus();
-    assert.equal(status.ksnakeButtonMappings?.length, 7);
-    assert.deepEqual(status.ksnakeButtonMappings?.[0], { type: 32, code1: 1, code2: 0, code3: 0 });
+    assert.deepEqual(status.buttonMappings, {
+      Left: "Left click",
+      Right: "Right click",
+      Middle: "Middle click",
+      Backward: "Backward",
+      // The fake ships a macro reference here: opaque slots surface as-is.
+      Forward: "Custom (112,0,1,3)",
+      DPI: "DPI loop",
+    });
+    assert.ok(status.buttonOptions?.includes("Backward"));
+    assert.ok(status.buttonOptions?.includes("DPI loop"));
+  });
+
+  it("remaps one button by label through setButtonMapping", async () => {
+    const device = new FakeKsnakeDevice();
+    device.keys = [
+      { type: 32, code1: 1, code2: 0, code3: 0 },
+      { type: 32, code1: 2, code2: 0, code3: 0 },
+      { type: 32, code1: 4, code2: 0, code3: 0 },
+      { type: 32, code1: 8, code2: 0, code3: 0 },
+      { type: 32, code1: 16, code2: 0, code3: 0 },
+      { type: 33, code1: 85, code2: 0, code3: 0 },
+      { type: 33, code1: 56, code2: 1, code3: 0 },
+    ];
+    await fastClient(device).setButtonMapping("Forward", "Backward");
+    assert.deepEqual(device.keys[4], { type: 32, code1: 8, code2: 0, code3: 0 });
+    assert.ok(device.sent.includes(0x09));
+  });
+
+  it("locks Left and rejects unknown buttons and actions", async () => {
+    const device = new FakeKsnakeDevice();
+    await assert.rejects(() => fastClient(device).setButtonMapping("Left", "Backward"), /fixed/);
+    await assert.rejects(() => fastClient(device).setButtonMapping("Side", "Backward"), /no "Side" button/);
+    await assert.rejects(() => fastClient(device).setButtonMapping("Forward", "Turbo"), /Unknown button action/);
+    assert.ok(!device.sent.includes(0x09));
   });
 
   it("reuses the last good config when a poll read fails", async () => {

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -400,6 +400,12 @@ describe("KsnakeHidClient writes", () => {
     assert.deepEqual(keys, device.keys);
   });
 
+  it("publishes the button map on readStatus", async () => {
+    const status = await fastClient(new FakeKsnakeDevice()).readStatus();
+    assert.equal(status.ksnakeButtonMappings?.length, 7);
+    assert.deepEqual(status.ksnakeButtonMappings?.[0], { type: 32, code1: 1, code2: 0, code3: 0 });
+  });
+
   it("rejects out-of-range DPI without touching the mouse", async () => {
     const device = new FakeKsnakeDevice();
     await assert.rejects(() => fastClient(device).setDpi(100), /between 200 and 12000/);

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -172,6 +172,8 @@ class FakeKsnakeDevice {
   badBatteryOnce = false;
   /** Next keys reply is zeroed once (simulates a stray report). */
   badKeysOnce = false;
+  /** Next keys reply is plausible-but-wrong once (simulates a crossed report). */
+  garbageKeysOnce = false;
   sent: number[] = [];
   private listeners = new Map<string, Set<FakeListener>>();
 
@@ -215,7 +217,12 @@ class FakeKsnakeDevice {
       this.badBatteryOnce = false;
     } else if (body[1] === 0x08) {
       reply = new Uint8Array(64);
-      if (!this.badKeysOnce) {
+      if (this.garbageKeysOnce) {
+        for (let i = 0; i < 7; i++) {
+          reply[8 + i * 4] = 99;
+          reply[9 + i * 4] = i;
+        }
+      } else if (!this.badKeysOnce) {
         this.keys.forEach((key, i) => {
           reply[8 + i * 4] = key.type;
           reply[9 + i * 4] = key.code1;
@@ -224,6 +231,7 @@ class FakeKsnakeDevice {
         });
       }
       this.badKeysOnce = false;
+      this.garbageKeysOnce = false;
     } else if (body[1] === 0x09) {
       for (let i = 0; i < 6; i++) {
         this.keys[i] = { type: body[8 + i * 4], code1: body[9 + i * 4], code2: body[10 + i * 4], code3: body[11 + i * 4] };
@@ -396,6 +404,13 @@ describe("KsnakeHidClient writes", () => {
   it("skips stray zeroed reports when reading the button map", async () => {
     const device = new FakeKsnakeDevice();
     device.badKeysOnce = true;
+    const keys = await fastClient(device).getKeys();
+    assert.deepEqual(keys, device.keys);
+  });
+
+  it("ignores a plausible stray until two reads agree", async () => {
+    const device = new FakeKsnakeDevice();
+    device.garbageKeysOnce = true;
     const keys = await fastClient(device).getKeys();
     assert.deepEqual(keys, device.keys);
   });

--- a/src/drivers/ksnake/hid.test.ts
+++ b/src/drivers/ksnake/hid.test.ts
@@ -421,6 +421,17 @@ describe("KsnakeHidClient writes", () => {
     assert.deepEqual(status.ksnakeButtonMappings?.[0], { type: 32, code1: 1, code2: 0, code3: 0 });
   });
 
+  it("reuses the last good config when a poll read fails", async () => {
+    const device = new FakeKsnakeDevice();
+    const client = fastClient(device);
+    const first = await client.readStatus();
+    assert.deepEqual(first.dpiStages?.slice(0, 3), [800, 1200, 1600]);
+    device.dropReplies = 99;
+    const second = await client.readStatus();
+    assert.deepEqual(second.dpiStages?.slice(0, 3), [800, 1200, 1600]);
+    assert.equal(second.dpi, first.dpi);
+  });
+
   it("rejects out-of-range DPI without touching the mouse", async () => {
     const device = new FakeKsnakeDevice();
     await assert.rejects(() => fastClient(device).setDpi(100), /between 200 and 12000/);

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -189,6 +189,9 @@ export class KsnakeHidClient {
         (v) => v.length > 0,
       ),
     ]);
+    // Sequential on purpose: parallel reads on this dongle collide into
+    // crossed reports, and keys are the least critical of the four.
+    const keys = await this.getKeys().catch(() => null);
     const stages = config?.stages ?? [];
     const activeStage = config ? Math.min(Math.max(config.dpiIndex, 0), Math.max(stages.length - 1, 0)) : 0;
     const dpi = stages[activeStage] ?? 1600;
@@ -222,6 +225,7 @@ export class KsnakeHidClient {
       connectionDetail: this.device.vendorId === KSNAKE_USB_VENDOR_ID ? "Wired USB" : "2.4 GHz receiver",
       liftOffDistance: config ? ksnakeDecodeLiftOff(config.lodValue) : null,
       supportedLiftOffDistances: ["Low", "High"],
+      ksnakeButtonMappings: keys,
       firmware: version ? [`X11 ${version}`] : ["K-snake X11"],
     };
   }

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -67,6 +67,8 @@ export class KsnakeHidClient {
   private queue: Promise<unknown> = Promise.resolve();
   private readonly replyTimeoutMs: number;
   private readonly settleAfterWriteMs: number;
+  /** Last config that passed validation (see readStatus). */
+  private lastGoodConfig: KsnakeConfig | null = null;
 
   constructor(device: HIDDevice, options: KsnakeClientOptions = {}) {
     this.device = device;
@@ -175,7 +177,7 @@ export class KsnakeHidClient {
 
   async readStatus(): Promise<MouseStatus> {
     await this.open();
-    const [config, battery, version] = await Promise.all([
+    const [freshConfig, battery, version] = await Promise.all([
       this.readValidated(
         () => this.exchange(ksnakeGetConfigRequest()).then((r) => ksnakeDecodeConfig(r)),
         (c) => ksnakeDecodePollingRate(c.reportRate) !== null && c.dpiIndex >= 0 && c.dpiIndex < c.stages.length,
@@ -192,6 +194,10 @@ export class KsnakeHidClient {
     // Sequential on purpose: parallel reads on this dongle collide into
     // crossed reports, and keys are the least critical of the four.
     const keys = await this.getKeys().catch(() => null);
+    // Last-good cache: a failed poll read must not blank the stages/DPI in
+    // the UI until the next poll (the panel re-renders on every change).
+    if (freshConfig) this.lastGoodConfig = freshConfig;
+    const config = freshConfig ?? this.lastGoodConfig;
     const stages = config?.stages ?? [];
     const activeStage = config ? Math.min(Math.max(config.dpiIndex, 0), Math.max(stages.length - 1, 0)) : 0;
     const dpi = stages[activeStage] ?? 1600;

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -1,5 +1,7 @@
 import type { MouseStatus } from "../mouse-types.ts";
 import {
+  KSNAKE_BUTTON_ACTIONS,
+  KSNAKE_BUTTON_NAMES,
   KSNAKE_PRODUCT_ID,
   KSNAKE_POLLING_RATES,
   KSNAKE_REPORT_ID,
@@ -20,6 +22,8 @@ import {
   ksnakeGetConfigRequest,
   ksnakeGetKeysRequest,
   ksnakeGetVersionRequest,
+  ksnakeBindingLabel,
+  ksnakeFindButtonAction,
   ksnakeIsKnownKeyType,
   ksnakeIsValidDpi,
   ksnakeKeysLookPlausible,
@@ -231,7 +235,18 @@ export class KsnakeHidClient {
       connectionDetail: this.device.vendorId === KSNAKE_USB_VENDOR_ID ? "Wired USB" : "2.4 GHz receiver",
       liftOffDistance: config ? ksnakeDecodeLiftOff(config.lodValue) : null,
       supportedLiftOffDistances: ["Low", "High"],
-      ksnakeButtonMappings: keys,
+      // Generic remap interface: the shared ButtonMappingCard renders these
+      // with no brand-specific code. Opaque slots surface as "Custom (…)" and
+      // stay selectable-visible; setButtonMapping refuses to rewrite them.
+      buttonMappings: keys
+        ? Object.fromEntries(
+            keys.slice(0, KSNAKE_BUTTON_NAMES.length).map((binding, index) => [
+              KSNAKE_BUTTON_NAMES[index] as string,
+              ksnakeBindingLabel(binding) ?? `Custom (${binding.type},${binding.code1},${binding.code2},${binding.code3})`,
+            ]),
+          )
+        : undefined,
+      buttonOptions: KSNAKE_BUTTON_ACTIONS.map((action) => action.label),
       firmware: version ? [`X11 ${version}`] : ["K-snake X11"],
     };
   }
@@ -341,6 +356,26 @@ export class KsnakeHidClient {
       if (keys && ksnakeKeysLookPlausible(keys)) return keys;
     }
     return null;
+  }
+
+  /**
+   * Remap one button by display label (generic `setButtonMapping` interface).
+   * SET_KEYS always carries all six remappable slots, so the current map is
+   * re-read and the single slot replaced — confirmed by setKeys' read-back.
+   * Slot "Left" is locked (the vendor panel refuses drops there too); opaque
+   * slots elsewhere abort the write rather than risk bricking macros.
+   */
+  async setButtonMapping(button: string, actionLabel: string): Promise<void> {
+    const index = KSNAKE_BUTTON_NAMES.indexOf(button as (typeof KSNAKE_BUTTON_NAMES)[number]);
+    if (index < 0) throw new Error(`This mouse has no "${button}" button.`);
+    if (index === 0) throw new Error("Left Click is fixed and cannot be reassigned.");
+    const binding = ksnakeFindButtonAction(actionLabel);
+    if (!binding) throw new Error(`Unknown button action "${actionLabel}".`);
+    const current = await this.getKeys();
+    if (!current) throw new Error("Could not read the current button map from the mouse.");
+    const slots = current.slice(0, KSNAKE_BUTTON_NAMES.length).map((slot) => ({ ...slot }));
+    slots[index] = binding;
+    await this.setKeys(slots);
   }
 
   async setLiftOffDistance(

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -199,7 +199,6 @@ export class KsnakeHidClient {
       ui: {
         family: "ksnake",
         settingsReady: config !== null,
-        hideLodLow: true,
         hideUnsupportedPollingRates: true,
         hideProcessingCard: true,
         defaultDisplayName: this.device.productName || "K-snake X11",

--- a/src/drivers/ksnake/hid.ts
+++ b/src/drivers/ksnake/hid.ts
@@ -287,10 +287,15 @@ export class KsnakeHidClient {
 
   /** Read-only dump of the 7 button slots (GET_KEYS, reply[8..35]). */
   async getKeys(): Promise<KsnakeKeyBinding[] | null> {
-    for (let attempt = 0; attempt < 3; attempt++) {
+    // Consensus, not first-plausible: a crossed report from another command
+    // can decode to plausible-but-wrong slots, and two strays never agree.
+    const seen: KsnakeKeyBinding[][] = [];
+    for (let attempt = 0; attempt < 5; attempt++) {
       const reply = await this.exchange(ksnakeGetKeysRequest()).catch(() => null);
       const keys = reply ? ksnakeDecodeKeys(reply) : null;
-      if (keys && ksnakeKeysLookPlausible(keys)) return keys;
+      if (!keys || !ksnakeKeysLookPlausible(keys)) continue;
+      if (seen.some((prev) => equalKeyMaps(prev, keys))) return keys;
+      seen.push(keys);
     }
     return null;
   }
@@ -369,4 +374,8 @@ function copyDataView(view: DataView): Uint8Array {
 
 function equalBinding(a: KsnakeKeyBinding | undefined, b: KsnakeKeyBinding): boolean {
   return a !== undefined && a.type === b.type && a.code1 === b.code1 && a.code2 === b.code2 && a.code3 === b.code3;
+}
+
+function equalKeyMaps(a: readonly KsnakeKeyBinding[], b: readonly KsnakeKeyBinding[]): boolean {
+  return a.length === b.length && a.every((key, index) => equalBinding(key, b[index] as KsnakeKeyBinding));
 }

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -246,6 +246,14 @@ export interface MouseStatus {
    * omitted rather than guessed at.
    */
   razerButtonMappings?: Record<string, string>;
+  /**
+   * K-snake X11 button slots 0-6 as read by GET_KEYS (7 slots of 4 bytes at
+   * reply[8..35]). The panel remaps slots 0-5 and treats 6 as fixed scroll.
+   * Opaque slots (macro references, keyboard combos the catalog cannot
+   * rebuild) are preserved as-is — the panel renders them locked rather than
+   * guessed at. Null/undefined when the keys reply was not answered.
+   */
+  ksnakeButtonMappings?: Array<{ type: number; code1: number; code2: number; code3: number }> | null;
   /** Keychron Nape Pro user layer currently running on the device (1–8).
    * Matches firmware get/set. Undefined when the layer commands were not answered.
    */

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -246,14 +246,6 @@ export interface MouseStatus {
    * omitted rather than guessed at.
    */
   razerButtonMappings?: Record<string, string>;
-  /**
-   * K-snake X11 button slots 0-6 as read by GET_KEYS (7 slots of 4 bytes at
-   * reply[8..35]). The panel remaps slots 0-5 and treats 6 as fixed scroll.
-   * Opaque slots (macro references, keyboard combos the catalog cannot
-   * rebuild) are preserved as-is — the panel renders them locked rather than
-   * guessed at. Null/undefined when the keys reply was not answered.
-   */
-  ksnakeButtonMappings?: Array<{ type: number; code1: number; code2: number; code3: number }> | null;
   /** Keychron Nape Pro user layer currently running on the device (1–8).
    * Matches firmware get/set. Undefined when the layer commands were not answered.
    */

--- a/src/ksnake/index.ts
+++ b/src/ksnake/index.ts
@@ -268,6 +268,48 @@ export function ksnakeIsKnownKeyType(type: number): boolean {
   return type === KSNAKE_KEY_TYPE.mouse || type === KSNAKE_KEY_TYPE.special || type === KSNAKE_KEY_TYPE.media;
 }
 
+/** Remappable actions from the vendor key catalog (display label + bytes). */
+export const KSNAKE_BUTTON_ACTIONS: ReadonlyArray<{
+  label: string;
+  type: number;
+  code1: number;
+  code2: number;
+  code3: number;
+}> = [
+  { label: "Left click", type: 32, code1: 1, code2: 0, code3: 0 },
+  { label: "Right click", type: 32, code1: 2, code2: 0, code3: 0 },
+  { label: "Middle click", type: 32, code1: 4, code2: 0, code3: 0 },
+  { label: "Backward", type: 32, code1: 8, code2: 0, code3: 0 },
+  { label: "Forward", type: 32, code1: 16, code2: 0, code3: 0 },
+  { label: "Disabled", type: 32, code1: 0, code2: 0, code3: 0 },
+  { label: "DPI loop", type: 33, code1: 85, code2: 0, code3: 0 },
+  { label: "Scroll up", type: 33, code1: 56, code2: 1, code3: 0 },
+  { label: "Scroll down", type: 33, code1: 56, code2: 255, code3: 0 },
+  { label: "Volume +", type: 48, code1: 233, code2: 0, code3: 0 },
+  { label: "Volume −", type: 48, code1: 234, code2: 0, code3: 0 },
+  { label: "Mute", type: 48, code1: 226, code2: 0, code3: 0 },
+  { label: "Play/Pause", type: 48, code1: 205, code2: 0, code3: 0 },
+  { label: "Prev track", type: 48, code1: 182, code2: 0, code3: 0 },
+  { label: "Next track", type: 48, code1: 181, code2: 0, code3: 0 },
+];
+
+/** Display label for a binding, or null when the catalog cannot name it. */
+export function ksnakeBindingLabel(binding: KsnakeKeyBinding): string | null {
+  return KSNAKE_BUTTON_ACTIONS.find(
+    (action) =>
+      action.type === binding.type &&
+      action.code1 === binding.code1 &&
+      action.code2 === binding.code2 &&
+      action.code3 === binding.code3,
+  )?.label ?? null;
+}
+
+/** Catalog binding for a display label, or null for unknown labels. */
+export function ksnakeFindButtonAction(label: string): KsnakeKeyBinding | null {
+  const action = KSNAKE_BUTTON_ACTIONS.find((entry) => entry.label === label);
+  return action ? { type: action.type, code1: action.code1, code2: action.code2, code3: action.code3 } : null;
+}
+
 /**
  * Plausibility gate for decoded key maps. `exchange()` resolves with the next
  * input report, so a stray report from another command can land here; those


### PR DESCRIPTION
Follow-up to #67 (merged) with the remaining K-snake X11 hardening, validated on retail hardware (FW 2.1.7, dongle 0xA8A5:0x2255):

- Generic button remapping: readStatus publishes buttonMappings/buttonOptions and setButtonMapping remaps one slot (read-modify-write through setKeys with read-back confirmation), so the stock ButtonMappingCard renders with no panel code. Left stays locked like the vendor panel; opaque slots abort instead of risking macros.
- Stop hiding the Low lift-off stop (supportedLiftOffDistances is [Low, High]).
- getKeys by consensus (two agreeing reads out of 5) instead of first-plausible: crossed reports decoded to plausible-but-wrong slots.
- readStatus reuses the last good config when a poll read fails, so the panel stops blanking DPI stages every 5s poll.

Tests: 30/30 ksnake driver tests green, tsc clean.