### PR TITLE
teevolution: Terra Pro button remap and four onboard banks

### DIFF
--- a/src/drivers/teevolution/hid.test.ts
+++ b/src/drivers/teevolution/hid.test.ts
@@ -3,10 +3,21 @@ import test from "node:test";
 
 import { TeevolutionHidClient } from "./hid.ts";
 import {
+  TEEVOLUTION_COMMAND,
+  TEEVOLUTION_FLASH,
+  TEEVOLUTION_KEY_CLASS,
   TEEVOLUTION_LCD_REPORT_ID,
+  TEEVOLUTION_PACKET_LENGTH,
+  TEEVOLUTION_PROFILE_COUNT,
   TEEVOLUTION_REPORT_ID,
   teevolutionBuildLcdTimePacket,
+  teevolutionEncodeKeyFunction,
+  teevolutionPacketChecksum,
 } from "@openmouse/protocol/teevolution";
+
+if (typeof (globalThis as { window?: unknown }).window === "undefined") {
+  Object.defineProperty(globalThis, "window", { value: globalThis, configurable: true });
+}
 
 function device(productId: number, reportId = TEEVOLUTION_REPORT_ID): HIDDevice {
   return {
@@ -106,4 +117,161 @@ test("syncDongleClock writes host time on the authorized LCD interface", async (
   assert.deepEqual([...lcd.sent[0]!.data], [...expected.subarray(1)]);
   assert.equal(await client.syncDongleClock(now), true);
   assert.equal(lcd.sent.length, 1, "clock sync is once per connection");
+});
+
+class FakeTerraDevice {
+  vendorId = 0x3554;
+  productId = 0xf520;
+  productName = "Terra Pro";
+  opened = false;
+  collections = [{
+    usagePage: 0xff00,
+    usage: 1,
+    children: [],
+    featureReports: [],
+    inputReports: [{ reportId: TEEVOLUTION_REPORT_ID, items: [{ reportCount: 16, reportSize: 8 }] }],
+    outputReports: [{ reportId: TEEVOLUTION_REPORT_ID, items: [{ reportCount: 16, reportSize: 8 }] }],
+  }];
+  readonly flash = new Uint8Array(256);
+  currentProfile = 0;
+  readonly sent: Array<{ reportId: number; data: Uint8Array }> = [];
+  private listeners = new Set<(event: HIDInputReportEvent) => void>();
+
+  constructor() {
+    const defaults: Array<readonly [number, number]> = [
+      [TEEVOLUTION_KEY_CLASS.mouse, 0x0100],
+      [TEEVOLUTION_KEY_CLASS.mouse, 0x0200],
+      [TEEVOLUTION_KEY_CLASS.mouse, 0x0400],
+      [TEEVOLUTION_KEY_CLASS.mouse, 0x0800],
+      [TEEVOLUTION_KEY_CLASS.mouse, 0x1000],
+      [TEEVOLUTION_KEY_CLASS.dpi, 0x0100],
+    ];
+    defaults.forEach(([cls, param], index) => {
+      this.flash.set(teevolutionEncodeKeyFunction(cls, param), TEEVOLUTION_FLASH.keyFunction + index * 4);
+    });
+    this.flash[TEEVOLUTION_FLASH.reportRate] = 1;
+    this.flash[TEEVOLUTION_FLASH.maxDpiStage] = 4;
+  }
+
+  async open(): Promise<void> {
+    this.opened = true;
+  }
+
+  async close(): Promise<void> {
+    this.opened = false;
+  }
+
+  addEventListener(type: string, listener: (event: HIDInputReportEvent) => void): void {
+    if (type === "inputreport") this.listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: HIDInputReportEvent) => void): void {
+    if (type === "inputreport") this.listeners.delete(listener);
+  }
+
+  async sendReport(reportId: number, data: BufferSource): Promise<void> {
+    const packet = new Uint8Array(data as Uint8Array);
+    this.sent.push({ reportId, data: packet });
+    const reply = new Uint8Array(TEEVOLUTION_PACKET_LENGTH);
+    const command = packet[0] ?? 0;
+    reply[0] = command;
+    if (command === TEEVOLUTION_COMMAND.deviceOnline) {
+      reply[5] = 1;
+    } else if (command === TEEVOLUTION_COMMAND.encryptionData) {
+      reply[9] = 14;
+      reply[10] = 2;
+      reply[11] = 2;
+    } else if (command === TEEVOLUTION_COMMAND.getCurrentConfig) {
+      reply[5] = this.currentProfile;
+    } else if (command === TEEVOLUTION_COMMAND.setCurrentConfig) {
+      this.currentProfile = packet[5] ?? 0;
+      reply[5] = this.currentProfile;
+    } else if (command === TEEVOLUTION_COMMAND.readFlashData) {
+      const address = ((packet[2] ?? 0) << 8) | (packet[3] ?? 0);
+      const length = packet[4] ?? 0;
+      reply[2] = packet[2] ?? 0;
+      reply[3] = packet[3] ?? 0;
+      reply[4] = length;
+      reply.set(this.flash.subarray(address, address + length), 5);
+    } else if (command === TEEVOLUTION_COMMAND.writeFlashData) {
+      const address = ((packet[2] ?? 0) << 8) | (packet[3] ?? 0);
+      const length = packet[4] ?? 0;
+      this.flash.set(packet.subarray(5, 5 + length), address);
+      reply[2] = packet[2] ?? 0;
+      reply[3] = packet[3] ?? 0;
+      reply[4] = length;
+    }
+    reply[15] = teevolutionPacketChecksum(reply);
+    queueMicrotask(() => {
+      for (const listener of this.listeners) {
+        listener({
+          reportId: TEEVOLUTION_REPORT_ID,
+          data: new DataView(reply.buffer),
+        } as HIDInputReportEvent);
+      }
+    });
+  }
+}
+
+test("setButtonMapping writes only that button's four flash bytes", async () => {
+  const fake = new FakeTerraDevice();
+  const client = new TeevolutionHidClient(fake as unknown as HIDDevice);
+  const before = [...fake.flash];
+
+  await client.setButtonMapping("Forward", "Backward");
+
+  const address = TEEVOLUTION_FLASH.keyFunction + 4 * 4;
+  const expected = teevolutionEncodeKeyFunction(TEEVOLUTION_KEY_CLASS.mouse, 0x0800);
+  assert.deepEqual([...fake.flash.subarray(address, address + 4)], [...expected]);
+  for (let index = 0; index < before.length; index += 1) {
+    if (index >= address && index < address + 4) continue;
+    assert.equal(fake.flash[index], before[index], `byte ${index} untouched`);
+  }
+  const write = fake.sent.find(({ data }) => data[0] === TEEVOLUTION_COMMAND.writeFlashData);
+  assert.ok(write);
+  assert.equal(write!.data[2], address >> 8);
+  assert.equal(write!.data[3], address & 0xff);
+  assert.deepEqual([...write!.data.subarray(5, 9)], [...expected]);
+});
+
+test("setButtonMapping refuses to remove the last Left Click", async () => {
+  const fake = new FakeTerraDevice();
+  const client = new TeevolutionHidClient(fake as unknown as HIDDevice);
+  await assert.rejects(() => client.setButtonMapping("Left", "Right Click"), /Left Click/);
+});
+
+test("setButtonMapping rejects an unknown button or action", async () => {
+  const client = new TeevolutionHidClient(new FakeTerraDevice() as unknown as HIDDevice);
+  await assert.rejects(() => client.setButtonMapping("Thumb", "Left Click"), /no "Thumb" button/);
+  await assert.rejects(() => client.setButtonMapping("Left", "Launch rocket"), /Unknown button action/);
+});
+
+test("readStatus reports four onboard profile banks", async () => {
+  const fake = new FakeTerraDevice();
+  fake.currentProfile = 2;
+  const client = new TeevolutionHidClient(fake as unknown as HIDDevice);
+  const status = await client.readStatus();
+  assert.equal(status.activeProfile, 3);
+  assert.equal(status.profileCount, TEEVOLUTION_PROFILE_COUNT);
+});
+
+test("setProfile switches the firmware bank and confirms", async () => {
+  const fake = new FakeTerraDevice();
+  const client = new TeevolutionHidClient(fake as unknown as HIDDevice);
+
+  await client.setProfile(4);
+
+  assert.equal(fake.currentProfile, 3);
+  const write = fake.sent.find(({ data }) => data[0] === TEEVOLUTION_COMMAND.setCurrentConfig);
+  assert.ok(write);
+  assert.equal(write!.data[4], 1);
+  assert.equal(write!.data[5], 3);
+  const status = await client.readStatus();
+  assert.equal(status.activeProfile, 4);
+});
+
+test("setProfile rejects an index outside the mouse's range", async () => {
+  const client = new TeevolutionHidClient(new FakeTerraDevice() as unknown as HIDDevice);
+  await assert.rejects(() => client.setProfile(0), /1-4/);
+  await assert.rejects(() => client.setProfile(5), /1-4/);
 });

--- a/src/drivers/teevolution/hid.ts
+++ b/src/drivers/teevolution/hid.ts
@@ -1,8 +1,11 @@
 import type { MouseStatus } from "../mouse-types.ts";
 import { VENDOR_ID } from "../vendors.ts";
 import {
+  TEEVOLUTION_BUTTON_OPTIONS,
   TEEVOLUTION_COMMAND,
   TEEVOLUTION_FLASH,
+  TEEVOLUTION_PROFILE_COUNT,
+  TEEVOLUTION_KEY_TABLE_LENGTH,
   TEEVOLUTION_LCD_REPORT_ID,
   TEEVOLUTION_LCD_USAGE,
   TEEVOLUTION_LCD_USAGE_PAGE,
@@ -12,8 +15,11 @@ import {
   teevolutionBuildLcdTimePacket,
   teevolutionBuildOnlinePayload,
   teevolutionBuildReadPayload,
+  teevolutionBuildSetCurrentProfile,
   teevolutionBuildSimplePayload,
   teevolutionBuildWritePayload,
+  teevolutionDecodeButtonMappings,
+  teevolutionDecodeCurrentProfile,
   teevolutionDecodeDpiLightBrightness,
   teevolutionDecodeDpiLightMode,
   teevolutionDecodeDpi,
@@ -24,9 +30,15 @@ import {
   teevolutionDpiOptions,
   teevolutionEncodeDpiLightBrightness,
   teevolutionEncodeDpi,
+  teevolutionEncodeKeyFunction,
   teevolutionEncodeLiftOff,
   teevolutionEncodePollingRate,
   teevolutionEncodeSensorMode,
+  teevolutionFindButton,
+  teevolutionFindButtonAction,
+  teevolutionKeyFunctionAddress,
+  teevolutionKeyFunctionLabel,
+  teevolutionKeyTableHasLeftClick,
   teevolutionPacketChecksum,
   teevolutionParseBattery,
   teevolutionParseReadResponse,
@@ -34,6 +46,12 @@ import {
   teevolutionSensorModeUi,
   type TeevolutionDeviceProfile,
 } from "@openmouse/protocol/teevolution";
+
+const PROFILE_SETTLE_MS = 100;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
 
 export interface TeevolutionDeviceInfo {
   cid: number;
@@ -164,6 +182,7 @@ export class TeevolutionHidClient {
     const dongleVersion = await this.query(TEEVOLUTION_COMMAND.getDongleVersion).catch(() => null);
     const profile = await this.query(TEEVOLUTION_COMMAND.getCurrentConfig).catch(() => null);
     const rssi = await this.query(TEEVOLUTION_COMMAND.getRssi).catch(() => null);
+    const currentBank = profile ? teevolutionDecodeCurrentProfile(profile) : null;
     const stageCount = this.decodeDpiStageCount(flash[TEEVOLUTION_FLASH.maxDpiStage], info.profile);
     const activeDpiStage = Math.min(flash[TEEVOLUTION_FLASH.currentDpi] ?? 0, stageCount - 1);
     const dpiStages = Array.from({ length: stageCount }, (_, stage) => {
@@ -200,7 +219,8 @@ export class TeevolutionHidClient {
       activeDpiStage,
       pollingRateHz,
       supportedPollingRates: info.profile.pollingRates.filter((rate) => rate <= info.maximumPollingRateHz),
-      activeProfile: profile && profile[1] === 0 ? (profile[5] ?? 0) + 1 : null,
+      activeProfile: currentBank !== null ? currentBank + 1 : null,
+      profileCount: currentBank !== null ? TEEVOLUTION_PROFILE_COUNT : undefined,
       connectionType: info.connection,
       connectionDetail: `CID ${info.cid} · MID ${info.mid} · Type ${info.type}`,
       signalStrength: rssi && rssi[1] === 0 ? Math.min(rssi[5] ?? 0, 4) : null,
@@ -224,6 +244,8 @@ export class TeevolutionHidClient {
       sensorModeEditable: sensorModeUi.editable,
       liftOffDistance: teevolutionDecodeLiftOff(flash[TEEVOLUTION_FLASH.liftOffDistance] ?? -1),
       supportedLiftOffDistances: [...info.profile.liftOffDistances],
+      buttonMappings: teevolutionDecodeButtonMappings(flash),
+      buttonOptions: TEEVOLUTION_BUTTON_OPTIONS,
       firmware: [
         this.decodeVersionOptional("Mouse", deviceVersion) ?? "Mouse firmware unavailable",
         this.decodeVersionOptional("Dongle", dongleVersion) ?? "Dongle firmware unavailable",
@@ -238,6 +260,62 @@ export class TeevolutionHidClient {
 
   getModelProfile(): TeevolutionDeviceProfile {
     return this.profile();
+  }
+
+  getButtonOptions(): string[] {
+    return [...TEEVOLUTION_BUTTON_OPTIONS];
+  }
+
+  async setButtonMapping(button: string, action: string): Promise<void> {
+    const slot = teevolutionFindButton(button);
+    if (!slot) throw new Error(`This mouse has no "${button}" button.`);
+    const assigned = teevolutionFindButtonAction(action);
+    if (!assigned) throw new Error(`Unknown button action "${action}".`);
+    const payload = teevolutionEncodeKeyFunction(assigned.cls, assigned.param);
+    await this.open();
+    await this.withDeviceControl(async () => {
+      const table = await this.readFlash(TEEVOLUTION_FLASH.keyFunction, TEEVOLUTION_KEY_TABLE_LENGTH);
+      const next = new Uint8Array(table);
+      next.set(payload, slot.index * payload.length);
+      if (!teevolutionKeyTableHasLeftClick(next)) {
+        throw new Error("Keep at least one button as Left Click.");
+      }
+      const address = teevolutionKeyFunctionAddress(slot.index);
+      await this.writeFlash(address, payload);
+      const confirmed = await this.readFlash(address, payload.length);
+      if (teevolutionKeyFunctionLabel(confirmed) !== assigned.label) {
+        throw new Error("The mouse did not accept that button assignment.");
+      }
+    });
+  }
+
+  /**
+   * Switch the active onboard bank. `profile` is 1-based to match the shell;
+   * TeevoLink / firmware use 0–3. DPI, buttons, and the rest of flash belong
+   * to that bank, so the panel re-reads status after this returns.
+   */
+  async setProfile(profile: number): Promise<void> {
+    if (!Number.isInteger(profile) || profile < 1 || profile > TEEVOLUTION_PROFILE_COUNT) {
+      throw new Error(`Profile must be 1-${TEEVOLUTION_PROFILE_COUNT}.`);
+    }
+    await this.open();
+    await this.withDeviceControl(async () => {
+      this.assertAccepted(
+        await this.exchange(teevolutionBuildSetCurrentProfile(profile - 1)),
+        "profile switch",
+      );
+      await delay(PROFILE_SETTLE_MS);
+      const confirmed = teevolutionDecodeCurrentProfile(
+        await this.query(TEEVOLUTION_COMMAND.getCurrentConfig),
+      );
+      if (confirmed !== profile - 1) {
+        throw new Error(
+          confirmed === null
+            ? "The mouse did not confirm the profile change."
+            : `The mouse kept profile ${confirmed + 1} instead of ${profile}.`,
+        );
+      }
+    });
   }
 
   async setPollingRate(pollingRateHz: number): Promise<number> {

--- a/src/drivers/teevolution/protocol.test.ts
+++ b/src/drivers/teevolution/protocol.test.ts
@@ -3,21 +3,28 @@ import test from "node:test";
 
 import {
   TEEVOLUTION_FLASH,
+  TEEVOLUTION_KEY_CLASS,
+  TEEVOLUTION_PROFILE_COUNT,
   TEEVOLUTION_REPORT_ID,
   teevolutionProfileForCid,
   teevolutionBuildOnlinePayload,
   teevolutionBuildReadPayload,
+  teevolutionBuildSetCurrentProfile,
   teevolutionBuildSimplePayload,
   teevolutionBuildWriteScalarPayload,
+  teevolutionDecodeButtonMappings,
+  teevolutionDecodeCurrentProfile,
   teevolutionDecodeDpiLightBrightness,
   teevolutionDecodeDpiLightMode,
   teevolutionDecodeDpi,
   teevolutionDecodeFirmwareVersion,
+  teevolutionDecodeKeyFunction,
   teevolutionDecodeLiftOff,
   teevolutionDecodePollingRate,
   teevolutionDpiOptions,
   teevolutionEncodeDpiLightBrightness,
   teevolutionEncodeDpi,
+  teevolutionEncodeKeyFunction,
   teevolutionEncodeLiftOff,
   teevolutionEncodePollingRate,
   teevolutionEncodeSensorMode,
@@ -25,6 +32,10 @@ import {
   teevolutionParseBattery,
   teevolutionParseReadResponse,
   teevolutionSensorModeUi,
+  teevolutionFindButtonAction,
+  teevolutionKeyFunctionAddress,
+  teevolutionKeyFunctionLabel,
+  teevolutionKeyTableHasLeftClick,
   teevolutionLcdChecksum,
   teevolutionBuildLcdTimePacket,
   TEEVOLUTION_LCD_REPORT_ID,
@@ -147,6 +158,7 @@ test("Terra Pro capabilities are selected by reported CID", () => {
   assert.equal(TEEVOLUTION_FLASH.maxDpiStage, 2);
   assert.equal(TEEVOLUTION_FLASH.currentDpi, 4);
   assert.equal(TEEVOLUTION_FLASH.dpiValues, 12);
+  assert.equal(TEEVOLUTION_FLASH.keyFunction, 96);
   assert.deepEqual(profile.pollingRates, [125, 250, 500, 1000, 2000, 4000, 8000]);
   assert.deepEqual(profile.liftOffDistances, ["Low", "Medium", "High"]);
   assert.deepEqual(profile.sensorModes, ["Eco", "High"]);
@@ -212,4 +224,59 @@ test("RapidSync LCD time packets match Teevolink framing and CRC", () => {
   assert.deepEqual([...packet.subarray(1, 11)], [0x00, 0x10, 0x07, 0xea, 0x08, 0x0f, 0x15, 0x1b, 0x00, 6]);
   assert.equal(packet[39], teevolutionLcdChecksum(packet));
   assert.equal(now.getDay(), 6);
+});
+
+test("key-function records match Teevolink's 4-byte flash layout", () => {
+  const left = teevolutionEncodeKeyFunction(TEEVOLUTION_KEY_CLASS.mouse, 0x0100);
+  assert.deepEqual([...left], [0x01, 0x01, 0x00, 0x53]);
+  assert.deepEqual(teevolutionDecodeKeyFunction(left), {
+    cls: 1,
+    param: 0x0100,
+    checksumValid: true,
+  });
+  assert.equal(teevolutionKeyFunctionLabel(left), "Left Click");
+  assert.equal(teevolutionKeyFunctionAddress(0), 96);
+  assert.equal(teevolutionKeyFunctionAddress(4), 0x70);
+  assert.equal(teevolutionFindButtonAction("Backward")?.param, 0x0800);
+  assert.equal(teevolutionFindButtonAction("Launch rocket"), null);
+
+  const table = new Uint8Array(24);
+  const defaults: Array<readonly [number, number]> = [
+    [1, 0x0100], [1, 0x0200], [1, 0x0400], [1, 0x0800], [1, 0x1000], [2, 0x0100],
+  ];
+  defaults.forEach(([cls, param], index) => {
+    table.set(teevolutionEncodeKeyFunction(cls, param), index * 4);
+  });
+  const flash = new Uint8Array(120);
+  flash.set(table, 96);
+  assert.deepEqual(teevolutionDecodeButtonMappings(flash), {
+    Left: "Left Click",
+    Right: "Right Click",
+    Middle: "Middle Click",
+    Back: "Backward",
+    Forward: "Forward",
+    DPI: "DPI Loop",
+  });
+  assert.equal(teevolutionKeyTableHasLeftClick(table), true);
+  table.set(teevolutionEncodeKeyFunction(1, 0x0200), 0);
+  assert.equal(teevolutionKeyTableHasLeftClick(table), false);
+  assert.equal(teevolutionKeyFunctionLabel([6, 0x01, 0x05, 0]), "Custom");
+});
+
+test("SetCurrentConfig matches TeevoLink's 0-based four-bank picker", () => {
+  const profile0 = teevolutionBuildSetCurrentProfile(0);
+  const profile3 = teevolutionBuildSetCurrentProfile(3);
+  assert.deepEqual([...profile0.slice(0, 6)], [0x0f, 0, 0, 0, 1, 0]);
+  assert.deepEqual([...profile3.slice(0, 6)], [0x0f, 0, 0, 0, 1, 3]);
+  assert.equal(teevolutionPacketChecksumIsValid(profile0), true);
+  assert.equal(teevolutionPacketChecksumIsValid(profile3), true);
+  assert.equal(TEEVOLUTION_PROFILE_COUNT, 4);
+  assert.throws(() => teevolutionBuildSetCurrentProfile(4), /0 and 3/);
+
+  const reply = new Uint8Array([0x0e, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  reply[15] = (0x55 - TEEVOLUTION_REPORT_ID - reply.slice(0, 15).reduce((sum, byte) => sum + byte, 0)) & 0xff;
+  assert.equal(teevolutionDecodeCurrentProfile(reply), 2);
+  reply[1] = 1;
+  reply[15] = (0x55 - TEEVOLUTION_REPORT_ID - reply.slice(0, 15).reduce((sum, byte) => sum + byte, 0)) & 0xff;
+  assert.equal(teevolutionDecodeCurrentProfile(reply), null);
 });

--- a/src/teevolution/index.ts
+++ b/src/teevolution/index.ts
@@ -85,6 +85,7 @@ export const TEEVOLUTION_COMMAND = {
   writeFlashData: 0x07,
   readFlashData: 0x08,
   getCurrentConfig: 0x0e,
+  setCurrentConfig: 0x0f,
   readVersionId: 0x12,
   getDongleVersion: 0x1d,
   getRssi: 0x2b,
@@ -104,6 +105,8 @@ export const TEEVOLUTION_FLASH = {
   dpiLightBrightness: 78,
   dpiLightSpeed: 80,
   dpiLightState: 82,
+  /** Base of 4-byte key-function records (one per physical button). */
+  keyFunction: 96,
   debounceTime: 169,
   motionSync: 171,
   sleepTime: 173,
@@ -113,6 +116,121 @@ export const TEEVOLUTION_FLASH = {
   performanceTime: 183,
   sensorMode: 185,
 } as const;
+
+/** Teevolink MouseKeyFunction class byte stored at flash 0x60 + 4×index. */
+export const TEEVOLUTION_KEY_CLASS = {
+  disable: 0,
+  mouse: 1,
+  dpi: 2,
+  tilt: 3,
+} as const;
+
+export const TEEVOLUTION_BUTTONS = [
+  { name: "Left", index: 0 },
+  { name: "Right", index: 1 },
+  { name: "Middle", index: 2 },
+  { name: "Back", index: 3 },
+  { name: "Forward", index: 4 },
+  { name: "DPI", index: 5 },
+] as const;
+
+export type TeevolutionButtonName = (typeof TEEVOLUTION_BUTTONS)[number]["name"];
+
+export interface TeevolutionButtonAction {
+  label: string;
+  cls: number;
+  param: number;
+}
+
+/** Simple assignments the generic remap dropdown can write. */
+export const TEEVOLUTION_BUTTON_ACTIONS: readonly TeevolutionButtonAction[] = [
+  { label: "Left Click", cls: TEEVOLUTION_KEY_CLASS.mouse, param: 0x0100 },
+  { label: "Right Click", cls: TEEVOLUTION_KEY_CLASS.mouse, param: 0x0200 },
+  { label: "Middle Click", cls: TEEVOLUTION_KEY_CLASS.mouse, param: 0x0400 },
+  { label: "Backward", cls: TEEVOLUTION_KEY_CLASS.mouse, param: 0x0800 },
+  { label: "Forward", cls: TEEVOLUTION_KEY_CLASS.mouse, param: 0x1000 },
+  { label: "DPI Loop", cls: TEEVOLUTION_KEY_CLASS.dpi, param: 0x0100 },
+  { label: "DPI+", cls: TEEVOLUTION_KEY_CLASS.dpi, param: 0x0200 },
+  { label: "DPI-", cls: TEEVOLUTION_KEY_CLASS.dpi, param: 0x0300 },
+  { label: "Scroll Left", cls: TEEVOLUTION_KEY_CLASS.tilt, param: 0x0100 },
+  { label: "Scroll Right", cls: TEEVOLUTION_KEY_CLASS.tilt, param: 0x0200 },
+  { label: "Disable", cls: TEEVOLUTION_KEY_CLASS.disable, param: 0x0000 },
+];
+
+export const TEEVOLUTION_BUTTON_OPTIONS = TEEVOLUTION_BUTTON_ACTIONS.map((action) => action.label);
+
+export const TEEVOLUTION_KEY_RECORD_LENGTH = 4;
+export const TEEVOLUTION_KEY_TABLE_LENGTH = TEEVOLUTION_BUTTONS.length * TEEVOLUTION_KEY_RECORD_LENGTH;
+/** TeevoLink ProfileOptions: four firmware-managed flash banks. */
+export const TEEVOLUTION_PROFILE_COUNT = 4;
+
+export function teevolutionKeyFunctionAddress(index: number): number {
+  if (!Number.isInteger(index) || index < 0 || index >= TEEVOLUTION_BUTTONS.length) {
+    throw new Error("Teevolution button index is out of range.");
+  }
+  return TEEVOLUTION_FLASH.keyFunction + index * TEEVOLUTION_KEY_RECORD_LENGTH;
+}
+
+export function teevolutionEncodeKeyFunction(cls: number, param: number): Uint8Array {
+  if (!Number.isInteger(cls) || cls < 0 || cls > 0xff) {
+    throw new Error("Teevolution key class must be one byte.");
+  }
+  if (!Number.isInteger(param) || param < 0 || param > 0xffff) {
+    throw new Error("Teevolution key parameter must be a 16-bit value.");
+  }
+  const bytes = [cls, (param >> 8) & 0xff, param & 0xff];
+  return new Uint8Array([...bytes, teevolutionDataChecksum(bytes)]);
+}
+
+export function teevolutionDecodeKeyFunction(data: Uint8Array | readonly number[]): {
+  cls: number;
+  param: number;
+  checksumValid: boolean;
+} {
+  const cls = data[0] ?? 0;
+  const param = ((data[1] ?? 0) << 8) | (data[2] ?? 0);
+  const checksumValid = data.length >= 4
+    && (data[3] ?? 0) === teevolutionDataChecksum([cls, (param >> 8) & 0xff, param & 0xff]);
+  return { cls, param, checksumValid };
+}
+
+export function teevolutionFindButtonAction(label: string): TeevolutionButtonAction | null {
+  return TEEVOLUTION_BUTTON_ACTIONS.find((action) => action.label === label) ?? null;
+}
+
+export function teevolutionFindButton(name: string): (typeof TEEVOLUTION_BUTTONS)[number] | null {
+  return TEEVOLUTION_BUTTONS.find((button) => button.name === name) ?? null;
+}
+
+export function teevolutionKeyFunctionLabel(data: Uint8Array | readonly number[]): string {
+  const { cls, param } = teevolutionDecodeKeyFunction(data);
+  return TEEVOLUTION_BUTTON_ACTIONS.find((action) => action.cls === cls && action.param === param)?.label
+    ?? "Custom";
+}
+
+export function teevolutionIsLeftClick(cls: number, param: number): boolean {
+  return cls === TEEVOLUTION_KEY_CLASS.mouse && param === 0x0100;
+}
+
+export function teevolutionKeyTableHasLeftClick(table: Uint8Array | readonly number[]): boolean {
+  for (let index = 0; index < TEEVOLUTION_BUTTONS.length; index += 1) {
+    const offset = index * TEEVOLUTION_KEY_RECORD_LENGTH;
+    const { cls, param } = teevolutionDecodeKeyFunction(table.slice(offset, offset + TEEVOLUTION_KEY_RECORD_LENGTH));
+    if (teevolutionIsLeftClick(cls, param)) return true;
+  }
+  return false;
+}
+
+export function teevolutionDecodeButtonMappings(flash: Uint8Array | readonly number[]): Record<string, string> {
+  const mappings: Record<string, string> = {};
+  for (const { name, index } of TEEVOLUTION_BUTTONS) {
+    const offset = teevolutionKeyFunctionAddress(index);
+    mappings[name] = flash.length >= offset + TEEVOLUTION_KEY_RECORD_LENGTH
+      ? teevolutionKeyFunctionLabel(flash.slice(offset, offset + TEEVOLUTION_KEY_RECORD_LENGTH))
+      : "Custom";
+  }
+  return mappings;
+}
 
 export const TEEVOLUTION_TYPE_MAX_POLL: Record<number, number> = {
   0: 1000,
@@ -202,6 +320,28 @@ export function teevolutionBuildOnlinePayload(enabled: boolean): Uint8Array {
   const payload = teevolutionBuildSimplePayload(TEEVOLUTION_COMMAND.deviceOnline);
   payload[5] = enabled ? 1 : 0;
   return finalize(payload);
+}
+
+/** Build SetCurrentConfig with TeevoLink's length byte and zero-based bank. */
+export function teevolutionBuildSetCurrentProfile(profile: number): Uint8Array {
+  if (!Number.isInteger(profile) || profile < 0 || profile >= TEEVOLUTION_PROFILE_COUNT) {
+    throw new Error(`Teevolution profile must be between 0 and ${TEEVOLUTION_PROFILE_COUNT - 1}.`);
+  }
+  const payload = teevolutionBuildSimplePayload(TEEVOLUTION_COMMAND.setCurrentConfig);
+  payload[4] = 1;
+  payload[5] = profile;
+  return finalize(payload);
+}
+
+/**
+ * Decode GetCurrentConfig. TeevoLink treats status 1 as “no profile switch”
+ * (`supportChangeProfile = false`); only a 0–3 bank in byte 5 is usable.
+ */
+export function teevolutionDecodeCurrentProfile(response: Uint8Array | readonly number[]): number | null {
+  if (!teevolutionPacketChecksumIsValid(response)) return null;
+  if (response[0] !== TEEVOLUTION_COMMAND.getCurrentConfig || response[1] !== 0) return null;
+  const profile = response[5] ?? 0;
+  return profile < TEEVOLUTION_PROFILE_COUNT ? profile : null;
 }
 
 export function teevolutionParseReadResponse(


### PR DESCRIPTION
## Summary
- Write Terra Pro button assignments as 4-byte key-function records in flash (`KeyFunction = 96`, button `i` at `96 + 4*i`), matching TeevoLink. Keep at least one Left Click.
- Expose the four firmware profile banks (`GetCurrentConfig` `0x0e` / `SetCurrentConfig` `0x0f`, 0-based 0–3). `setProfile` is 1-based in the driver, settles, then confirms with GetCurrentConfig.
- `readStatus` now reports `profileCount: 4`, 1-based `activeProfile`, plus `buttonMappings` / `buttonOptions` so OpenMouse can show the Profiles UI.

## Test plan
- [ ] `npm test` in mouse-protocol (codec + HID tests for remap, last Left Click, and bank switch)
- [ ] On a Terra Pro: remap a non-left button, power-cycle, confirm it stuck
- [ ] Switch banks 1–4 and confirm DPI / buttons / debounce follow the bank
- [ ] Confirm refusing to remap the last Left Click still works