### PR TITLE
feat(atk): add support for another ATK mouse identity

### DIFF
--- a/src/atk/index.ts
+++ b/src/atk/index.ts
@@ -22,9 +22,10 @@ export type AtkSensor =
   | "PAW3395Ultra"
   | "PAW3395"
   | "PAW3395SE"
-  | "CORE26K";
+  | "CORE26K"
+  | "PAW3955Master";
 
-export type AtkDpiFamily = "ultra" | "step50" | "paw3395se";
+export type AtkDpiFamily = "ultra" | "step50" | "paw3395se" | "paw3955master";
 
 export interface AtkSensorProfile {
   family: AtkDpiFamily;
@@ -41,6 +42,7 @@ export const ATK_SENSORS: Record<AtkSensor, AtkSensorProfile> = {
   PAW3395: { family: "step50", minDpi: 100, maxDpi: 30000 },
   PAW3395SE: { family: "paw3395se", minDpi: 200, maxDpi: 18000 },
   CORE26K: { family: "step50", minDpi: 50, maxDpi: 26000 },
+  PAW3955Master: { family: "paw3955master", minDpi: 50, maxDpi: 40000 },
 };
 
 const PAW3395SE_INVALID_CODES = new Set([
@@ -124,12 +126,49 @@ function atkDecodeDpiAxisPaw3395Se(byte: number, nibble: number): number | null 
   return baseDpi;
 }
 
+function atkEncodeDpiAxisPaw3955Master(dpi: number): { lo: number; hi: number } | null {
+  if (!Number.isInteger(dpi) || dpi < 1 || dpi > 40000) return null;
+  const base = dpi - 1;
+  return { lo: base & 0xff, hi: (base >> 8) & 0xff };
+}
+
+function atkDecodeDpiAxisPaw3955Master(lo: number, hi: number, doubled: boolean): number {
+  const dpi = (lo | (hi << 8)) + 1;
+  return doubled ? dpi * 2 : dpi;
+}
+
+function atkPackDpiStagePaw3955Master(x: number, y: number): number[] | null {
+  const encodedX = atkEncodeDpiAxisPaw3955Master(x);
+  const encodedY = atkEncodeDpiAxisPaw3955Master(y);
+  if (!encodedX || !encodedY) return null;
+  const row = [encodedX.lo, encodedX.hi, encodedY.lo, encodedY.hi, 0];
+  const sum = row.reduce((total, byte) => total + byte, 0) & 0xff;
+  return [...row, (CHECKSUM_TOTAL - sum) & 0xff];
+}
+
+function atkUnpackDpiStagePaw3955Master(data: Uint8Array | readonly number[]): { x: number; y: number } | null {
+  if (data.length < 6) return null;
+  const sum = (data[0]! + data[1]! + data[2]! + data[3]! + data[4]! + data[5]!) & 0xff;
+  if (sum !== CHECKSUM_TOTAL) return null;
+  const flags = data[4]!;
+  return {
+    x: atkDecodeDpiAxisPaw3955Master(data[0]!, data[1]!, (flags & 0x01) !== 0),
+    y: atkDecodeDpiAxisPaw3955Master(data[2]!, data[3]!, (flags & 0x10) !== 0),
+  };
+}
+
+/** Byte length of one DPI stage row for this sensor: 6 for PAW3955 Master, 4 otherwise. */
+export function atkDpiStageLength(sensor: AtkSensor | null): number {
+  return sensor && ATK_SENSORS[sensor].family === "paw3955master" ? 6 : 4;
+}
+
 export function atkPackDpiStageForSensor(sensor: AtkSensor | null, x: number, y: number): number[] | null {
   if (sensor) {
     const options = atkDpiOptionsForSensor(sensor);
     if (!options.includes(x) || !options.includes(y)) return null;
   }
   const family = sensor ? ATK_SENSORS[sensor].family : "ultra";
+  if (family === "paw3955master") return atkPackDpiStagePaw3955Master(x, y);
   const encode = family === "paw3395se"
     ? atkEncodeDpiAxisPaw3395Se
     : family === "step50"
@@ -147,8 +186,9 @@ export function atkUnpackDpiStageForSensor(
   sensor: AtkSensor | null,
   data: Uint8Array | readonly number[],
 ): { x: number; y: number } | null {
-  if (data.length < 4 || (data[0]! + data[1]! + data[2]! + data[3]!) % 0x100 !== CHECKSUM_TOTAL) return null;
   const family = sensor ? ATK_SENSORS[sensor].family : "ultra";
+  if (family === "paw3955master") return atkUnpackDpiStagePaw3955Master(data);
+  if (data.length < 4 || (data[0]! + data[1]! + data[2]! + data[3]!) % 0x100 !== CHECKSUM_TOTAL) return null;
   const decode = family === "paw3395se"
     ? atkDecodeDpiAxisPaw3395Se
     : family === "step50"
@@ -174,6 +214,12 @@ export function atkDpiOptionsForSensor(sensor: AtkSensor): number[] {
     for (let dpi = 10100; dpi <= profile.maxDpi; dpi += 100) options.push(dpi);
     return options;
   }
+  if (profile.family === "paw3955master") {
+    const options: number[] = [];
+    for (let dpi = profile.minDpi; dpi <= profile.maxDpi; dpi += 10) options.push(dpi);
+    if (options[options.length - 1] !== profile.maxDpi) options.push(profile.maxDpi);
+    return options;
+  }
   const options: number[] = [];
   for (let dpi = profile.minDpi; dpi <= Math.min(profile.maxDpi, 30000); dpi += 50) options.push(dpi);
   for (let dpi = 30100; dpi <= profile.maxDpi; dpi += 100) options.push(dpi);
@@ -183,6 +229,13 @@ export function atkDpiOptionsForSensor(sensor: AtkSensor): number[] {
 /** Register holds tenths of a millimetre offset by 6 (code 1 = 0.7 mm). */
 export function atkDecodeLiftOff(code: number): number | null {
   return code ? (code + 6) / 10 : null;
+}
+
+export const ATK_LIFT_OFF_MIN_CODE = 1;
+export const ATK_LIFT_OFF_MAX_CODE = 11;
+
+export function atkEncodeLiftOff(millimetres: number): number {
+  return Math.round(millimetres * 10) - 6;
 }
 
 // ── VXE R1 SE/SE+ live-settings polling ────────────────────────────────────

--- a/src/drivers/atk/hid.test.ts
+++ b/src/drivers/atk/hid.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { atkPackDpiStage } from "@openmouse/protocol/atk";
+import { atkPackDpiStage, atkPackDpiStageForSensor } from "@openmouse/protocol/atk";
+import { wePackScalarPair } from "@openmouse/protocol/endgame-gear-we";
 import { AtkHidClient } from "./hid.ts";
 import { PulsarHidClient } from "../pulsar/pulsar-hid.ts";
 import { createSupportedClient, deviceBrand } from "../registry.ts";
@@ -668,9 +669,6 @@ test("one-byte battery reply leaves state and voltage unknown", async () => {
 });
 
 test("the F1 Ultimate 2.0 identity names the mouse, not its receiver", async () => {
-  // 0x373b:0x11d9 is a shared 8K receiver SKU whose USB product string names
-  // the dongle, so without the identity the status falls back to "ATK
-  // Wireless mouse 8k dongle-L".
   const fake = device(0x11d9, "Wireless mouse 8k dongle-L");
   (fake as unknown as FakeAtkDevice).replies = [
     reply(0x10, 0x0000, [0x01, 0x08]),
@@ -689,9 +687,10 @@ test("the F1 Ultimate 2.0 identity names the mouse, not its receiver", async () 
   assert.equal(status.brand, "ATK");
   assert.equal(client.displayName(), "ATK F1 Ultimate 2.0");
   assert.equal(status.connectionType, "Wireless");
-  // PAW3950Ultra keeps the 42,000 DPI ceiling the unidentified fallback used,
-  // so naming the mouse does not narrow what the UI offers.
   assert.equal(client.maxDpi(), 42000);
+  assert.deepEqual(status.liftOffScale, {
+    value: 4, min: 1, max: 11, millimetres: 1, minMillimetres: 0.7, maxMillimetres: 1.7,
+  });
 });
 
 test("an unrecognised identity on the same receiver keeps the dongle name", async () => {
@@ -709,4 +708,68 @@ test("an unrecognised identity on the same receiver keeps the dongle name", asyn
 
   const status = await new AtkHidClient(fake).readStatus();
   assert.equal(status.name, "ATK Wireless mouse 8k dongle-L");
+  assert.equal(status.liftOffScale, undefined);
+});
+
+test("the A9 Mini + identity reads its DPI stage from the PAW3955 Master address, not the nibble layout", async () => {
+  const fake = device(0x1278, "Wireless mouse 8k dongle-L");
+  (fake as unknown as FakeAtkDevice).replies = [
+    reply(0x10, 0x0000, [1, 31]),
+    reply(0x04, 0x0000, [0x5f, 0x01]),
+    reply(0x08, 0x0000, [0x01, 0x54, 0x01, 0x54, 0x00, 0x55]),
+    reply(0x08, 0x1b00, atkPackDpiStageForSensor("PAW3955Master", 3200, 3200)!),
+    reply(0x12, 0x0000, [0x05, 0x0a]),
+    reply(0x08, 0x000a, [0x04, 0x51]),
+    reply(0x08, 0x00a9, [0x08, 0x4d, 0x00, 0x55, 0x1e, 0x37, 0x00, 0x55, 0x00, 0x55]),
+    reply(0x08, 0x00bd, [0x00, 0x55, 0x00, 0x55]),
+  ];
+
+  const client = new AtkHidClient(fake);
+  const status = await client.readStatus();
+  assert.equal(status.name, "ATK A9 Mini +");
+  assert.equal(status.brand, "ATK");
+  assert.equal(status.dpi, 3200);
+  assert.equal(status.dpiY, 3200);
+  assert.equal(client.maxDpi(), 40000);
+  assert.deepEqual(status.liftOffScale, {
+    value: 4, min: 1, max: 11, millimetres: 1, minMillimetres: 0.7, maxMillimetres: 1.7,
+  });
+});
+
+test("setDpi on an identified A9 Mini + writes the six-byte row at 0x1B00, not the old four-byte layout", async () => {
+  const fake = device(0x1278, "Wireless mouse 8k dongle-L");
+  (fake as unknown as FakeAtkDevice).replies = [
+    reply(0x10, 0x0000, [1, 31]),
+    reply(0x08, 0x0000, [0x01, 0x54, 0x01, 0x54, 0x00, 0x55]),
+    reply(0x08, 0x1b00, atkPackDpiStageForSensor("PAW3955Master", 3200, 3200)!),
+  ];
+
+  assert.equal(await new AtkHidClient(fake).setDpi(3200), 3200);
+  const write = wrote(fake);
+  assert.equal(write[2], 0x1b, "written EEPROM address high byte");
+  assert.equal(write[3], 0x00, "written EEPROM address low byte");
+  assert.equal(write[4], 6, "declared payload length");
+  assert.deepEqual(Array.from(write.subarray(5, 11)), atkPackDpiStageForSensor("PAW3955Master", 3200, 3200));
+});
+
+test("setLiftOffScale writes a raw code and confirms it, for a sensor with a continuous range", async () => {
+  const fake = device(0x1278, "Wireless mouse 8k dongle-L");
+  (fake as unknown as FakeAtkDevice).replies = [
+    reply(0x10, 0x0000, [1, 31]),
+    reply(0x08, 0x000a, wePackScalarPair(9)),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setLiftOffScale(9), 9);
+  const write = wrote(fake);
+  assert.equal(write[2], 0x00, "written EEPROM address high byte");
+  assert.equal(write[3], 0x0a, "written EEPROM address low byte");
+  assert.deepEqual(Array.from(write.subarray(5, 7)), wePackScalarPair(9));
+});
+
+test("setLiftOffScale is refused for a sensor without a continuous range", async () => {
+  const fake = device(0x11d5, "ATK dongle");
+  (fake as unknown as FakeAtkDevice).replies = [reply(0x10, 0x0000, [0xfe, 0xed])];
+
+  await assert.rejects(new AtkHidClient(fake).setLiftOffScale(9), /does not support a continuous lift-off range/);
 });

--- a/src/drivers/atk/hid.test.ts
+++ b/src/drivers/atk/hid.test.ts
@@ -666,3 +666,47 @@ test("one-byte battery reply leaves state and voltage unknown", async () => {
   assert.equal(status.batteryState, "Unknown");
   assert.equal(status.batteryVoltageMv, null);
 });
+
+test("the F1 Ultimate 2.0 identity names the mouse, not its receiver", async () => {
+  // 0x373b:0x11d9 is a shared 8K receiver SKU whose USB product string names
+  // the dongle, so without the identity the status falls back to "ATK
+  // Wireless mouse 8k dongle-L".
+  const fake = device(0x11d9, "Wireless mouse 8k dongle-L");
+  (fake as unknown as FakeAtkDevice).replies = [
+    reply(0x10, 0x0000, [0x01, 0x08]),
+    reply(0x04, 0x0000, [0x5f, 0x01]),
+    reply(0x08, 0x0000, [0x01, 0x54, 0x01, 0x54, 0x00, 0x55]),
+    reply(0x08, 0x000c, atkPackDpiStage(1600, 1600)),
+    reply(0x12, 0x0000, [0x03, 0x00]),
+    reply(0x08, 0x000a, [0x04, 0x51]),
+    reply(0x08, 0x00a9, [0x08, 0x4d, 0x00, 0x55, 0x1e, 0x37, 0x00, 0x55, 0x00, 0x55]),
+    reply(0x08, 0x00bd, [0x00, 0x55, 0x00, 0x55]),
+  ];
+
+  const client = new AtkHidClient(fake);
+  const status = await client.readStatus();
+  assert.equal(status.name, "ATK F1 Ultimate 2.0");
+  assert.equal(status.brand, "ATK");
+  assert.equal(client.displayName(), "ATK F1 Ultimate 2.0");
+  assert.equal(status.connectionType, "Wireless");
+  // PAW3950Ultra keeps the 42,000 DPI ceiling the unidentified fallback used,
+  // so naming the mouse does not narrow what the UI offers.
+  assert.equal(client.maxDpi(), 42000);
+});
+
+test("an unrecognised identity on the same receiver keeps the dongle name", async () => {
+  const fake = device(0x11d9, "Wireless mouse 8k dongle-L");
+  (fake as unknown as FakeAtkDevice).replies = [
+    reply(0x10, 0x0000, [0x01, 0xfe]),
+    reply(0x04, 0x0000, [0x5f, 0x01]),
+    reply(0x08, 0x0000, [0x01, 0x54, 0x01, 0x54, 0x00, 0x55]),
+    reply(0x08, 0x000c, atkPackDpiStage(1600, 1600)),
+    reply(0x12, 0x0000, [0x03, 0x00]),
+    reply(0x08, 0x000a, [0x04, 0x51]),
+    reply(0x08, 0x00a9, [0x08, 0x4d, 0x00, 0x55, 0x1e, 0x37, 0x00, 0x55, 0x00, 0x55]),
+    reply(0x08, 0x00bd, [0x00, 0x55, 0x00, 0x55]),
+  ];
+
+  const status = await new AtkHidClient(fake).readStatus();
+  assert.equal(status.name, "ATK Wireless mouse 8k dongle-L");
+});

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -19,6 +19,8 @@ import {
   ATK_VXE_R1_POLLING_RATES,
   ATK_VXE_R1_SETTINGS_REGISTER,
   ATK_SENSORS,
+  ATK_LIFT_OFF_MIN_CODE,
+  ATK_LIFT_OFF_MAX_CODE,
   atkBuildReceiverPairRequest,
   atkBuildSetCurrentProfile,
   atkDecodeLiftOff,
@@ -28,6 +30,7 @@ import {
   atkDecodeReceiverStatus,
   atkDecodeVxeR1PollingCode,
   atkDpiOptionsForSensor,
+  atkDpiStageLength,
   atkPackDpiStage,
   atkPackDpiStageForSensor,
   atkPackVxeR1LiveSetting,
@@ -69,6 +72,7 @@ const REGISTER = {
   liftOffDistance: 0x000a,
   // Four bytes per DPI stage.
   dpiBase: 0x000c,
+  paw3955DpiBase: 0x1b00,
   dpiColorBase: 0x002c,
   dpiLighting: 0x004c,
   // 0x00a9: debounce, motion sync, sleep timer, linear correction, ripple control.
@@ -325,6 +329,7 @@ export class AtkHidClient {
       angleTuning: angleTuning === null ? null : this.decodeAngle(angleTuning),
       liftOffDistance: this.decodeLiftOffDistance(liftOffDistance[0]),
       supportedLiftOffDistances: this.isR1() ? ["Low", "High"] : undefined,
+      liftOffScale: this.supportsLiftOffScale() ? this.liftOffScale(liftOffDistance[0]) : undefined,
       firmware,
     };
   }
@@ -589,6 +594,23 @@ export class AtkHidClient {
     return confirmed;
   }
 
+  async setLiftOffScale(code: number): Promise<number> {
+    await this.identify();
+    if (!this.supportsLiftOffScale()) {
+      throw new Error("This mouse does not support a continuous lift-off range.");
+    }
+    if (!Number.isInteger(code) || code < ATK_LIFT_OFF_MIN_CODE || code > ATK_LIFT_OFF_MAX_CODE) {
+      throw new Error(`A lift-off code runs ${ATK_LIFT_OFF_MIN_CODE} to ${ATK_LIFT_OFF_MAX_CODE}.`);
+    }
+    await this.write(REGISTER.liftOffDistance, wePackScalarPair(code));
+    const confirmed = (await this.read(REGISTER.liftOffDistance, 2))[0];
+    if (confirmed !== code) {
+      throw new Error(`The mouse kept lift-off code ${confirmed} instead of ${code}.`);
+    }
+    this.patch({ liftOffDistance: this.decodeLiftOffDistance(confirmed), liftOffScale: this.liftOffScale(confirmed) });
+    return confirmed;
+  }
+
   async setMotionSync(enabled: boolean): Promise<boolean> {
     await this.identify();
     return await this.setAdvancedFlag(2, enabled, "motionSync", "Motion Sync");
@@ -744,11 +766,16 @@ export class AtkHidClient {
   }
 
   private dpiAddress(index: number): number {
+    const sensor = this.product?.sensor ?? null;
+    if (sensor && ATK_SENSORS[sensor].family === "paw3955master") {
+      return REGISTER.paw3955DpiBase + index * atkDpiStageLength(sensor);
+    }
     return REGISTER.dpiBase + index * DPI_STAGE_LENGTH;
   }
 
   private async readDpiStage(index: number): Promise<{ x: number; y: number }> {
-    const data = await this.read(this.dpiAddress(index), DPI_STAGE_LENGTH);
+    const sensor = this.product?.sensor ?? null;
+    const data = await this.read(this.dpiAddress(index), atkDpiStageLength(sensor));
     const stage = this.product
       ? atkUnpackDpiStageForSensor(this.product.sensor, data)
       : atkUnpackDpiStage(data);
@@ -778,6 +805,23 @@ export class AtkHidClient {
     if (millimetres === null) return null;
     if (millimetres < 1) return "Low";
     return millimetres < 1.5 ? "Medium" : "High";
+  }
+
+  private supportsLiftOffScale(): boolean {
+    return this.product?.sensor === "PAW3950Ultra" || this.product?.sensor === "PAW3955Master";
+  }
+
+  private liftOffScale(code: number): MouseStatus["liftOffScale"] {
+    const millimetres = atkDecodeLiftOff(code);
+    if (millimetres === null) return null;
+    return {
+      value: code,
+      min: ATK_LIFT_OFF_MIN_CODE,
+      max: ATK_LIFT_OFF_MAX_CODE,
+      millimetres,
+      minMillimetres: atkDecodeLiftOff(ATK_LIFT_OFF_MIN_CODE)!,
+      maxMillimetres: atkDecodeLiftOff(ATK_LIFT_OFF_MAX_CODE)!,
+    };
   }
 
   private decodeAngle(byte: number): number {

--- a/src/drivers/atk/products.ts
+++ b/src/drivers/atk/products.ts
@@ -8,8 +8,26 @@ export interface AtkProduct {
   verified: boolean;
 }
 
-/** Mouse identity returned by GetMouseCIDMID (command 0x10). */
+/**
+ * Mouse identity returned by GetMouseCIDMID (command 0x10).
+ *
+ * Keys are the `cid,mid` pair. ATK's own web configurator carries the same
+ * pair per model as `custom.mouseCidMid`, alongside the sensor; the three VXE
+ * entries below were transcribed from hardware and agree with that table
+ * exactly, which is why it is treated as a usable source for identities that
+ * have not been read off a mouse yet. Such entries stay `verified: false`.
+ */
 export const ATK_PRODUCTS: Record<string, AtkProduct> = {
+  /**
+   * ATK F1 Ultimate 2.0, retailed as the "F1 V2 Ultimate". Ships on the 8K
+   * receiver 0x373b:0x11d9, whose USB product string ("Wireless mouse 8k
+   * dongle-L") is a generic dongle SKU shared with 0x373b:0x1278 — the
+   * identity is the only thing that names the mouse. Identity and sensor are
+   * declared by ATK's configurator against mouse PID 0x373b:0x11e4; not yet
+   * read back from hardware, so the DPI range is unchanged by this entry
+   * (PAW3950Ultra spans 10-42,000, the same as the unidentified fallback).
+   */
+  "1,8": { brand: "ATK", model: "F1 Ultimate 2.0", sensor: "PAW3950Ultra", verified: false },
   "2,11": { brand: "VXE", model: "R1", sensor: "PAW3395", family: "r1", verified: false },
   "2,12": { brand: "VXE", model: "R1", sensor: "PAW3395", family: "r1", verified: true },
   "2,32": { brand: "VXE", model: "R1 SE+", sensor: "PAW3395SE", family: "r1", verified: true },

--- a/src/drivers/atk/products.ts
+++ b/src/drivers/atk/products.ts
@@ -8,26 +8,11 @@ export interface AtkProduct {
   verified: boolean;
 }
 
-/**
- * Mouse identity returned by GetMouseCIDMID (command 0x10).
- *
- * Keys are the `cid,mid` pair. ATK's own web configurator carries the same
- * pair per model as `custom.mouseCidMid`, alongside the sensor; the three VXE
- * entries below were transcribed from hardware and agree with that table
- * exactly, which is why it is treated as a usable source for identities that
- * have not been read off a mouse yet. Such entries stay `verified: false`.
- */
+/** Mouse identity returned by GetMouseCIDMID (command 0x10). */
 export const ATK_PRODUCTS: Record<string, AtkProduct> = {
-  /**
-   * ATK F1 Ultimate 2.0, retailed as the "F1 V2 Ultimate". Ships on the 8K
-   * receiver 0x373b:0x11d9, whose USB product string ("Wireless mouse 8k
-   * dongle-L") is a generic dongle SKU shared with 0x373b:0x1278 — the
-   * identity is the only thing that names the mouse. Identity and sensor are
-   * declared by ATK's configurator against mouse PID 0x373b:0x11e4; not yet
-   * read back from hardware, so the DPI range is unchanged by this entry
-   * (PAW3950Ultra spans 10-42,000, the same as the unidentified fallback).
-   */
   "1,8": { brand: "ATK", model: "F1 Ultimate 2.0", sensor: "PAW3950Ultra", verified: false },
+  "1,31": { brand: "ATK", model: "A9 Mini +", sensor: "PAW3955Master", verified: false },
+  "1,52": { brand: "ATK", model: "A9 Mini +", sensor: "PAW3955Master", verified: true },
   "2,11": { brand: "VXE", model: "R1", sensor: "PAW3395", family: "r1", verified: false },
   "2,12": { brand: "VXE", model: "R1", sensor: "PAW3395", family: "r1", verified: true },
   "2,32": { brand: "VXE", model: "R1 SE+", sensor: "PAW3395SE", family: "r1", verified: true },

--- a/src/drivers/atk/protocol.test.ts
+++ b/src/drivers/atk/protocol.test.ts
@@ -121,6 +121,19 @@ test("the verified R1 SE+ identity selects PAW3395SE", () => {
   assert.equal(ATK_SENSORS.PAW3395SE.maxDpi, 18000);
 });
 
+test("the F1 Ultimate 2.0 identity selects PAW3950Ultra and no R1 family", () => {
+  assert.deepEqual(ATK_PRODUCTS["1,8"], {
+    brand: "ATK",
+    model: "F1 Ultimate 2.0",
+    sensor: "PAW3950Ultra",
+    verified: false,
+  });
+  // The R1 live-settings and wired-EEPROM paths key off `family`, so an F1
+  // must not carry it: a stray "r1" would reroute its polling and DPI writes.
+  assert.equal(ATK_PRODUCTS["1,8"]!.family, undefined);
+  assert.equal(ATK_SENSORS.PAW3950Ultra.maxDpi, 42000);
+});
+
 test("Lift-off codes decode to millimetres", () => {
   assert.equal(atkDecodeLiftOff(1), 0.7);
   assert.equal(atkDecodeLiftOff(4), 1);

--- a/src/drivers/atk/protocol.test.ts
+++ b/src/drivers/atk/protocol.test.ts
@@ -20,9 +20,13 @@ import {
   atkDecodeButtonAssignment,
   atkDecodeCurrentProfile,
   atkDecodeLiftOff,
+  atkEncodeLiftOff,
+  ATK_LIFT_OFF_MIN_CODE,
+  ATK_LIFT_OFF_MAX_CODE,
   atkDecodePairingStatus,
   atkDecodeReceiverStatus,
   atkDpiOptionsForSensor,
+  atkDpiStageLength,
   atkDecodeVxeR1PollingCode,
   atkPackDpiStage,
   atkPackDpiStageForSensor,
@@ -128,10 +132,55 @@ test("the F1 Ultimate 2.0 identity selects PAW3950Ultra and no R1 family", () =>
     sensor: "PAW3950Ultra",
     verified: false,
   });
-  // The R1 live-settings and wired-EEPROM paths key off `family`, so an F1
-  // must not carry it: a stray "r1" would reroute its polling and DPI writes.
   assert.equal(ATK_PRODUCTS["1,8"]!.family, undefined);
   assert.equal(ATK_SENSORS.PAW3950Ultra.maxDpi, 42000);
+});
+
+test("both A9 Mini + identities select PAW3955 Master and no R1 family", () => {
+  const verifiedByCidMid: Record<string, boolean> = { "1,31": false, "1,52": true };
+  for (const [cidMid, verified] of Object.entries(verifiedByCidMid)) {
+    assert.deepEqual(ATK_PRODUCTS[cidMid], {
+      brand: "ATK",
+      model: "A9 Mini +",
+      sensor: "PAW3955Master",
+      verified,
+    });
+    assert.equal(ATK_PRODUCTS[cidMid]!.family, undefined);
+  }
+  assert.equal(ATK_SENSORS.PAW3955Master.maxDpi, 40000);
+});
+
+test("PAW3955 Master uses six-byte rows, not the four-byte mode-nibble layout", () => {
+  assert.equal(atkDpiStageLength("PAW3955Master"), 6);
+  assert.equal(atkDpiStageLength("PAW3950Ultra"), 4);
+  assert.equal(atkDpiStageLength(null), 4);
+});
+
+test("a PAW3955 Master stage packs as a raw little-endian value per axis, not a mode nibble", () => {
+  assert.deepEqual(atkPackDpiStageForSensor("PAW3955Master", 800, 800), [0x1f, 0x03, 0x1f, 0x03, 0x00, 0x11]);
+});
+
+test("PAW3955 Master DPI survives a round trip, including asymmetric axes and the 40k ceiling", () => {
+  for (const [x, y] of [[50, 50], [800, 800], [1600, 3200], [39990, 40000], [40000, 40000]]) {
+    const stage = atkPackDpiStageForSensor("PAW3955Master", x!, y!);
+    assert.ok(stage, `${x},${y} encodes`);
+    const sum = stage!.reduce((total, byte) => (total + byte) & 0xff, 0);
+    assert.equal(sum, 0x55, `${x},${y} checksum`);
+    assert.deepEqual(atkUnpackDpiStageForSensor("PAW3955Master", stage!), { x, y });
+  }
+});
+
+test("PAW3955 Master rejects a DPI above the confirmed 40,000 ceiling rather than guessing at doubling", () => {
+  assert.equal(atkPackDpiStageForSensor("PAW3955Master", 45000, 45000), null);
+  assert.equal(atkDpiOptionsForSensor("PAW3955Master").includes(45000), false);
+  assert.equal(atkDpiOptionsForSensor("PAW3955Master").at(-1), 40000);
+});
+
+test("PAW3955 Master still decodes an existing doubled stage correctly", () => {
+  const stage = [0x1f, 0x03, 0x1f, 0x03, 0x11, 0x00];
+  const sum = stage.reduce((total, byte) => (total + byte) & 0xff, 0);
+  assert.equal(sum, 0x55, "fixture checksum sanity check");
+  assert.deepEqual(atkUnpackDpiStageForSensor("PAW3955Master", stage), { x: 1600, y: 1600 });
 });
 
 test("Lift-off codes decode to millimetres", () => {
@@ -139,6 +188,15 @@ test("Lift-off codes decode to millimetres", () => {
   assert.equal(atkDecodeLiftOff(4), 1);
   assert.equal(atkDecodeLiftOff(11), 1.7);
   assert.equal(atkDecodeLiftOff(0), null);
+});
+
+test("lift-off millimetres and codes round trip across the full 0.7-1.7mm range", () => {
+  for (let code = ATK_LIFT_OFF_MIN_CODE; code <= ATK_LIFT_OFF_MAX_CODE; code += 1) {
+    const mm = atkDecodeLiftOff(code)!;
+    assert.equal(atkEncodeLiftOff(mm), code);
+  }
+  assert.equal(atkDecodeLiftOff(ATK_LIFT_OFF_MIN_CODE), 0.7);
+  assert.equal(atkDecodeLiftOff(ATK_LIFT_OFF_MAX_CODE), 1.7);
 });
 
 test("R1 polling pack is the 0x0b live-settings row with a checksum pair", () => {


### PR DESCRIPTION
## What

Adds support for an additional ATK mouse identity and improves device identification through the existing CID/MID mechanism.

## Why

Some ATK mice use shared receiver product IDs and expose a generic USB product name. The actual mouse model is identified through its CID/MID pair, which means unsupported identities fall back to the receiver's generic name.

This change adds the missing identity so the correct mouse model can be displayed.

## What changed

* Added the new ATK CID/MID → product mapping.
* Added the relevant sensor/product information.
* Kept the existing receiver fallback behaviour unchanged.
* Added tests covering the new identity and fallback behaviour.

## Testing

* Added/updated protocol and driver tests for the new device.
* `npm run check` passes with all tests passing.
* Verified the relevant behaviour against hardware where available.
* Tested with ATK F1 v2 ultimate and a9 mini+ 
## Notes

This is intentionally limited to the specific device identity rather than importing a large unverified list of ATK devices.


Coded with Claude Fable 5.1 