### PR TITLE
feat(atk): name the F1 Ultimate 2.0 behind its shared 8K receiver

### DIFF
--- a/src/drivers/atk/hid.test.ts
+++ b/src/drivers/atk/hid.test.ts
@@ -666,3 +666,47 @@ test("one-byte battery reply leaves state and voltage unknown", async () => {
   assert.equal(status.batteryState, "Unknown");
   assert.equal(status.batteryVoltageMv, null);
 });
+
+test("the F1 Ultimate 2.0 identity names the mouse, not its receiver", async () => {
+  // 0x373b:0x11d9 is a shared 8K receiver SKU whose USB product string names
+  // the dongle, so without the identity the status falls back to "ATK
+  // Wireless mouse 8k dongle-L".
+  const fake = device(0x11d9, "Wireless mouse 8k dongle-L");
+  (fake as unknown as FakeAtkDevice).replies = [
+    reply(0x10, 0x0000, [0x01, 0x08]),
+    reply(0x04, 0x0000, [0x5f, 0x01]),
+    reply(0x08, 0x0000, [0x01, 0x54, 0x01, 0x54, 0x00, 0x55]),
+    reply(0x08, 0x000c, atkPackDpiStage(1600, 1600)),
+    reply(0x12, 0x0000, [0x03, 0x00]),
+    reply(0x08, 0x000a, [0x04, 0x51]),
+    reply(0x08, 0x00a9, [0x08, 0x4d, 0x00, 0x55, 0x1e, 0x37, 0x00, 0x55, 0x00, 0x55]),
+    reply(0x08, 0x00bd, [0x00, 0x55, 0x00, 0x55]),
+  ];
+
+  const client = new AtkHidClient(fake);
+  const status = await client.readStatus();
+  assert.equal(status.name, "ATK F1 Ultimate 2.0");
+  assert.equal(status.brand, "ATK");
+  assert.equal(client.displayName(), "ATK F1 Ultimate 2.0");
+  assert.equal(status.connectionType, "Wireless");
+  // PAW3950Ultra keeps the 42,000 DPI ceiling the unidentified fallback used,
+  // so naming the mouse does not narrow what the UI offers.
+  assert.equal(client.maxDpi(), 42000);
+});
+
+test("an unrecognised identity on the same receiver keeps the dongle name", async () => {
+  const fake = device(0x11d9, "Wireless mouse 8k dongle-L");
+  (fake as unknown as FakeAtkDevice).replies = [
+    reply(0x10, 0x0000, [0x01, 0xfe]),
+    reply(0x04, 0x0000, [0x5f, 0x01]),
+    reply(0x08, 0x0000, [0x01, 0x54, 0x01, 0x54, 0x00, 0x55]),
+    reply(0x08, 0x000c, atkPackDpiStage(1600, 1600)),
+    reply(0x12, 0x0000, [0x03, 0x00]),
+    reply(0x08, 0x000a, [0x04, 0x51]),
+    reply(0x08, 0x00a9, [0x08, 0x4d, 0x00, 0x55, 0x1e, 0x37, 0x00, 0x55, 0x00, 0x55]),
+    reply(0x08, 0x00bd, [0x00, 0x55, 0x00, 0x55]),
+  ];
+
+  const status = await new AtkHidClient(fake).readStatus();
+  assert.equal(status.name, "ATK Wireless mouse 8k dongle-L");
+});

--- a/src/drivers/atk/products.ts
+++ b/src/drivers/atk/products.ts
@@ -8,8 +8,26 @@ export interface AtkProduct {
   verified: boolean;
 }
 
-/** Mouse identity returned by GetMouseCIDMID (command 0x10). */
+/**
+ * Mouse identity returned by GetMouseCIDMID (command 0x10).
+ *
+ * Keys are the `cid,mid` pair. ATK's own web configurator carries the same
+ * pair per model as `custom.mouseCidMid`, alongside the sensor; the three VXE
+ * entries below were transcribed from hardware and agree with that table
+ * exactly, which is why it is treated as a usable source for identities that
+ * have not been read off a mouse yet. Such entries stay `verified: false`.
+ */
 export const ATK_PRODUCTS: Record<string, AtkProduct> = {
+  /**
+   * ATK F1 Ultimate 2.0, retailed as the "F1 V2 Ultimate". Ships on the 8K
+   * receiver 0x373b:0x11d9, whose USB product string ("Wireless mouse 8k
+   * dongle-L") is a generic dongle SKU shared with 0x373b:0x1278 — the
+   * identity is the only thing that names the mouse. Identity and sensor are
+   * declared by ATK's configurator against mouse PID 0x373b:0x11e4; not yet
+   * read back from hardware, so the DPI range is unchanged by this entry
+   * (PAW3950Ultra spans 10-42,000, the same as the unidentified fallback).
+   */
+  "1,8": { brand: "ATK", model: "F1 Ultimate 2.0", sensor: "PAW3950Ultra", verified: false },
   "2,11": { brand: "VXE", model: "R1", sensor: "PAW3395", family: "r1", verified: false },
   "2,12": { brand: "VXE", model: "R1", sensor: "PAW3395", family: "r1", verified: true },
   "2,32": { brand: "VXE", model: "R1 SE+", sensor: "PAW3395SE", family: "r1", verified: true },

--- a/src/drivers/atk/protocol.test.ts
+++ b/src/drivers/atk/protocol.test.ts
@@ -121,6 +121,19 @@ test("the verified R1 SE+ identity selects PAW3395SE", () => {
   assert.equal(ATK_SENSORS.PAW3395SE.maxDpi, 18000);
 });
 
+test("the F1 Ultimate 2.0 identity selects PAW3950Ultra and no R1 family", () => {
+  assert.deepEqual(ATK_PRODUCTS["1,8"], {
+    brand: "ATK",
+    model: "F1 Ultimate 2.0",
+    sensor: "PAW3950Ultra",
+    verified: false,
+  });
+  // The R1 live-settings and wired-EEPROM paths key off `family`, so an F1
+  // must not carry it: a stray "r1" would reroute its polling and DPI writes.
+  assert.equal(ATK_PRODUCTS["1,8"]!.family, undefined);
+  assert.equal(ATK_SENSORS.PAW3950Ultra.maxDpi, 42000);
+});
+
 test("Lift-off codes decode to millimetres", () => {
   assert.equal(atkDecodeLiftOff(1), 0.7);
   assert.equal(atkDecodeLiftOff(4), 1);


### PR DESCRIPTION
The 8K receiver 0x373b:0x11d9 reports "Wireless mouse 8k dongle-L" as its USB product string, and that SKU is shared (0x373b:0x1278 carries the same string), so the product id cannot name the mouse. The driver already asks for the identity with GetMouseCIDMID on every readStatus; ATK_PRODUCTS simply had no "1,x" key, so the lookup missed and displayName() fell back to prefixing the dongle string, showing "ATK Wireless mouse 8k dongle-L".

Add the identity 1,8 -> ATK F1 Ultimate 2.0 (PAW3950Ultra), left unverified pending a hardware readback of the pair.