### PR TITLE
gearhub: R2 device id 3009, R3, generic fallback, DPI stage colours

### DIFF
--- a/src/drivers/gearhub/hid.test.ts
+++ b/src/drivers/gearhub/hid.test.ts
@@ -504,6 +504,39 @@ describe("GearHubHidClient", () => {
     assert.ok(status.firmware.includes("PixArt PAW3950"));
   });
 
+  it("identifies the Attack Shark R3 (device id 1643, PAW3395)", async () => {
+    const { device } = fakeReceiver({
+      deviceId: 1643,
+      replies: {
+        [CMD.GET_DPI]: dpiReply([1200, 26000], 0),
+        [CMD.GET_OPTIONPARAM0]: opt0Reply({ rate: 129, lod: 0 }),
+      },
+    });
+    const client = new GearHubHidClient(device);
+    const status = await client.readStatus();
+
+    assert.equal(status.brand, "Attack Shark");
+    assert.equal(status.name, "Attack Shark R3");
+    assert.ok(status.firmware.includes("PixArt PAW3395"));
+    assert.equal(client.getDpiOptions().at(-1), 26000, "PAW3395 DPI ceiling");
+  });
+
+  it("maps the PAW3950 R3 revision (device id 3310) to the 42000 DPI profile", async () => {
+    const { device } = fakeReceiver({
+      deviceId: 3310,
+      replies: {
+        [CMD.GET_DPI]: dpiReply([800, 1600, 42000], 0),
+        [CMD.GET_OPTIONPARAM0]: opt0Reply({ rate: 1, lod: 2 }),
+      },
+    });
+    const client = new GearHubHidClient(device);
+    const status = await client.readStatus();
+
+    assert.equal(status.name, "Attack Shark R3");
+    assert.ok(status.firmware.includes("PixArt PAW3950"));
+    assert.ok(client.getDpiOptions().includes(42000), "PAW3950 DPI ceiling");
+  });
+
   it("falls back to the generic profile for an unknown device id", async () => {
     const { device } = fakeReceiver({
       deviceId: 9999,

--- a/src/drivers/gearhub/hid.test.ts
+++ b/src/drivers/gearhub/hid.test.ts
@@ -238,8 +238,8 @@ describe("GearHubHidClient", () => {
   });
 
   it("sets the lift-off distance by patching OPTIONPARAM0 byte 52", async () => {
-    // No readStatus() first, so the fallback profile (M5 Pro / PAW3395) is in
-    // effect: two stops, Low (index 0) and High (index 1).
+    // No readStatus() first, so the generic fallback profile is in effect:
+    // the common three stops, Low (0) / Medium (1) / High (2).
     const { device, sent } = fakeReceiver({
       replies: { [CMD.GET_OPTIONPARAM0]: opt0Reply({ rate: 3, lod: 0 }) },
     });
@@ -247,7 +247,7 @@ describe("GearHubHidClient", () => {
 
     const write = sent.filter((buf) => buf[0] === CMD.SET_OPTIONPARAM0).at(-1);
     assert.ok(write, "a SET_OPTIONPARAM0 report should have been sent");
-    assert.equal(write![OPT0_SILENT_HEIGHT], 1, "High maps to index 1 on a two-stop sensor");
+    assert.equal(write![OPT0_SILENT_HEIGHT], 2, "High maps to index 2 on a three-stop list");
     assert.equal(write![OPT0_REPORT_RATE], 3, "report rate carried over");
   });
 
@@ -398,12 +398,15 @@ describe("GearHubHidClient", () => {
   });
 
   it("rejects a lift-off level the model does not offer", async () => {
+    // Resolve the M5 Pro profile (device id 2285, PAW3395): two stops, no "Medium".
     const { device } = fakeReceiver({
-      replies: { [CMD.GET_OPTIONPARAM0]: opt0Reply() },
+      replies: { [CMD.GET_DPI]: dpiReply([800, 1600], 0), [CMD.GET_OPTIONPARAM0]: opt0Reply() },
     });
-    // PAW3395 fallback has no "Medium".
+    const client = new GearHubHidClient(device);
+    await client.readStatus();
+
     await assert.rejects(
-      () => new GearHubHidClient(device).setLiftOffDistance("Medium"),
+      () => client.setLiftOffDistance("Medium"),
       /not available on this model/,
     );
   });
@@ -501,7 +504,7 @@ describe("GearHubHidClient", () => {
     assert.ok(status.firmware.includes("PixArt PAW3950"));
   });
 
-  it("falls back to the M5 Pro profile for an unknown device id", async () => {
+  it("falls back to the generic profile for an unknown device id", async () => {
     const { device } = fakeReceiver({
       deviceId: 9999,
       replies: { [CMD.GET_DPI]: dpiReply([400, 800, 1600], 0), [CMD.GET_OPTIONPARAM0]: opt0Reply() },
@@ -509,9 +512,9 @@ describe("GearHubHidClient", () => {
     const client = new GearHubHidClient(device);
     const status = await client.readStatus();
 
-    assert.equal(status.brand, "Lingbao");
-    assert.equal(status.name, "Lingbao M5 Pro");
-    assert.equal(client.getDpiOptions().at(-1), 26000, "DPI stops stay at the PAW3395 ceiling");
+    assert.equal(status.brand, "GearHub");
+    assert.equal(status.name, "GearHub V5 mouse");
+    assert.equal(client.getDpiOptions().at(-1), 42000, "DPI stops are not clamped below the platform ceiling");
   });
 
   it("survives a device that will not answer GET_USB_VERSION", async () => {
@@ -524,8 +527,8 @@ describe("GearHubHidClient", () => {
     });
     const status = await new GearHubHidClient(device).readStatus();
 
-    assert.equal(status.brand, "Lingbao");
-    assert.equal(status.name, "Lingbao M5 Pro");
+    assert.equal(status.brand, "GearHub");
+    assert.equal(status.name, "GearHub V5 mouse");
   });
 
   it("keeps working when OPTIONPARAM0 cannot be read", async () => {
@@ -553,6 +556,61 @@ describe("GearHubHidClient", () => {
     assert.equal(write![40], 0x10);       // indicator colours carried over
     assert.equal(write![43], 0x11);
     assert.equal(write![46], 0x12);
+  });
+
+  it("setDpiStageColor recolours one stage and keeps the other stages", async () => {
+    const { device, sent } = fakeReceiver({
+      replies: { [CMD.GET_DPI]: dpiReply([800, 1600, 3200], 0, [0x111111, 0x222222, 0x333333]) },
+    });
+    const confirmed = await new GearHubHidClient(device).setDpiStageColor(1, "#40c8ff");
+
+    assert.equal(confirmed, "#40c8ff");
+    const write = sent.filter((buf) => buf[0] === CMD.SET_DPI).at(-1);
+    assert.ok(write, "a SET_DPI report should have been sent");
+    const u16 = (buf: Uint8Array, i: number) => buf[i] | (buf[i + 1] << 8);
+    assert.equal(u16(write!, 8), 800);    // stage 0 resolution untouched
+    assert.equal(u16(write!, 10), 1600);  // stage 1 resolution untouched
+    assert.deepEqual([write![40], write![41], write![42]], [0x11, 0x11, 0x11]); // stage 0 colour kept
+    assert.deepEqual([write![43], write![44], write![45]], [0x40, 0xc8, 0xff]); // stage 1 recoloured
+    assert.deepEqual([write![46], write![47], write![48]], [0x33, 0x33, 0x33]); // stage 2 colour kept
+    assert.equal(write![2], 0, "active stage kept, not moved to the edited one");
+  });
+
+  it("setActiveDpiStage re-sends the table with the new active index", async () => {
+    const { device, sent } = fakeReceiver({
+      replies: { [CMD.GET_DPI]: dpiReply([800, 1600, 3200], 0, [0x111111, 0x222222, 0x333333]) },
+    });
+    const at = await new GearHubHidClient(device).setActiveDpiStage(2);
+
+    assert.equal(at, 2);
+    const write = sent.filter((buf) => buf[0] === CMD.SET_DPI).at(-1);
+    assert.ok(write, "a SET_DPI report should have been sent");
+    assert.equal(write![2], 2, "active index moved to stage 3");
+    const u16 = (buf: Uint8Array, i: number) => buf[i] | (buf[i + 1] << 8);
+    assert.equal(u16(write!, 8), 800);    // resolutions untouched
+    assert.equal(u16(write!, 12), 3200);
+    assert.deepEqual([write![40], write![43], write![46]], [0x11, 0x22, 0x33]); // colours untouched
+  });
+
+  it("setActiveDpiStage clamps an out-of-range index", async () => {
+    const { device, sent } = fakeReceiver({
+      replies: { [CMD.GET_DPI]: dpiReply([800, 1600], 0) },
+    });
+    assert.equal(await new GearHubHidClient(device).setActiveDpiStage(9), 1);
+    assert.equal(sent.filter((buf) => buf[0] === CMD.SET_DPI).at(-1)![2], 1);
+  });
+
+  it("readStatus reports every DPI stage colour as #rrggbb", async () => {
+    const { device } = fakeReceiver({
+      deviceId: 1893,
+      replies: {
+        [CMD.GET_DPI]: dpiReply([400, 800, 1600], 1, [0x000000, 0xff8000, 0x00ff00]),
+        [CMD.GET_OPTIONPARAM0]: opt0Reply({ rate: 1, lod: 2 }),
+      },
+    });
+    const status = await new GearHubHidClient(device).readStatus();
+
+    assert.deepEqual(status.dpiStageColors, ["#000000", "#ff8000", "#00ff00"]);
   });
 
   it("refuses a rate the wired mode cannot reach", async () => {

--- a/src/drivers/gearhub/hid.test.ts
+++ b/src/drivers/gearhub/hid.test.ts
@@ -487,6 +487,20 @@ describe("GearHubHidClient", () => {
     assert.equal(await client.setLiftOffDistance("Medium"), "Medium");
   });
 
+  it("maps the later R2 firmware batch (device id 3009) to the R2 profile", async () => {
+    const { device } = fakeReceiver({
+      deviceId: 3009,
+      replies: {
+        [CMD.GET_DPI]: dpiReply([400, 800, 1600, 5600, 8000, 42000], 2),
+        [CMD.GET_OPTIONPARAM0]: opt0Reply({ rate: 1, lod: 2 }),
+      },
+    });
+    const status = await new GearHubHidClient(device).readStatus();
+
+    assert.equal(status.name, "Attack Shark R2");
+    assert.ok(status.firmware.includes("PixArt PAW3950"));
+  });
+
   it("falls back to the M5 Pro profile for an unknown device id", async () => {
     const { device } = fakeReceiver({
       deviceId: 9999,

--- a/src/drivers/gearhub/hid.ts
+++ b/src/drivers/gearhub/hid.ts
@@ -498,19 +498,52 @@ export class GearHubHidClient {
   }
 
   /**
-   * Replace one DPI stage. SET_DPI carries the whole stage table, so the other
-   * stages — and every stage's indicator colour — are read back and echoed
-   * unchanged rather than zeroed.
+   * Replace one DPI stage's resolution. SET_DPI carries the whole stage table,
+   * so the other stages — and every stage's indicator colour — are read back
+   * and echoed unchanged rather than zeroed.
    */
   async setDpiForStage(x: number, y: number, index: number): Promise<number> {
     const { stages, activeIndex } = await this.getDpi();
     const target = index >= 0 && index < stages.length ? index : activeIndex;
     stages[target] = { ...stages[target], x, y };
+    await this.writeDpiTable(stages, activeIndex);
+    return x;
+  }
 
+  /**
+   * Recolour one DPI stage's indicator LED. Same whole-table write as
+   * `setDpiForStage`, changing `rgb` instead of the resolution. `color` is
+   * `#rrggbb`; returns it normalised.
+   */
+  async setDpiStageColor(index: number, color: string): Promise<string> {
+    const rgb = Number.parseInt(color.replace(/^#/, ""), 16);
+    if (!Number.isFinite(rgb)) throw new Error(`Invalid DPI stage colour "${color}".`);
+
+    const { stages, activeIndex } = await this.getDpi();
+    const target = index >= 0 && index < stages.length ? index : activeIndex;
+    stages[target] = { ...stages[target], rgb: rgb & 0xffffff };
+    await this.writeDpiTable(stages, activeIndex);
+    return `#${(rgb & 0xffffff).toString(16).padStart(6, "0")}`;
+  }
+
+  /**
+   * Switch which DPI stage the mouse is on. SET_DPI's byte 2 is the active
+   * index; re-send the unchanged table with it moved.
+   */
+  async setActiveDpiStage(index: number): Promise<number> {
+    const { stages } = await this.getDpi();
+    if (stages.length === 0) throw new Error("GearHub reported no DPI stages.");
+    const target = Math.max(0, Math.min(index, stages.length - 1));
+    await this.writeDpiTable(stages, target);
+    return target;
+  }
+
+  /** Encode the full stage table into one SET_DPI report and send it. */
+  private async writeDpiTable(stages: GearHubDpiStage[], active: number): Promise<void> {
     const cmd = new Uint8Array(GEARHUB_REPORT_SIZE);
     cmd[0] = CMD.SET_DPI;
     cmd[1] = this.currentProfile;
-    cmd[2] = target;
+    cmd[2] = active;
     cmd[3] = stages.length;
     stages.forEach((stage, i) => {
       cmd[DPI_X_OFFSET + i * 2] = stage.x & 0xff;
@@ -522,7 +555,6 @@ export class GearHubHidClient {
       cmd[DPI_RGB_OFFSET + 2 + i * 3] = stage.rgb & 0xff;
     });
     await this.sendWrite(cmd);
-    return x;
   }
 
   /** A write takes the same relay path as a read, minus the read-back. */
@@ -625,6 +657,7 @@ export class GearHubHidClient {
         ? this.buttonMappingsFrom(keyMatrixResult.value)
         : undefined;
 
+
     return {
       brand: profile.brand,
       name: displayName,
@@ -632,6 +665,15 @@ export class GearHubHidClient {
         family: "gearhub",
         settingsReady: true,
         defaultDisplayName: displayName,
+        // Stage-list DPI editor: per-stage resolution + indicator colour, the
+        // way GearHub itself shows it. Stage count is fixed (no SET for it), so
+        // countEditable is left off and the count picker stays hidden.
+        dpiStageEditor: {
+          maxStages: dpi.stages.length,
+          minDpi: profile.minDpi,
+          maxDpi: profile.maxDpi,
+          stepDpi: profile.dpiStep,
+        },
       },
       batteryPercent: battery,
       batteryState: battery === null ? "Unknown" : "Discharging",
@@ -639,6 +681,9 @@ export class GearHubHidClient {
       dpiY: active.y,
       supportsSeparateDpiAxes: true,
       dpiStages: dpi.stages.map((stage) => stage.x),
+      dpiStageColors: dpi.stages.map(
+        (stage) => `#${(stage.rgb & 0xffffff).toString(16).padStart(6, "0")}`,
+      ),
       activeDpiStage: dpi.activeIndex,
       pollingRateHz,
       supportedPollingRates: this.supportedPollingRates,

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -144,7 +144,7 @@ export interface AtkReceiverInfo {
 }
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "Corsair" | "Microsoft";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "GearHub" | "Corsair" | "Microsoft";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;

--- a/src/gearhub/index.ts
+++ b/src/gearhub/index.ts
@@ -290,6 +290,34 @@ export const ATTACK_SHARK_R2_PROFILE: GearHubProfile = {
   dpiStep: 50,
 };
 
+/**
+ * Attack Shark R3. Same GearHub-V5 platform, VID:PID and block protocol as
+ * the R2. qmk.top's catalog carries it under four device ids: 1643 and 3485
+ * with the PixArt PAW3395 (26000 DPI), 3309 and 3310 with the PAW3950
+ * (42000 DPI). Device id 1643 confirmed from a user diagnostic - firmware
+ * v3.00, on 0x3151:0x402D, every relay read (D3/D4/D0/8F/80) answering and
+ * a full status; it was falling back to the M5 Pro name only. The other
+ * three ids are catalog-derived.
+ */
+export const ATTACK_SHARK_R3_PROFILE: GearHubProfile = {
+  deviceId: 1643,
+  brand: "Attack Shark",
+  model: "R3",
+  sensor: "PixArt PAW3395",
+  maxPollingHz: 8000,
+  minDpi: 50,
+  maxDpi: 26000,
+  dpiStep: 50,
+};
+
+/** The PixArt PAW3950 R3 revision (device ids 3309 / 3310, catalog-derived). */
+export const ATTACK_SHARK_R3_3950_PROFILE: GearHubProfile = {
+  ...ATTACK_SHARK_R3_PROFILE,
+  deviceId: 3309,
+  sensor: "PixArt PAW3950",
+  maxDpi: 42000,
+};
+
 export const GEARHUB_DEVICE_PROFILES: ReadonlyMap<number, GearHubProfile> = new Map<
   number,
   GearHubProfile
@@ -299,6 +327,10 @@ export const GEARHUB_DEVICE_PROFILES: ReadonlyMap<number, GearHubProfile> = new 
   // A later R2 firmware batch on the same 0x40xx silicon, PID and PAW3950
   // sensor as 1893. Block protocol assumed identical; not hardware-verified.
   [3009, ATTACK_SHARK_R2_PROFILE],
+  [ATTACK_SHARK_R3_PROFILE.deviceId, ATTACK_SHARK_R3_PROFILE],
+  [3485, ATTACK_SHARK_R3_PROFILE],
+  [ATTACK_SHARK_R3_3950_PROFILE.deviceId, ATTACK_SHARK_R3_3950_PROFILE],
+  [3310, ATTACK_SHARK_R3_3950_PROFILE],
 ]);
 
 /**

--- a/src/gearhub/index.ts
+++ b/src/gearhub/index.ts
@@ -131,6 +131,9 @@ export const GEARHUB_LIFT_OFF_LEVELS: Record<string, readonly LiftOffLevel[]> = 
   "PixArt PAW3950": ["Low", "Medium", "High"],
   "PixArt PAW3955": ["Low", "Medium", "High"],
   "PixArt PAW3395": ["Low", "High"],
+  // Unidentified GearHub-V5 device: offer the common three stops. The
+  // firmware clamps the index if its sensor only has two.
+  "PixArt (GearHub-V5)": ["Low", "Medium", "High"],
 };
 
 // ── Button remapping (keymatrix) ───────────────────────────────────────────
@@ -235,7 +238,7 @@ export const GEARHUB_PRODUCTS: ReadonlyMap<number, GearHubTransport> = new Map([
  */
 export interface GearHubProfile {
   deviceId: number;
-  brand: "Lingbao" | "Attack Shark";
+  brand: "Lingbao" | "Attack Shark" | "GearHub";
   model: string;
   sensor: string;
   maxPollingHz: number;
@@ -299,10 +302,23 @@ export const GEARHUB_DEVICE_PROFILES: ReadonlyMap<number, GearHubProfile> = new 
 ]);
 
 /**
- * Identity for an unrecognised GearHub-V5 sibling: the M5 Pro, which is what
- * this driver always reported before it learned to ask for the device id.
+ * Identity for a GearHub-V5 device this driver reached but could not name:
+ * GET_USB_VERSION failed, or it answered a device id not in the catalog.
+ * Deliberately generic - naming a concrete model here (it used to borrow the
+ * M5 Pro's) is a guess that is wrong for every sibling that is not an M5 Pro.
+ * The DPI/polling bounds are the platform ceilings so a real device's range
+ * is never clamped; the live DPI stages still come from the device's table.
  */
-export const GEARHUB_FALLBACK_PROFILE = LINGBAO_M5_PRO_PROFILE;
+export const GEARHUB_FALLBACK_PROFILE: GearHubProfile = {
+  deviceId: 0,
+  brand: "GearHub",
+  model: "V5 mouse",
+  sensor: "PixArt (GearHub-V5)",
+  maxPollingHz: 8000,
+  minDpi: 50,
+  maxDpi: 42000,
+  dpiStep: 50,
+};
 
 /** Resolve a device id to its profile, or the fallback. */
 export function gearHubProfileFor(deviceId: number | null | undefined): GearHubProfile {

--- a/src/gearhub/index.ts
+++ b/src/gearhub/index.ts
@@ -269,6 +269,12 @@ export const LINGBAO_M5_PRO_PROFILE: GearHubProfile = {
  * receiver and by cable (PID 0x4026): identity, firmware v2.01, the
  * six-stage DPI table (top stage ~42000), 8000 Hz polling, DPI / lift-off /
  * debounce / correction / sleep read + write, and 6-button remapping.
+ *
+ * qmk.top's catalog carries three R2 device ids: 1893 and 3009 on the
+ * original 0x40xx MCU (PID 0x4026 / 0x402D), and 3016 on the newer 0x50xx
+ * MCU (PID 0x5043). 1893 and 3009 share this profile; 3016 is not handled
+ * here - its PID is not in GEARHUB_PRODUCTS and it is most likely the
+ * individual-command firmware this block-protocol driver cannot drive.
  */
 export const ATTACK_SHARK_R2_PROFILE: GearHubProfile = {
   deviceId: 1893,
@@ -281,9 +287,16 @@ export const ATTACK_SHARK_R2_PROFILE: GearHubProfile = {
   dpiStep: 50,
 };
 
-export const GEARHUB_DEVICE_PROFILES: ReadonlyMap<number, GearHubProfile> = new Map(
-  [LINGBAO_M5_PRO_PROFILE, ATTACK_SHARK_R2_PROFILE].map((profile) => [profile.deviceId, profile]),
-);
+export const GEARHUB_DEVICE_PROFILES: ReadonlyMap<number, GearHubProfile> = new Map<
+  number,
+  GearHubProfile
+>([
+  [LINGBAO_M5_PRO_PROFILE.deviceId, LINGBAO_M5_PRO_PROFILE],
+  [ATTACK_SHARK_R2_PROFILE.deviceId, ATTACK_SHARK_R2_PROFILE],
+  // A later R2 firmware batch on the same 0x40xx silicon, PID and PAW3950
+  // sensor as 1893. Block protocol assumed identical; not hardware-verified.
+  [3009, ATTACK_SHARK_R2_PROFILE],
+]);
 
 /**
  * Identity for an unrecognised GearHub-V5 sibling: the M5 Pro, which is what


### PR DESCRIPTION
Follow-on work for the Attack Shark R2 / GearHub-V5 driver.

## device ids 3009 + Attack Shark R3

qmk.top's catalog lists a second R2 device id, **3009**, on the same PAN1080 MCU and PID (`0x4026` / `0x402D`) as **1893** - aliased to `ATTACK_SHARK_R2_PROFILE` (was falling back to the M5 Pro).

The **Attack Shark R3** is the same story: same `0x3151:0x402D`, same block protocol, resolving to the M5 Pro fallback. Added under its four catalog device ids - 1643/3485 (PixArt PAW3395, 26000 DPI) and 3309/3310 (PAW3950, 42000 DPI). **id 1643 confirmed from a user diagnostic** (firmware v3.00, every relay read answering, full status); the other three are catalog-derived.

Not included: R2 id **3016** (PID `0x5043`, RongYuan RY6601 MCU) - different PID, uses qmk's opcode-159 aggregate protocol rather than the `0xD3` block protocol this driver speaks.

## generic fallback

`GEARHUB_FALLBACK_PROFILE` pointed at the M5 Pro, so any GearHub-V5 device the driver couldn't name showed as "Lingbao M5 Pro" with its sensor and DPI ceiling. Split into its own generic profile (brand `GearHub`, `V5 mouse`, platform-ceiling bounds). `LINGBAO_M5_PRO_PROFILE` keeps its catalog entry for id 2285. Adds a `PixArt (GearHub-V5)` lift-off entry so lift-off still works when unidentified.

## DPI stage colours + active-stage switching

- `readStatus()` reports `dpiStageColors` (`#rrggbb` per stage) and sets `ui.dpiStageEditor`, so OpenMouse's existing stage-list DPI editor with per-stage colour pickers renders for these mice. No OpenMouse changes needed.
- `setDpiStageColor(index, color)` re-writes the stage table changing only that stage's RGB.
- `setActiveDpiStage(index)` switches the active stage via `SET_DPI` byte 2. DPI-edit writes now preserve the active index instead of moving it to the edited stage. Shared table encoder factored into `writeDpiTable()`.

## checks

`npm run build && npm test` - gearhub suite 38/38, full suite green (one unrelated pre-existing Corsair locale test aside). New tests cover the 3009/R3 profile resolution, the generic fallback, per-stage colour read + write, and active-stage switching + clamping.