### PR TITLE
logitech: reach HID++ over Bluetooth (MX Master 4)

### DIFF
--- a/src/drivers/logitech/bolt.test.ts
+++ b/src/drivers/logitech/bolt.test.ts
@@ -5,15 +5,19 @@ import {
   boltSupportScore,
   classifyHidpp20Probe,
   collapseBoltPeers,
+  hasHidppBluetoothCollection,
   hasHidppLongCollection,
   hasHidppShortCollection,
   hidppIndexCandidates,
   resolveBoltReportDevice,
 } from "./bolt.ts";
+import { LogitechHidppClient } from "./hidpp.ts";
+import { LOGITECH_BLUETOOTH_FILTERS, SUPPORTED_HID_FILTERS } from "../vendors.ts";
 import {
   BOLT_PAIRING_SLOTS,
   DEVICE_INDEX_DIRECT,
   DEVICE_INDEX_RECEIVER,
+  HIDPP_BLUETOOTH_USAGE_PAGE,
   isBoltReceiverProduct,
   isDirectConnectProduct,
 } from "@openmouse/protocol/logitech";
@@ -31,9 +35,9 @@ function fakeHidDevice(productId: number, collections: HIDCollectionInfo[]): HID
   } as unknown as HIDDevice;
 }
 
-function hidppCollection(usage: number): HIDCollectionInfo {
+function hidppCollection(usage: number, usagePage = 0xff00): HIDCollectionInfo {
   return {
-    usagePage: 0xff00,
+    usagePage,
     usage,
     type: 1,
     children: [],
@@ -110,4 +114,41 @@ test("HID++ 1.0 probe errors are treated as absent indices", () => {
     classifyHidpp20Probe(new Error("The mouse rejected that setting (unsupported)."), false),
     "hidpp20",
   );
+});
+
+/**
+ * An MX Master 4 paired over Bluetooth, as reported by the diagnostics scan on
+ * macOS: a mouse collection plus one vendor collection on 0xFF43, and nothing
+ * at all on 0xFF00.
+ */
+const MX_MASTER_4_BLUETOOTH = fakeHidDevice(0xb042, [
+  { usagePage: 0x01, usage: 0x02, children: [] } as unknown as HIDCollectionInfo,
+  hidppCollection(0x0202, HIDPP_BLUETOOTH_USAGE_PAGE),
+]);
+
+test("HID++ over Bluetooth is recognised on its own vendor page", () => {
+  assert.equal(hasHidppBluetoothCollection(MX_MASTER_4_BLUETOOTH), true);
+  assert.equal(
+    hasHidppShortCollection(MX_MASTER_4_BLUETOOTH), false,
+    "Bluetooth carries no 0xFF00 collection, which is why the 0xFF00-only check missed it",
+  );
+  assert.equal(hasHidppLongCollection(MX_MASTER_4_BLUETOOTH), false);
+  assert.equal(
+    hasHidppBluetoothCollection(fakeHidDevice(BOLT_RECEIVER, [hidppCollection(0x0002)])), false,
+    "a Bolt receiver is not a Bluetooth endpoint",
+  );
+});
+
+test("a Bluetooth-only Logitech mouse is driven, and offered by the picker", () => {
+  assert.equal(
+    LogitechHidppClient.isSupported(MX_MASTER_4_BLUETOOTH), true,
+    "listed in the sidebar but unsupported is exactly the reported symptom",
+  );
+  const offered = SUPPORTED_HID_FILTERS.map((filter) => JSON.stringify(filter));
+  for (const filter of LOGITECH_BLUETOOTH_FILTERS) {
+    assert.ok(
+      offered.includes(JSON.stringify(filter)),
+      "the Bluetooth filter must reach the picker or the mouse is never detected",
+    );
+  }
 });

--- a/src/drivers/logitech/bolt.ts
+++ b/src/drivers/logitech/bolt.ts
@@ -8,30 +8,45 @@ import {
   BOLT_PAIRING_SLOTS,
   DEVICE_INDEX_DIRECT,
   DEVICE_INDEX_RECEIVER,
+  HIDPP_BLUETOOTH_USAGE_PAGE,
+  HIDPP_USAGE_PAGE,
   isBoltReceiverProduct,
 } from "@openmouse/protocol/logitech";
 
 /** Index probe on empty Bolt slots should fail fast; feature I/O keeps longer. */
 export const BOLT_INDEX_PROBE_TIMEOUT_MS = 800;
 
-/** True when a collection (or nested child) is an HID++ short- or long-report endpoint. */
-function collectionHasHidppUsage(
+/** True when a collection, or any nested child, matches. */
+function anyCollection(
   collections: readonly HIDCollectionInfo[],
-  usage: number,
+  matches: (collection: HIDCollectionInfo) => boolean,
 ): boolean {
   return collections.some((collection) =>
-    (collection.usagePage === 0xff00 && collection.usage === usage)
-    || collectionHasHidppUsage(collection.children, usage));
+    matches(collection) || anyCollection(collection.children, matches));
 }
 
 /** Short-report HID++ collection (Lightspeed, Bolt receiver registers). */
 export function hasHidppShortCollection(device: HIDDevice): boolean {
-  return collectionHasHidppUsage(device.collections, 0x0001);
+  return anyCollection(device.collections, (collection) =>
+    collection.usagePage === HIDPP_USAGE_PAGE && collection.usage === 0x0001);
 }
 
 /** Long-report HID++ collection (required for Bolt device feature traffic). */
 export function hasHidppLongCollection(device: HIDDevice): boolean {
-  return collectionHasHidppUsage(device.collections, 0x0002);
+  return anyCollection(device.collections, (collection) =>
+    collection.usagePage === HIDPP_USAGE_PAGE && collection.usage === 0x0002);
+}
+
+/**
+ * HID++ over Bluetooth, which lives on its own vendor page instead of the
+ * 0xFF00 short/long pair. Kept separate from those two so Bolt peer collapsing
+ * and report-device selection keep reasoning only about 0xFF00 interfaces.
+ *
+ * @see HIDPP_BLUETOOTH_USAGE_PAGE
+ */
+export function hasHidppBluetoothCollection(device: HIDDevice): boolean {
+  return anyCollection(device.collections, (collection) =>
+    collection.usagePage === HIDPP_BLUETOOTH_USAGE_PAGE);
 }
 
 /**

--- a/src/drivers/logitech/hidpp.test.ts
+++ b/src/drivers/logitech/hidpp.test.ts
@@ -220,17 +220,35 @@ function hidppResponder(roles: Record<number, "mouse" | "keyboard">) {
   };
 }
 
+const fakeCollection = (usagePage: number, usage: number): HIDCollectionInfo =>
+  ({ usagePage, usage, children: [] }) as unknown as HIDCollectionInfo;
+
+/** What a receiver or wired vendor interface exposes: HID++ short and long. */
+const USB_HIDPP_COLLECTIONS = [fakeCollection(0xff00, 0x0001), fakeCollection(0xff00, 0x0002)];
+
+/** What a Bluetooth-paired mouse exposes instead: one vendor collection, no 0xFF00. */
+const BLUETOOTH_HIDPP_COLLECTIONS = [fakeCollection(0xff43, 0x0202)];
+
 class FakeHidDevice {
   readonly productId: number;
   readonly productName: string;
+  // The driver reads these to tell a Bluetooth endpoint from a USB one, so a
+  // double without them silently answers "not Bluetooth" at best and throws at
+  // worst.
+  readonly collections: HIDCollectionInfo[];
   opened = false;
   readonly probed: Array<{ reportId: number; data: Uint8Array }> = [];
   private listeners = new Map<string, (event: unknown) => void>();
   onRequest: (request: Uint8Array) => Uint8Array | null = () => null;
 
-  constructor(productId: number, productName = "USB Receiver") {
+  constructor(
+    productId: number,
+    productName = "USB Receiver",
+    collections: HIDCollectionInfo[] = USB_HIDPP_COLLECTIONS,
+  ) {
     this.productId = productId;
     this.productName = productName;
+    this.collections = collections;
   }
 
   addEventListener(type: string, listener: (event: unknown) => void): void {
@@ -262,11 +280,15 @@ class FakeHidDevice {
   }
 }
 
-function harness(productId: number, roles: Record<number, "mouse" | "keyboard">): {
+function harness(
+  productId: number,
+  roles: Record<number, "mouse" | "keyboard">,
+  collections?: HIDCollectionInfo[],
+): {
   client: LogitechHidppClient;
   device: FakeHidDevice;
 } {
-  const device = new FakeHidDevice(productId);
+  const device = new FakeHidDevice(productId, "USB Receiver", collections);
   device.onRequest = hidppResponder(roles);
   return { client: new LogitechHidppClient(device as unknown as HIDDevice), device };
 }
@@ -366,4 +388,26 @@ test("a direct-connect product with no sensor anywhere is reported as not a mous
   assert.equal(await resolveIndex(client), 0xff, "the fast path still trusts the first answer with no probe");
   const error = await resolveIndexExcluding(client, new Set([0xff])).catch((reason) => reason);
   assert.equal((error as Error).name, "NotAMouseError");
+});
+
+test("a Bluetooth mouse is addressed on long reports only", async () => {
+  // BLE declares report 0x11 and nothing else, so the short-report path that
+  // Lightspeed and wired mice use would be rejected by the device outright.
+  const { client, device } = harness(0xb042, { 0xff: "mouse" }, BLUETOOTH_HIDPP_COLLECTIONS);
+  assert.equal(await resolveIndex(client), 0xff);
+  assert.ok(device.probed.length > 0, "the index probe must have sent something");
+  assert.deepEqual(
+    [...new Set(device.probed.map(({ reportId }) => reportId))],
+    [0x11],
+    "every request over Bluetooth must go out as a long report",
+  );
+});
+
+test("a receiver-attached mouse keeps using short reports", async () => {
+  const { client, device } = harness(0xc547, { 0x01: "mouse" });
+  assert.equal(await resolveIndex(client), 0x01);
+  assert.ok(
+    device.probed.some(({ reportId }) => reportId === 0x10),
+    "the 0xFF00 short path is unchanged for receivers",
+  );
 });

--- a/src/drivers/logitech/hidpp.ts
+++ b/src/drivers/logitech/hidpp.ts
@@ -1,10 +1,11 @@
 import type { MouseLighting, MouseStatus } from "../mouse-types.ts";
-import { LOGITECH_RECEIVER_PRODUCT_IDS } from "../vendors.ts";
+import { LOGITECH_BLUETOOTH_FILTERS, LOGITECH_RECEIVER_FILTERS, LOGITECH_RECEIVER_PRODUCT_IDS } from "../vendors.ts";
 import {
   BOLT_INDEX_PROBE_TIMEOUT_MS,
   boltSupportScore,
   classifyHidpp20Probe,
   collapseBoltPeers,
+  hasHidppBluetoothCollection,
   hasHidppLongCollection,
   hasHidppShortCollection,
   resolveBoltReportDevice,
@@ -73,6 +74,7 @@ import {
 
 export {
   collapseBoltPeers,
+  hasHidppBluetoothCollection,
   hasHidppLongCollection,
   hasHidppShortCollection,
 } from "./bolt.ts";
@@ -483,11 +485,20 @@ export class LogitechHidppClient {
    * field initializers before the `device` parameter property is assigned.
    */
   private get isDirectConnect(): boolean {
-    return isDirectConnection(this.resolvedDeviceIndex);
+    // A Bluetooth mouse also answers on 0xFF, because over BLE it really is the
+    // endpoint, but nothing this flag gates is true of it. Onboard-profile
+    // writes, short-report DPI and the "Wired USB" label all describe a *wired*
+    // vendor interface, so Bluetooth takes the receiver-style paths instead.
+    return !this.isBluetooth && isDirectConnection(this.resolvedDeviceIndex);
   }
 
   private get isBoltReceiver(): boolean {
     return isBoltReceiverProduct(this.device.productId);
+  }
+
+  /** @see hasHidppBluetoothCollection */
+  private get isBluetooth(): boolean {
+    return hasHidppBluetoothCollection(this.device);
   }
 
   /** HID++ device index: a receiver pairing slot, or the mouse itself. */
@@ -594,7 +605,9 @@ export class LogitechHidppClient {
    */
   static isSupported(device: HIDDevice): boolean {
     if (device.vendorId !== LOGITECH_VENDOR_ID) return false;
-    return hasHidppShortCollection(device) || hasHidppLongCollection(device);
+    return hasHidppShortCollection(device)
+      || hasHidppLongCollection(device)
+      || hasHidppBluetoothCollection(device);
   }
 
   /**
@@ -621,11 +634,10 @@ export class LogitechHidppClient {
       throw new Error("WebHID is unavailable. Use Chrome or Edge on desktop.");
     }
 
+    // The shared lists, not a second copy: a Bluetooth filter added to one and
+    // not the other is how the mouse stayed invisible on this path.
     const devices = await navigator.hid.requestDevice({
-      filters: [
-        { vendorId: LOGITECH_VENDOR_ID, usagePage: 0xff00, usage: 0x0001 },
-        { vendorId: LOGITECH_VENDOR_ID, usagePage: 0xff00, usage: 0x0002 },
-      ],
+      filters: [...LOGITECH_RECEIVER_FILTERS, ...LOGITECH_BLUETOOTH_FILTERS],
     });
     const ranked = [...devices]
       .filter((device) => this.isSupported(device))
@@ -846,9 +858,11 @@ export class LogitechHidppClient {
       // for Logi Bolt (BLE-based) versus Lightspeed.
       connectionDetail: this.isDirectConnect
         ? "Wired USB"
-        : this.isBoltReceiver
-          ? "Logi Bolt"
-          : undefined,
+        : this.isBluetooth
+          ? "Bluetooth"
+          : this.isBoltReceiver
+            ? "Logi Bolt"
+            : undefined,
       activeProfile: profileState.activeProfile,
       deviceMode: profileState.deviceMode,
       unitId: identity.unitId,
@@ -3168,10 +3182,12 @@ export class LogitechHidppClient {
     parameters: number[],
     options: { timeoutMs?: number } = {},
   ): Promise<Uint8Array> {
-    // Bolt feature traffic only answers on long reports. Lightspeed and wired
-    // mice keep the short form for the three-parameter path they were verified
-    // with; longer payloads still go through requestLong.
-    if (this.isBoltReceiver) {
+    // Bolt feature traffic only answers on long reports, and Bluetooth has no
+    // short report at all: its descriptor declares report 0x11 alone, so a
+    // sendReport(0x10) is rejected outright. Lightspeed and wired mice keep the
+    // short form for the three-parameter path they were verified with; longer
+    // payloads still go through requestLong.
+    if (this.isBoltReceiver || this.isBluetooth) {
       return this.requestLong(featureIndex, functionId, parameters, options.timeoutMs);
     }
     if (parameters.length > 3) {
@@ -3228,7 +3244,7 @@ export class LogitechHidppClient {
         }
         reject(new HidppTimeoutError(this.isDirectConnect
           ? "The mouse did not answer. Close Logitech G HUB or Logitech Gaming Software, then try again."
-          : this.isBoltReceiver
+          : this.isBoltReceiver || this.isBluetooth
             ? "The mouse did not answer. Move it, close Logi Options+, then try again."
             : "The mouse did not answer. Move it or click a button, then try again."));
       }, timeoutMs);

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -12,6 +12,8 @@ import {
   MCHOSE_DOCK_USAGE_PAGE,
 } from "@openmouse/protocol/mchose";
 import {
+  HIDPP_BLUETOOTH_USAGE_PAGE,
+  HIDPP_USAGE_PAGE,
   LOGITECH_BOLT_PRODUCT_IDS,
   LOGITECH_DIRECT_PRODUCT_IDS,
 } from "@openmouse/protocol/logitech";
@@ -353,8 +355,21 @@ export const LOGITECH_PRODUCT_IDS = [
  * 2.0 feature traffic. The driver decides mouse-vs-keyboard after connecting.
  */
 export const LOGITECH_RECEIVER_FILTERS: HIDDeviceFilter[] = [
-  { vendorId: VENDOR_ID.logitech, usagePage: 0xff00, usage: 0x0001 },
-  { vendorId: VENDOR_ID.logitech, usagePage: 0xff00, usage: 0x0002 },
+  { vendorId: VENDOR_ID.logitech, usagePage: HIDPP_USAGE_PAGE, usage: 0x0001 },
+  { vendorId: VENDOR_ID.logitech, usagePage: HIDPP_USAGE_PAGE, usage: 0x0002 },
+];
+
+/**
+ * The same protocol reached over Bluetooth, where none of the filters above
+ * match: a paired MX Master exposes one vendor collection on 0xFF43 and nothing
+ * on 0xFF00, so it was listed by the diagnostics scan (which filters by vendor
+ * id alone) while never appearing in the picker at all.
+ *
+ * Matched by page, without a usage, because 0xFF43 is Logitech's own page and
+ * the collection is numbered differently across firmware.
+ */
+export const LOGITECH_BLUETOOTH_FILTERS: HIDDeviceFilter[] = [
+  { vendorId: VENDOR_ID.logitech, usagePage: HIDPP_BLUETOOTH_USAGE_PAGE },
 ];
 
 // Retained for existing imports; points at the first supported receiver.
@@ -513,6 +528,7 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   ...[...NINJUTSO_MOUSE_PRODUCT_IDS, ...NINJUTSO_RECEIVER_PRODUCT_IDS]
     .map((productId) => ({ vendorId: NINJUTSO_VENDOR_ID, productId })),
   ...LOGITECH_RECEIVER_FILTERS,
+  ...LOGITECH_BLUETOOTH_FILTERS,
   ...LINGBAO_HID_FILTERS,
   // Fantech mice use vendor usage page 0xFFFF, usage 0x02 for configuration.
   { vendorId: VENDOR_ID.fantech, usagePage: 0xffff, usage: 0x02 },

--- a/src/logitech/index.ts
+++ b/src/logitech/index.ts
@@ -13,6 +13,25 @@ export function withSoftwareId(functionId: number): number {
   return (functionId & 0xf0) | SOFTWARE_ID;
 }
 
+/**
+ * Usage page carrying HID++ over USB: a receiver, or a mouse's own wired
+ * vendor interface. Usage 1 is the short-report collection, usage 2 the long.
+ */
+export const HIDPP_USAGE_PAGE = 0xff00;
+
+/**
+ * Usage page carrying HID++ over Bluetooth. BLE devices do not expose the
+ * 0xFF00 pair at all: Logitech moves the protocol to its own vendor page
+ * (usage 0x0202) and carries long reports only, which is why an MX Master
+ * paired over Bluetooth shows a single `Vendor (0xFF43)` interface and was
+ * never offered by a 0xFF00-only picker filter.
+ *
+ * The page is Logitech's alone, so both the filter and the support check match
+ * the whole page rather than a single usage, keeping firmware that numbers the
+ * collection differently within reach.
+ */
+export const HIDPP_BLUETOOTH_USAGE_PAGE = 0xff43;
+
 /** Receiver-attached mice answer on the receiver's first pairing slot. */
 export const DEVICE_INDEX_RECEIVER = 0x01;
 /** A mouse addressed over its own USB interface answers on 0xFF. */


### PR DESCRIPTION
## The report

An MX Master 4 on macOS shows up in Mouse Check but never appears in Add Device.

```
MX Master 4 — Logitech | VID_046D | PARTIAL
Interfaces: Generic Desktop, Vendor (0xFF43)
Connection: Bluetooth
```

## Cause

Logitech puts HID++ on a different usage page depending on transport:

| Transport | Usage page | Reports |
|---|---|---|
| Receiver / Bolt / wired | `0xFF00` usage 1 and 2 | short `0x10` and long `0x11` |
| Bluetooth | `0xFF43` | long `0x11` only |

Every Logitech gate in this package was `0xFF00`-only, so `requestDevice` never
listed the mouse. Mouse Check filters by vendor id alone, which is exactly why
it was visible there and nowhere else. The reporter's interface list is the
confirmation: one vendor collection on `0xFF43`, nothing on `0xFF00`.

## Changes

- Both usage pages named in `src/logitech`, the module the driver and the WebHID
  filters already share, so they cannot disagree about them.
- `LOGITECH_BLUETOOTH_FILTERS` offered in the picker, matched by page rather
  than usage, since `0xFF43` is Logitech's own page and firmware numbers the
  collection differently.
- `isSupported()` accepts the Bluetooth collection. Its own predicate, so Bolt
  peer collapsing and report-device selection keep reasoning only about
  `0xFF00` interfaces.
- Long reports over Bluetooth, as Bolt already does. The short path would send
  `sendReport(0x10)`, a report id BLE does not declare.
- Bluetooth no longer counts as a wired direct connection. It resolves to device
  index `0xFF` because over BLE the mouse really is the endpoint, but that flag
  gates onboard-profile writes, short-report DPI and a `"Wired USB"` label on a
  device the same code path already reports as Wireless. It now takes the
  receiver-style paths and reports its connection as Bluetooth.
- `requestReceiver()` had its own copy of the `0xFF00` filters and now shares
  the exported lists. That duplication is what let one path drift from the other.

## Tests

1087 pass. New coverage: the Bluetooth collection is recognised and the `0xFF00`
checks correctly do not match it, `isSupported()` accepts a Bluetooth-only
device, the filter reaches `SUPPORTED_HID_FILTERS`, every Bluetooth request goes
out as `0x11`, and receivers still use `0x10`.

Worth noting for review: `FakeHidDevice` had no `collections`, so reading them
threw a `TypeError` that `classifyHidpp20Probe` classified as a successful
HID++ 2.0 answer. Any programming error inside the request path is currently
read as "the mouse answered". I left that alone as out of scope, but it is
worth its own look.

## Not verified

No MX Master 4 to hand, so this is reasoned from the descriptor and the
reporter's diagnostic, not confirmed on hardware. Two things a tester should
check: enumerating the `0xFF43` collection and being permitted to open it are
separate, and Logi Options+ claims Logitech devices exclusively, which bites
hardest over Bluetooth on macOS.

Pairs with the `supported` row in OpenMouse-Project/openmouse.