### PR TITLE
feat(incott): add Incott driver (G23V2Pro / 8K wireless)

### DIFF
--- a/captures/incott-8k-wireless/README.md
+++ b/captures/incott-8k-wireless/README.md
@@ -1,0 +1,77 @@
+# Incott 8K wireless mouse fixtures
+
+Hardware-verified reference material for `src/incott/` and
+`src/drivers/incott/`. Everything here was captured from an "incott 8K
+wireless mouse" (VID `0x093A`, PID `0x522C`, manufacturer string "Pixart
+Imaging, Inc.") over its `0xFF05` vendor collection, using node-hid.
+
+Three capture sessions now exist, at increasing trust:
+1. **2026-09-07, read-only node-hid probes** (`targeted-reads.hex`,
+   `query-sweep-0x80-0x8f.hex`, `repeatability.hex`, `device-enumeration.txt`)
+   — no write was ever sent.
+2. **2026-09-07, vendor-tool session** (`vendor-tool-session.hex`) — the
+   vendor's own WebHID configurator talking to a second unit (a G23V2Pro).
+3. **2026-09-08, write round-trip session** (`write-roundtrip.hex`) — node-hid
+   directly against hardware again, but this time performing real writes,
+   reading each one back, and restoring the original value afterwards. This
+   is the only session that confirms a write took effect rather than only
+   confirming that a query answers.
+
+| File | What it is |
+|---|---|
+| `write-roundtrip.hex` | **Highest-trust file here: real writes, read back, then restored.** Fixes the DPI stage-index write bug (byte 1 of the `0x02` write is a stage index 0-5, not a hardcoded constant), confirms `0x82` is the per-stage DPI value read, confirms the `0x81` polling-rate byte by watching it follow a write, cross-checks lift-off and motion sync's packed-byte-7 reads against their symmetric single-purpose reads, and adds a button-binding round-trip (new capability). |
+| `vendor-tool-session.hex` | **Ground truth for DPI and battery on a G23V2Pro.** Captured by instrumenting Incott's own WebHID configurator at incott.net/mouse/ (not a raw node-hid probe like the files below). Disproves the DPI-preset-index and 0x89-battery-byte assumptions this driver inherited from IncottHIDApp; also confirms lift-off, receiver LED, sleep and identity writes/reads, and records the unverified performance-mode writes. |
+| `targeted-reads.hex` | Replies to the specific queries the driver issues: `09 89` (status — NOT battery, see above), `09 84 00/02/03` (sensor: lift-off+motion sync, ripple, angle snap), `09 85 01/03` (timing: debounce, sleep), `09 88` (receiver LED). |
+| `query-sweep-0x80-0x8f.hex` | Replies to every opcode `0x80`-`0x8F` sent with no sub-command, to map out which commands answer at all. `0x80`, `0x87`, and `0x8a`-`0x8e` never answered THIS WAY — `0x8e` in particular only answers sub-command `0x01`, not `0x00`; see `vendor-tool-session.hex`. This is also why `0x82`'s DPI stage table and `0x86`'s buttons were missed here: they only ever answer on a non-zero sub-command, and this sweep only ever tried `0x00`. |
+| `device-enumeration.txt` | The device's 8 HID collections (wireless, 0x522C) and which interface carries the vendor protocol. |
+| `wired-device-enumeration.txt` | **2026-09-08, wired (0x622C).** Interface 2 exposes TWO `0xFF05` collections, indistinguishable by vendor/product id or usage page — only one answers feature reports, the other fails `HidD_SetFeature` outright. Also captures the wired product string, "incott Esports G23V2Pro mouse" — the real model name, absent from the wireless dongle's generic string. This is the capture behind the wired-mode fix in `incottProbeCollection`/`incottSelectCollection` (`src/drivers/incott/hid.ts`). |
+| `repeatability.hex` | The same query returned three different payloads across three separate runs — the finding that shaped the driver's entire transaction discipline. |
+
+## The single most important protocol fact
+
+Repeating the *same* query (`09 84 00`) returned *different* payloads across
+runs, with nothing else changed:
+
+```
+run A:   09 84 00 04 00 0f 0f 01
+run B:   09 84 00 0e 00 f1 00 00
+sweep:   09 84 00 01 00 00 00 00
+```
+
+The device latches a single shared response buffer. A read issued too early,
+or issued right after a *different* query, can hand back a frame that
+belongs to that earlier query rather than the one just sent. This is why
+`IncottTransactionQueue` (`src/drivers/incott/hid.ts`) serializes every
+request, discards whatever is already latched before sending, and only
+accepts a reply whose report ID, command byte, and — for `0x83`/`0x84`/`0x85`
+only — sub-command byte all echo the request. See `repeatability.hex` for the
+full detail and `src/incott/index.ts`'s `incottFrameMatches()` for the check
+itself.
+
+The sub-command echo is matched **only** for `0x83`/`0x84`/`0x85`. For
+`0x81`/`0x88`/`0x89`/`0x8f`, byte 2 of the reply is *data*, not an echoed
+sub-command — matching it there would reject every polling rate but 1000 Hz
+and every LED mode but 0.
+
+## What is confirmed vs. unconfirmed
+
+Confirmed by these captures:
+- `0x81` answers the polling-rate query; `0x83`/`0x06` answers the DPI query.
+- `0x84` (sensor) sub `0x00` carries lift-off + motion sync, `0x02` ripple
+  control, `0x03` angle snap.
+- `0x85` (timing) sub `0x01` carries debounce, `0x03` carries sleep.
+- `0x88` and `0x89` answer (receiver LED, status/battery).
+- `0x8f` answers with an identity payload whose byte layout is not decoded.
+- `0x80`, `0x87`, and `0x8a`-`0x8e` never answer on this hardware.
+
+Not confirmed — see `docs/incott-testing.md` for the full list of open
+questions this capture session did not resolve, including which byte of the
+`0x81` reply actually carries the polling rate, whether `0x89` byte 8 is
+really a battery percentage, and what `0x82`/`0x86` mean.
+
+## Attribution
+
+The command and opcode set these captures exercise was derived from the
+MIT-licensed [IncottHIDApp](https://github.com/romkazor/IncottHIDApp)
+(`device.go`). These captures are original data taken directly from hardware,
+not reproduced from that project.

--- a/captures/incott-8k-wireless/device-enumeration.txt
+++ b/captures/incott-8k-wireless/device-enumeration.txt
@@ -1,0 +1,20 @@
+Incott 8K wireless mouse — HID enumeration (Windows, node-hid), 2026-09-07
+093A:522C, manufacturer string "Pixart Imaging, Inc."
+
+The device exposes 8 HID collections across its interfaces. The vendor
+protocol this driver speaks lives on interface 3; the rest are ordinary
+mouse/keyboard/consumer/system collections unrelated to configuration.
+
+  interface  collection  usagePage  usage   role
+  ---------  ----------  ---------  ------  ----------------------------------
+  3          (top)       0xFF05     0x01    vendor protocol (this driver)
+  2          col03       0xFF00     0x01    unidentified vendor collection
+  2          col04       0xFF01     0x01    unidentified vendor collection
+  1          (top)       0x0001     0x02    boot mouse
+  0 or 2     col05       0x0001     0x06    keyboard
+  2          col01       0x000C     0x01    consumer control
+  2          col02       0x0001     0x0080  system control
+
+Only interface 3 (usage page 0xFF05) answered feature-report queries in this
+capture session; the 0xFF00 and 0xFF01 vendor collections on interface 2 were
+not probed and their purpose is unknown.

--- a/captures/incott-8k-wireless/input-report-battery.hex
+++ b/captures/incott-8k-wireless/input-report-battery.hex
@@ -1,0 +1,48 @@
+# Battery, hardware-relocated: the UNSOLICITED input report the mouse emits
+# on its vendor collection (report id 0x09) while it is actively being used —
+# NOT a feature-report reply to anything this driver sends. Captured across a
+# full charge cycle from roughly 60% to roughly 97% on 2026-09-08.
+#
+# Captured DIRECTLY with node-hid against an "incott 8K wireless mouse"
+# (093A:522C), reading raw `inputreport`-equivalent packets off the vendor
+# collection. Byte 0 is the report id; this is node-hid's raw buffer shape,
+# which INCLUDES the report id — unlike WebHID's `inputreport` event, whose
+# `data` DataView EXCLUDES it (the report id arrives separately as
+# `event.reportId`). So node-hid buf[1] here is WebHID's
+# `event.data.getUint8(0)`, and node-hid buf[2] is `event.data.getUint8(1)`.
+# See `incottDecodeInputStatus` in `src/incott/index.ts` for the codec that
+# takes the WebHID-shaped (report-id-excluded) bytes, and
+# `IncottHidClient.onInputReport` in `src/drivers/incott/hid.ts` for where the
+# WebHID event is unwrapped into that convention.
+#
+# The mouse only emits these reports while it is being used (moved or
+# clicked) — it does not emit them at rest, and there is no way to request
+# one on demand (no feature-report query answers with this data).
+
+# --- discharging, ~95% ---
+09 5f 10 04 00 0f 0f 10
+# byte 1 (node-hid) = 0x5f = 95 -> raw <= 100, so discharging: percent = 95.
+# byte 2 (node-hid) = 0x10 -> high nibble 1 = active DPI stage index,
+#   low nibble 0 = polling-rate index. Both independently confirmed at
+#   capture time via the feature reads: `09 83 06` -> stage 1, `09 81` byte 2
+#   -> wire 0 (1000 Hz).
+
+# --- charging (plugged into USB while still reporting the wireless collection), ~97% ---
+09 e1 10 04 00 0f 0f 10
+# byte 1 (node-hid) = 0xe1 = 225 -> raw > 100, so charging: percent = 225 - 128 = 97.
+# byte 2 (node-hid) unchanged at 0x10 (stage/polling did not change between
+# the two captures).
+
+# Decoding rule, hardware-verified in BOTH states above (matches
+# IncottHIDApp's parseStatus — unlike that project's other claims about this
+# device, this one is now independently confirmed on real hardware):
+#   raw = byte 1 (node-hid) / event.data.getUint8(0) (WebHID)
+#   raw > 100   -> charging,    level = raw - 128
+#   raw <= 100  -> discharging, level = raw
+#
+# This DISPROVES both earlier battery hypotheses: across this same full
+# charge cycle (~60% to ~97%), the 0x8e/sub 0x01 feature-report reply's byte 6
+# stayed the exact constant `09 8e 01 5a 04 84 38 01` (0x38 = 56) the entire
+# time — it never moved even as the real level visibly climbed. The 0x89
+# byte-8 hypothesis before it was disproven the same way (constant 0x5a = 90
+# across every capture ever taken). See docs/incott-testing.md.

--- a/captures/incott-8k-wireless/query-sweep-0x80-0x8f.hex
+++ b/captures/incott-8k-wireless/query-sweep-0x80-0x8f.hex
@@ -1,0 +1,53 @@
+# Full query opcode sweep 0x80-0x8F, one request per byte, no sub-command.
+# First 12 bytes of the 64-byte feature-report response; "no response" means
+# the device never answered within the capture's read budget.
+# Captured 2026-09-07 from an "incott 8K wireless mouse" (093A:522C) over the
+# 0xFF05 vendor collection with node-hid. Read-only: no write was ever sent.
+
+# request 09 80
+# no response
+
+# request 09 81 (query polling rate)
+09 81 00 04 00 0f 0f 01 00 00 00 00
+
+# request 09 82 (unidentified)
+09 82 00 07 00 00 00 00 00 00 00 00
+
+# request 09 83 (query DPI, no sub-command supplied)
+09 83 06 01 00 00 00 00 00 00 00 00
+
+# request 09 84 (query sensor, no sub-command supplied)
+09 84 00 01 00 00 00 00 00 00 00 00
+
+# request 09 85 (query timing, no sub-command supplied)
+09 85 00 01 00 00 00 00 00 00 00 00
+
+# request 09 86 (unidentified)
+09 86 00 01 00 f0 00 00 00 00 00 00
+
+# request 09 87
+# no response
+
+# request 09 88 (query receiver LED)
+09 88 00 00 00 00 00 00 00 00 00 00
+
+# request 09 89 (query status/battery)
+09 89 00 00 00 00 00 00 5a 00 00 00
+
+# request 09 8a
+# no response
+
+# request 09 8b
+# no response
+
+# request 09 8c
+# no response
+
+# request 09 8d
+# no response
+
+# request 09 8e
+# no response
+
+# request 09 8f (query identity)
+09 8f 01 0e 02 f0 f1 00 ff 00 00 00

--- a/captures/incott-8k-wireless/repeatability.hex
+++ b/captures/incott-8k-wireless/repeatability.hex
@@ -1,0 +1,24 @@
+# THE SINGLE MOST IMPORTANT PROTOCOL FACT IN THIS DIRECTORY.
+#
+# The same request, sent unchanged, returned three DIFFERENT payloads across
+# three separate capture runs against the same physical device (093A:522C),
+# 2026-09-07. Nothing else about the setup changed between runs.
+#
+# request 09 84 00 (query sensor, sub 0x00), run A:
+09 84 00 04 00 0f 0f 01
+
+# same request, run B:
+09 84 00 0e 00 f1 00 00
+
+# same request, taken during the 0x80-0x8F sweep (no sub-command supplied):
+09 84 00 01 00 00 00 00
+
+# This is why the driver in src/drivers/incott/hid.ts and the transaction
+# queue in src/drivers/incott/hid.ts (IncottTransactionQueue) never trust a
+# single read: every request flushes whatever is already latched in the
+# device's single shared response buffer before sending, then only accepts a
+# reply whose report ID, command byte, and (for 0x83/0x84/0x85 only)
+# sub-command byte all echo the request. A read that skips this discipline
+# will silently decode a stale frame left over from an earlier, unrelated
+# query as if it were the answer to the current one. See incottFrameMatches()
+# in src/incott/index.ts.

--- a/captures/incott-8k-wireless/targeted-reads.hex
+++ b/captures/incott-8k-wireless/targeted-reads.hex
@@ -1,0 +1,26 @@
+# Targeted reads: request bytes echoed as a comment, reply is the data line.
+# First 12 bytes of the 64-byte feature-report response (report ID at byte 0);
+# remaining bytes were not recorded but were zero in every capture taken.
+# Captured 2026-09-07 from an "incott 8K wireless mouse" (093A:522C) over the
+# 0xFF05 vendor collection with node-hid. Read-only: no write was ever sent.
+
+# request 09 89 (query status/battery)
+09 89 00 00 00 00 00 00 5a 00 00 00
+
+# request 09 84 00 (query sensor, sub 0x00 -> lift-off / motion sync)
+09 84 00 04 00 0f 0f 01 00 00 00 00
+
+# request 09 84 02 (query sensor, sub 0x02 -> ripple control)
+09 84 02 00 00 0f 0f 01 00 00 00 00
+
+# request 09 84 03 (query sensor, sub 0x03 -> angle snap)
+09 84 03 00 00 0f 0f 01 00 00 00 00
+
+# request 09 85 01 (query timing, sub 0x01 -> debounce)
+09 85 01 04 00 0f 0f 01 00 00 00 00
+
+# request 09 85 03 (query timing, sub 0x03 -> sleep)
+09 85 03 3c 00 0f 0f 01 00 00 00 00
+
+# request 09 88 (query receiver LED)
+09 88 00 00 00 00 00 00 00 00 00 00

--- a/captures/incott-8k-wireless/vendor-tool-session.hex
+++ b/captures/incott-8k-wireless/vendor-tool-session.hex
@@ -1,0 +1,108 @@
+# Vendor-tool session: DPI and battery ground truth.
+#
+# Captured 2026-09-07 by instrumenting Incott's OWN WebHID configurator at
+# incott.net/mouse/ — hooking HIDDevice.prototype.sendFeatureReport and
+# HIDDevice.prototype.receiveFeatureReport in the browser and recording the
+# real traffic the vendor tool exchanged with a real G23V2Pro. This is a
+# DIFFERENT, higher-trust capture session than targeted-reads.hex and
+# query-sweep-0x80-0x8f.hex (which were read-only probes taken directly with
+# node-hid, not through the vendor's own software) and it OUTRANKS every
+# assumption this driver inherited from the MIT-licensed IncottHIDApp.
+#
+# TX lines are feature-report payloads as sent to sendFeatureReport(0x09, …),
+# i.e. they OMIT the report id byte, matching what this driver's
+# incottEncode* functions build. RX lines are full feature reports as
+# returned by receiveFeatureReport(0x09), i.e. they INCLUDE the report id at
+# byte 0 — the same TX/RX asymmetry the rest of this driver already handles.
+#
+# This session disproved two things this driver used to assume:
+#   1. DPI was believed to be a 6-entry preset index written under command
+#      0x03. It is actually a linear little-endian uint16 written under
+#      command 0x02, sub-command 0x01 (see the two DPI lines below).
+#   2. Battery percentage was believed to be byte 8 of the 0x89 response
+#      (it read the constant 0x5a/90 on every capture ever taken, in every
+#      device state — see targeted-reads.hex and query-sweep-0x80-0x8f.hex).
+#      It is actually byte 6 of the 0x8e/sub-0x01 response (see the battery
+#      line below); 0x8e never answered in the earlier sweep because that
+#      sweep only ever tried sub-command 0x00.
+
+## DPI — command 0x02, sub 0x01, little-endian uint16 at payload bytes 2-3.
+## wire = dpi/50 - 1, dpi = (wire + 1) * 50.
+
+# TX: set DPI to 800 (wire 15 = 0x000f)
+TX 09 02 01 0f 00
+# The vendor UI showed "800" immediately after this write.
+
+# TX: set DPI to 25000 (wire 499 = 0x01f3)
+TX 09 02 01 f3 01
+# The vendor UI showed "25000" immediately after this write. 25000 is inside
+# even the lower of the two known sensor ceilings (PAW3395: 32000), so this
+# alone does not tell us which sensor variant is fitted; see INCOTT_DPI_MAX
+# in src/incott/index.ts for how the driver handles that.
+
+## DPI stage query — command 0x83, sub 0x06. Returns the ACTIVE STAGE INDEX
+## (0-5) into the vendor's six default stage presets, NOT the DPI value
+## written above. This is the same request/reply shape earlier captures
+## already recorded (targeted-reads.hex has nothing for this sub-command, but
+## query-sweep-0x80-0x8f.hex's bare "09 83" sweep got back "09 83 06 01",
+## which this driver used to (mis)decode as index 1 -> 800 DPI, matching the
+## vendor UI only because the device happened to be on stage 1 of 6 at that
+## moment).
+
+TX 09 83 00
+RX 09 83 06 01 00 00 00 00
+
+## Battery — command 0x8e, sub 0x01. Percentage is the EXACT value at byte 6.
+## The earlier opcode sweep only ever tried 0x8e with sub-command 0x00 and
+## got no answer, and concluded "0x8e never answered" — sub-commands are not
+## optional on this opcode. The same lesson applies to 0x86, which the vendor
+## tool queries as "09 86 09" (payload meaning still undecoded).
+
+TX 09 8e 01
+RX 09 8e 01 5a 04 84 38 01 00
+# Byte 6 = 0x38 = 56 (decimal). The vendor UI displayed "60%" for this exact
+# reading — confirmed directly by the person who captured this session to be
+# the vendor UI rounding to the nearest 10%, not a different underlying
+# value. This driver reports the exact 56, not the rounded 60.
+
+## Performance mode — command 0x04, sub 0x05, one byte value. The vendor UI's
+## "Performance mode" control (HP / Corded / LP, described as trading
+## performance for battery life) was switched between two of its three
+## positions during this session:
+
+TX 09 04 05 02
+TX 09 04 05 01
+# Only the writes were captured, NOT which on-screen label (HP / Corded / LP)
+# produced which value. Do not assume an order — see
+# incottEncodeSetPerformanceMode in src/incott/index.ts and
+# docs/incott-testing.md's open questions.
+
+## Lift-off — command 0x04, sub 0x01. Confirms the write shape this driver
+## already used (incottEncodeSetLiftOff); it does NOT settle which on-screen
+## label (0.7 / 1 / 2 mm) produced which hardware value:
+
+TX 09 04 01 02
+TX 09 04 01 00
+# See the UNRESOLVED CONFLICT comment on INCOTT_LOD_WIRE_TO_TENTHS in
+# src/incott/index.ts and the matching open question in
+# docs/incott-testing.md.
+
+## Receiver LED — command 0x08, one byte value. Confirms the write shape this
+## driver already used (incottEncodeSetReceiverLed):
+
+TX 09 08 00
+TX 09 08 01
+TX 09 08 02
+
+## Sleep timer read — command 0x85, sub 0x03. Confirms the decode this driver
+## already used (incottDecodeSleep):
+
+TX 09 85 03
+RX 09 85 03 3c 00 00 00 00 00
+# 0x3c 0x00 little-endian = 60 seconds.
+
+## Identity — command 0x8f. Confirms the decode this driver already used
+## (incottDecodeIdentity):
+
+TX 09 8f 00
+RX 09 8f 01 0e 02 f0 f1 00 ff

--- a/captures/incott-8k-wireless/wired-device-enumeration.txt
+++ b/captures/incott-8k-wireless/wired-device-enumeration.txt
@@ -1,0 +1,46 @@
+Incott G23V2Pro — WIRED HID enumeration (Windows, node-hid), 2026-09-08
+093A:622C, product string "incott Esports G23V2Pro mouse"
+
+Same physical mouse as the rest of this fixture directory (VID 0x093A),
+captured plugged into USB instead of over the 2.4 GHz dongle. Two things
+differ from the wireless enumeration in `device-enumeration.txt`:
+
+  1. The product id is 0x622C, not 0x522C.
+  2. The product string carries the real model name — "incott Esports
+     G23V2Pro mouse" — where the wireless dongle reports only the generic
+     "incott 8K wireless mouse" with no model in it at all. See
+     `incottNormalizeProductName` in `src/incott/index.ts`.
+
+THE HEADLINE FINDING: interface 2 exposes TWO top-level collections on usage
+page 0xFF05, both usage 0x01 — indistinguishable by vendor id, product id, or
+usage page alone:
+
+  interface  collection  usagePage  usage   feature-report probe (09 8f 00)
+  ---------  ----------  ---------  ------  --------------------------------
+  2          col-a       0xFF05     0x01    HidD_SetFeature: (0x00000001)
+                                             Incorrect function — DEAD
+  2          col-b       0xFF05     0x01    RX 09 8f 01 0e 02 f0 f1 00 ff
+                                             — LIVE, this is the vendor
+                                             protocol
+
+Every read and every write this driver issues failed 100% of the time before
+this was diagnosed, because collection selection previously trusted usage
+page alone and took the FIRST 0xFF05 match — which on this hardware happens
+to be the dead one. There is no other observable difference between the two
+collections' descriptors that would let usage-page matching alone tell them
+apart; only sending something and checking for a real reply does.
+
+THE FIX (see `incottProbeCollection`/`incottSelectCollection` and
+`IncottHidClient.open()` in `src/drivers/incott/hid.ts`): probe a candidate
+with the identity query (`09 8f 00`) and require a well-formed reply (byte 0
+= report id 0x09, byte 1 = 0x8f) before trusting it, trying 0xFF05 candidates
+first, then any page >= 0xFF00 as a fallback. In the browser, WebHID hands
+this driver exactly one HIDDevice per collection — already chosen by the
+picker/filters before the driver ever sees it — so there is no second
+candidate to fall back to at that layer; `open()` instead probes the single
+collection it was given and `readStatus()` degrades gracefully
+(`ui.settingsReady: false`) rather than throwing when it is the dead one.
+
+Remaining rows are unchanged from the wireless enumeration (boot mouse,
+keyboard, consumer control, system control collections) and were not
+re-captured here since nothing about them changed.

--- a/captures/incott-8k-wireless/write-roundtrip.hex
+++ b/captures/incott-8k-wireless/write-roundtrip.hex
@@ -1,0 +1,255 @@
+# Write round-trip session: DPI stage table, polling rate, lift-off, motion
+# sync, and buttons — all verified on real hardware.
+#
+# Captured 2026-09-08 using node-hid DIRECTLY against an "incott 8K wireless
+# mouse" (093A:522C) — not through the vendor's own configurator, unlike
+# vendor-tool-session.hex. Every value this session wrote was READ BACK and
+# then RESTORED to what the device held before the write, so the device was
+# left in the same state it started in. This is the highest-trust session in
+# this directory for the facts it covers, because it is the only one that
+# performed real writes and confirmed them with a read-back before undoing
+# them.
+#
+# TX lines omit the report id byte (0x09), matching what this driver's
+# incottEncode* functions build for sendFeatureReport(0x09, …). RX lines
+# include the report id at byte 0, matching receiveFeatureReport(0x09).
+
+## ---------------------------------------------------------------------
+## DPI stage table — command 0x02 (write) / 0x82 (read), byte 1 is a STAGE
+## INDEX (0-5), not a fixed sub-command. This is the bug fix: the driver used
+## to hardcode byte 1 as a constant 0x01, so it could only ever write stage 1.
+## ---------------------------------------------------------------------
+
+# Reading all six stages independently — six points on the wire = dpi/50 - 1
+# line, proving DPI is linear, not an index into a preset table:
+TX 09 82 00
+RX 09 82 00 07 00 00 00 00
+# wire 0x07 -> (7+1)*50 = 400 DPI
+
+TX 09 82 01
+RX 09 82 01 0f 00 00 00 00
+# wire 0x0f -> (15+1)*50 = 800 DPI
+
+TX 09 82 02
+RX 09 82 02 1f 00 00 00 00
+# wire 0x1f -> (31+1)*50 = 1600 DPI
+
+TX 09 82 03
+RX 09 82 03 2f 00 00 00 00
+# wire 0x2f -> (47+1)*50 = 2400 DPI
+
+TX 09 82 04
+RX 09 82 04 3f 00 00 00 00
+# wire 0x3f -> (63+1)*50 = 3200 DPI
+
+TX 09 82 05
+RX 09 82 05 7f 00 00 00 00
+# wire 0x7f -> (127+1)*50 = 6400 DPI
+
+# 0x82 echoes its sub-command (confirmed by every RX line above carrying the
+# requested stage back at byte 2) — it is added to SUB_ECHOING_QUERIES in
+# src/drivers/incott/hid.ts alongside 0x83/0x84/0x85/0x86/0x8e.
+
+# Write/read-back/restore round-trip on stage 2 (was 1600 DPI, wire 0x1f):
+TX 09 02 02 f3 01
+# wire 499 = 25000/50 - 1
+TX 09 82 02
+RX 09 82 02 f3 01 00 00 00
+# Read back exactly 25000 DPI — confirms the write landed as written.
+
+TX 09 02 02 1f 00
+# Restoring wire 31 = 1600 DPI, the original value.
+TX 09 82 02
+RX 09 82 02 1f 00 00 00 00
+# Read back exactly 1600 DPI — the device was left as it started.
+
+## ---------------------------------------------------------------------
+## Active DPI stage index — command 0x83, sub 0x06. Unchanged by this
+## session; recorded here because MouseStatus.dpi now depends on it (read the
+## active stage index, then that stage's value via 0x82).
+## ---------------------------------------------------------------------
+
+TX 09 83 06
+RX 09 83 06 01 00 00 00 00
+# Stage 1 of 6 active on this unit at capture time.
+
+## ---------------------------------------------------------------------
+## Polling rate — command 0x01 (write) / 0x81 (read). Byte 2 of the 0x81
+## reply is DATA, not an echoed sub-command; confirmed by writing two
+## different wire values in sequence and watching byte 2 follow.
+## ---------------------------------------------------------------------
+
+TX 09 01 01
+# wire 1 = 500 Hz
+TX 09 81 00
+RX 09 81 01 00 00 00 00 00
+# Byte 2 = 0x01, following the write.
+
+TX 09 01 00
+# wire 0 = 1000 Hz
+TX 09 81 00
+RX 09 81 00 00 00 00 00 00
+# Byte 2 = 0x00, following the write. 0 -> 1 -> 0 confirms this is genuinely
+# the polling-rate byte, kept OUT of SUB_ECHOING_QUERIES (it is data here,
+# not an echo — matching it as a sub-command would reject every rate but
+# 1000 Hz).
+
+## ---------------------------------------------------------------------
+## Lift-off — command 0x04 sub 0x01 (write) / 0x84 sub 0x01 (read, the
+## symmetric single-purpose form) and 0x84 sub 0x00 byte 7 high nibble (the
+## packed form this driver used before). Both forms were read after each
+## write and agreed at every step.
+## ---------------------------------------------------------------------
+
+TX 09 04 01 00
+TX 09 84 01
+RX 09 84 01 00 00 00 00 00
+# Symmetric read: byte 3 = 0x00.
+TX 09 84 00
+RX 09 84 00 00 00 00 00 01
+# Packed read: byte 7 high nibble = 0x0 -> matches.
+
+TX 09 04 01 01
+TX 09 84 01
+RX 09 84 01 01 00 00 00 00
+# Symmetric read: byte 3 = 0x01.
+TX 09 84 00
+RX 09 84 00 00 00 00 00 11
+# Packed read: byte 7 high nibble = 0x1 -> matches.
+
+TX 09 04 01 02
+TX 09 84 01
+RX 09 84 01 02 00 00 00 00
+# Symmetric read: byte 3 = 0x02.
+TX 09 84 00
+RX 09 84 00 00 00 00 00 21
+# Packed read: byte 7 high nibble = 0x2 -> matches.
+
+# Restored to hw 0x00 (the value observed before this sequence started) after
+# the check above.
+TX 09 04 01 00
+
+## ---------------------------------------------------------------------
+## Motion sync — command 0x04 sub 0x04 (write) / 0x84 sub 0x04 (read, the
+## symmetric single-purpose form) and 0x84 sub 0x00 byte 7 low nibble (the
+## packed form). Both forms were read after each write and agreed.
+## ---------------------------------------------------------------------
+
+TX 09 04 04 00
+TX 09 84 04
+RX 09 84 04 00 00 00 00 00
+# Symmetric read: byte 3 = 0x00 (off).
+TX 09 84 00
+RX 09 84 00 00 00 00 00 00
+# Packed read: byte 7 low nibble = 0x0 -> matches.
+
+TX 09 04 04 01
+TX 09 84 04
+RX 09 84 04 01 00 00 00 00
+# Symmetric read: byte 3 = 0x01 (on).
+TX 09 84 00
+RX 09 84 00 00 00 00 00 01
+# Packed read: byte 7 low nibble = 0x1 -> matches.
+
+TX 09 04 04 00
+TX 09 84 04
+RX 09 84 04 00 00 00 00 00
+# Symmetric read: byte 3 = 0x00 (off) — restored to the value observed before
+# this sequence started.
+TX 09 84 00
+RX 09 84 00 00 00 00 00 00
+# Packed read: byte 7 low nibble = 0x0 -> matches.
+
+## ---------------------------------------------------------------------
+## Buttons — command 0x06 (write) / 0x86 (read). New capability this session;
+## the meaning of the three payload bytes (key code / macro / remap) is NOT
+## established and is not decoded beyond the raw bytes — see
+## incottDecodeButtonBinding in src/incott/index.ts.
+## ---------------------------------------------------------------------
+
+TX 09 06 00 01 00 f0
+TX 09 86 00
+RX 09 86 00 01 00 f0 00 00
+# Byte-for-byte match with the write above — round-trip confirmed.
+
+# Reading all six buttons without writing them (left, right, middle, forward,
+# back, DPI — physically, in some order not established by this capture):
+TX 09 86 00
+RX 09 86 00 01 00 f0 00 00
+TX 09 86 01
+RX 09 86 01 01 00 f1 00 00
+TX 09 86 02
+RX 09 86 02 01 00 f2 00 00
+TX 09 86 03
+RX 09 86 03 01 00 f3 00 00
+TX 09 86 04
+RX 09 86 04 01 00 f4 00 00
+TX 09 86 05
+RX 09 86 05 07 00 03 00 00
+# Button 5 (DPI) carries a visibly different payload shape (07 00 03) from
+# the other five (01 00 fN) — consistent with it being a different kind of
+# action (a DPI-cycle function) rather than a key, but this is an inference,
+# not something this capture decodes.
+
+## ---------------------------------------------------------------------
+## Active DPI stage SELECT — command 0x03, sub 0x06 (write) / 0x83, sub 0x06
+## (read). Added 2026-09-08 in response to an owner report: the driver's
+## setDpi() was reading the active stage and writing the requested DPI INTO
+## it, silently overwriting the stage's stored value (one owner's stage 2 was
+## found changed from 1600 to 800 this way). This section proves selecting a
+## stage and editing a stage's value are genuinely different operations: the
+## unit under test started on stage 1 (see the 0x83/0x06 read earlier in this
+## file); every write below is a SELECT (0x03), and the stage table (read via
+## 0x82 for all six stages) was re-read after the sequence and found
+## byte-for-byte unchanged from the six-stage read at the top of this file.
+##
+## IncottHIDApp labels this same 0x03/0x06 write "set DPI" and treats its six
+## "DPI presets" as if picking one changes the DPI value — it does not; it
+## only changes which already-stored stage answers as active. That mislabel
+## is the root of the confusion this fix addresses; do not re-introduce it.
+## ---------------------------------------------------------------------
+
+TX 09 03 06 00
+TX 09 83 06
+RX 09 83 06 00 00 00 00 00
+# Selected stage 0; read back confirms stage 0 is now active.
+
+TX 09 03 06 03
+TX 09 83 06
+RX 09 83 06 03 00 00 00 00
+# Selected stage 3; read back confirms stage 3 is now active.
+
+TX 09 03 06 05
+TX 09 83 06
+RX 09 83 06 05 00 00 00 00
+# Selected stage 5; read back confirms stage 5 is now active.
+
+TX 09 03 06 01
+TX 09 83 06
+RX 09 83 06 01 00 00 00 00
+# Restored the original active stage (1), the value observed before this
+# sequence started (see the 0x83/0x06 read earlier in this file).
+
+# Re-reading all six stages after the four selects above — table completely
+# unchanged from the six-stage read at the top of this file, proving a select
+# never edits a stored value:
+TX 09 82 00
+RX 09 82 00 07 00 00 00 00
+TX 09 82 01
+RX 09 82 01 0f 00 00 00 00
+TX 09 82 02
+RX 09 82 02 1f 00 00 00 00
+TX 09 82 03
+RX 09 82 03 2f 00 00 00 00
+TX 09 82 04
+RX 09 82 04 3f 00 00 00 00
+TX 09 82 05
+RX 09 82 05 7f 00 00 00 00
+# Identical to the six-stage read at the top of this file (400/800/1600/2400/
+# 3200/6400 DPI) — the four active-stage selects above left the table
+# completely untouched.
+
+## Attribution: the opcode set exercised here was established by earlier
+## capture sessions in this directory (see README.md) and by the MIT-licensed
+## IncottHIDApp. This file's data — every byte sequence above — is original,
+## taken directly from hardware with node-hid.

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -1,0 +1,678 @@
+# Incott hardware testing
+
+Hardware: an "incott 8K wireless mouse" over its 2.4 GHz dongle (VID
+`0x093A`, PID `0x522C`, manufacturer string "Pixart Imaging, Inc."), and the
+SAME physical mouse plugged in over USB (PID `0x622C`, product string "incott
+Esports G23V2Pro mouse" — the real model name). Both product ids are now
+directly hardware-verified — see "Four bugs found probing wired AND wireless
+hardware" below; `0x622C` was previously only inferred, not observed
+directly.
+
+Wireless, the vendor protocol answers on interface 3, the sole `0xFF05`
+collection. Wired, the picture is more complicated — see below. See
+`captures/incott-8k-wireless/` for the raw data this document summarizes.
+
+## Battery relocated to an unsolicited input report; receiver LED scoped to wireless (2026-09-08)
+
+These are the newest findings, superseding the "Four bugs" section below on
+battery specifically.
+
+### Battery is an UNSOLICITED INPUT report, not a feature-report reply — both prior hypotheses disproven
+
+The `0x8e`/sub `0x01` byte-6 reading (see "Battery" further down, and the
+"Disproven: 0x89 byte 8" section) was itself disproven by a **full charge
+cycle**: charging a unit from roughly 60% to roughly 97% while polling that
+feature-report reply showed byte 6 **never change at all** — the identical
+frame `09 8e 01 5a 04 84 38 01` the entire time, `0x38` = 56 throughout. A
+value that does not move while the real battery level visibly does cannot be
+a battery reading. This is the second battery hypothesis disproven this way
+(the first, `0x89` byte 8, was a constant `0x5a`/90 across every capture ever
+taken — see below); **two disproven battery hypotheses on the same device is
+exactly the kind of dead end this document exists to record.**
+
+The real battery level lives in an **unsolicited INPUT report** the mouse
+emits on its vendor collection (report id `0x09`) while it is actively being
+used (moved or clicked) — not a reply to any request this driver sends, and
+not obtainable on demand. Captured directly with node-hid across the same
+full charge cycle:
+
+```
+discharging: 09 5f 10 04 00 0f 0f 10   byte 1 = 0x5f = 95   -> 95%
+charging:    09 e1 10 04 00 0f 0f 10   byte 1 = 0xe1 = 225  -> charging, 225-128 = 97%
+```
+
+Decoding rule, verified in both states above (matches IncottHIDApp's
+`parseStatus` — unlike that project's other claims about this device, this
+one is now independently hardware-confirmed):
+
+```
+raw = byte 1 (node-hid buf[1] / WebHID event.data.getUint8(0))
+raw > 100   -> charging,    level = raw - 128
+raw <= 100  -> discharging, level = raw
+```
+
+Byte 2 of the same report (`0x10` in both captures above) is a packed pair,
+ALSO verified: high nibble = active DPI **stage index** (0-5, the same value
+`0x83`/`0x06` reports), low nibble = polling-rate index (into
+`INCOTT_POLLING_WIRE_TO_HZ`). Both nibbles independently matched what the
+feature reads returned at the same moment (`09 83 06` -> stage 1, `09 81`
+byte 2 -> wire 0). This is a corroborating cross-check only — `readStatus()`
+still treats the `0x83`/`0x81` feature reads as authoritative for DPI stage
+and polling rate, not this packed byte.
+
+See `captures/incott-8k-wireless/input-report-battery.hex` for the full
+capture and byte-index notes, and `incottDecodeInputStatus` /
+`IncottHidClient.onInputReport` for the codec and the WebHID listener.
+
+**CRITICAL BYTE-INDEX ASYMMETRY, same class of trap as the feature-report one
+documented in "Read-only transaction discipline" below**: the captures above
+were taken with node-hid, whose raw input buffer INCLUDES the report id at
+index 0. WebHID's `inputreport` event is different — it carries `reportId` as
+a separate property, and its `data` DataView EXCLUDES the report id. So:
+
+```
+node-hid buf[1]  ==  WebHID event.data.getUint8(0)
+node-hid buf[2]  ==  WebHID event.data.getUint8(1)
+```
+
+`incottDecodeInputStatus` is written against the WebHID convention (report id
+excluded) — the same convention every `incottEncode*` function in this module
+already uses for outgoing feature reports — and `onInputReport` unwraps the
+WebHID event into it. Get this backwards and every field reads off by one
+byte.
+
+`IncottHidClient` caches the most recently decoded report and its charging
+bit; `readStatus()` reports the cached values. The device only emits these
+while in use, so **until the first report arrives, battery is `null` and
+`batteryState` is `"Unknown"`** — no fabricated number, and no fallback to
+the disproven feature-report bytes. The charging state comes from the
+report's own bit (`raw > 100`), not from the product id: `incottIsWiredProduct`
+(`0x622C`) still means the CONNECTION is wired (which `connectionType` uses),
+and being wired does imply charging in practice, but the report is the
+authoritative source, not an inference from the product id.
+
+### Receiver LED is meaningless over USB — not currently advertised anywhere, so nothing to hide yet
+
+The receiver LED (`0x08` write / `0x88` read, `IncottHidClient.setReceiverLed`)
+is a property of the 2.4 GHz dongle and has no meaning when the mouse is
+wired (`incottIsWiredProduct` true) — there is no dongle in that mode.
+Checked `MouseUiHints` in `src/drivers/mouse-types.ts` for an existing `hide*`
+flag to gate this and found none scoped to the receiver LED (the closest,
+`hideSignalCard`, is about link-quality telemetry, a different control).
+Deliberately did **not** add a new flag to that shared contract: `setReceiverLed`
+is not wired into `MouseStatus`/the app's generic UI for Incott at all today
+(same status as `setPerformanceMode` — a codec + client method kept for
+protocol parity, per the class comment on `setReceiverLed` in
+`src/drivers/incott/hid.ts`), so there is currently no advertised control to
+hide. A comment at `setReceiverLed` records this for whoever wires the
+control up later.
+
+## Four bugs found probing wired AND wireless hardware (2026-09-08)
+
+All four of the following were found by probing the owner's mouse in BOTH
+wireless and wired modes, and are the newest, highest-trust findings in this
+document — see `captures/incott-8k-wireless/wired-device-enumeration.txt` for
+the wired capture.
+
+### 1. Wired mode was completely broken: two look-alike 0xFF05 collections, only one live
+
+Wired, interface 2 exposes TWO top-level collections on usage page `0xFF05`
+(both usage `0x01`) — indistinguishable by vendor id, product id, or usage
+page. The FIRST one rejects every feature report: Windows returns
+`HidD_SetFeature: (0x00000001) Incorrect function`. The SECOND one is the
+real vendor protocol. Wireless, by contrast, there is exactly one `0xFF05`
+collection (interface 3) and it works — which is why this went unnoticed
+until someone tried the mouse wired.
+
+The driver used to pick the first `0xFF05` match (falling back to any page
+`>= 0xFF00`), so wired it always picked the dead collection and every read
+and write failed — 100% failure, not an intermittent one.
+
+**The fix**: never trust usage page alone. `incottProbeCollection`
+(`src/drivers/incott/hid.ts`) sends the identity query (`09 8f 00`) and
+requires a well-formed reply (byte 0 = report id `0x09`, byte 1 = `0x8f`)
+before accepting a collection; `incottSelectCollection` tries candidates in
+order — `0xFF05` first, then any page `>= 0xFF00` — and moves on when one
+throws or never replies.
+
+**The WebHID constraint**: a WebHID `HIDDevice` corresponds to a single
+collection, and the browser's picker/filters — not this driver — decide
+which one the app receives. So `IncottHidClient.isSupported` stays
+permissive (it must, or it would just as easily reject the live collection,
+which looks identical from vendor/product id and usage page), and
+`IncottHidClient.open()` probes the one collection it was handed instead of
+choosing between several: it never throws, and records the result so
+`readStatus()` can skip straight to a fully degraded, `ui.settingsReady:
+false` status (the existing graceful-degradation path) rather than spending
+its full retry budget on roughly a dozen queries a known-dead collection
+cannot answer either. `IncottHidClient.filters` already requested both
+product ids (`0x522C` and `0x622C`) before this fix.
+
+### 2. 0x622C means WIRED, not "charging"
+
+Verified: plugged into USB the device enumerates as product id `0x622C`; on
+the 2.4 GHz dongle it is `0x522C`. The driver used to treat `0x622C` as a
+charging FLAG (`incottIsChargingProduct`) — the wrong axis. It is really the
+CONNECTION type; charging is a consequence of being plugged in, not what the
+id itself encodes.
+
+**The fix**: `MouseStatus.connectionType` is now `"Wired"` for `0x622C` and
+`"Wireless"` for `0x522C`. `batteryState: "Charging"` is kept for `0x622C`
+(it genuinely is charging) but is now derived from the connection via the
+renamed helper `incottIsWiredProduct` (`src/incott/index.ts`), not from a
+constant that claimed to mean "charging."
+
+### 3. The polling-rate ceiling depends on the connection
+
+The owner confirmed the mouse only reaches 1000 Hz over the cable; 2000/4000/
+8000 Hz are wireless-only. Publishing the full 125-8000 Hz ladder while wired
+would let the shell offer a rate the device silently refuses, which
+`setPollingRate`'s read-back verification would then report as a failure on
+every attempt — indistinguishable from a genuine device fault.
+
+**The fix**: `readStatus()` now publishes `supportedPollingRates` from
+`INCOTT_POLLING_STEPS_HZ_WIRED` (`[125, 250, 500, 1000]`) when
+`incottIsWiredProduct` is true, and the full `INCOTT_POLLING_STEPS_HZ` ladder
+otherwise, alongside `ui.hideUnsupportedPollingRates: true` and an
+`ui.pollingNote` footnote naming the ceiling for the current connection (the
+same pattern MCHOSE and G-Wolves already use for their own connection-
+dependent ceilings).
+
+### 4. The real model name is only in the wired product string
+
+Verified product strings:
+```
+wired    (0x622C): "incott Esports G23V2Pro mouse"    <- the REAL model
+wireless (0x522C): "incott 8K wireless mouse"          <- the dongle's generic name
+```
+
+**The fix**: `MouseStatus.name` still comes from the HID product string, but
+`incottNormalizeProductName` (`src/incott/index.ts`) now tidies it for
+display — stripping a leading vendor word ("incott") and a trailing "mouse"
+when present — so "incott Esports G23V2Pro mouse" reads as "Esports
+G23V2Pro". The raw string is untouched and stays available as
+`client.device.productName`. This does NOT hardcode a model table and does
+NOT infer a model when wireless: there is no way to read the model over the
+air, and guessing one would be a fabricated value, so the wireless name
+simply normalizes down to "8K wireless" — tidied, not invented.
+
+The identity query's reply (`09 8f 00` -> `01 0e 02 f0 f1 00 ff`) has still
+NOT been decoded (see "Unresolved unknowns" below), so it is not currently a
+source for the model name either, wired or wireless.
+
+### Not a bug: motion sync reading OFF while the vendor tool displays ON
+
+With the vendor tool reporting motion sync ON, BOTH of this driver's
+independent reads reported OFF: `0x84` sub `0x04` byte 3 = 0, and `0x84` sub
+`0x00` byte 7's low nibble = 0. These are two separately-implemented decoders
+(`incottDecodeToggle`/`incottDecodeMotionSync`) reading two different byte
+positions in two different response frames, and they agree with each other
+against the vendor tool's display. Two independent reads agreeing with one
+another, both disagreeing with a single vendor-tool display, points at the
+vendor tool rather than at this driver's decode: the most likely explanation
+is that the vendor tool renders its own last-WRITTEN value rather than
+re-reading the device, so it never shows a change made outside its own
+session. This is left as an observation, not a defect — the decoders were
+NOT changed.
+
+## Three capture sessions, three trust levels
+
+There are now three capture sessions in `captures/incott-8k-wireless/`, and
+they do not carry equal weight:
+
+1. **2026-09-07, read-only node-hid probes** (`targeted-reads.hex`,
+   `query-sweep-0x80-0x8f.hex`, `repeatability.hex`, `device-enumeration.txt`).
+   No write was ever sent; these only confirm which opcodes answer and what
+   their raw bytes look like.
+2. **2026-09-07, vendor-tool session** (`vendor-tool-session.hex`) — captured
+   by instrumenting Incott's own WebHID configurator at incott.net/mouse/
+   (hooking `HIDDevice.prototype.sendFeatureReport` /
+   `receiveFeatureReport`) against a real G23V2Pro. Ground truth for that
+   session's claims: it is the vendor's own software talking to the vendor's
+   own device.
+3. **2026-09-08, write round-trip session** (`write-roundtrip.hex`) —
+   node-hid directly against hardware again, but this time performing real
+   writes, reading each one back, and restoring the original value
+   afterwards. This is the **highest-trust session**: it is the only one that
+   confirms a write actually took effect (by reading it back) rather than
+   only confirming that a query answers.
+
+## Verified on hardware
+
+Everything in this section was read back and, where a write was involved,
+restored afterwards — see `captures/incott-8k-wireless/write-roundtrip.hex`
+unless noted otherwise.
+
+### DPI is a six-stage table with FOUR independent commands, not one (2026-09-08)
+
+DPI lives in a **six-stage table**, not a single value, and there are **four
+genuinely independent operations** on it — two concerns (which stage is
+active, and what a stage holds), each with its own read and write:
+
+|                    | Read | Write |
+|---|---|---|
+| **which stage is active** | `09 83 06` -> response byte 3 (0-5) | `09 03 06 <idx>` |
+| **what a stage holds** | `09 82 <stage>` -> RESPONSE bytes 3-4 (LE16) | `09 02 <stage> <lo> <hi>` |
+
+Each stage's value is a linear little-endian uint16 "wire" value:
+
+```
+wire = dpi / 50 - 1        dpi = (wire + 1) * 50
+```
+
+Proof the value is linear: reading stages 0-5 returned wire `0x07`/`0x0f`/
+`0x1f`/`0x2f`/`0x3f`/`0x7f` = 400/800/1600/2400/3200/6400 DPI — six
+independent points on the `wire = dpi/50 - 1` line, ruling out an
+index-into-presets interpretation. Writing 25000 to stage 2 read back as
+exactly 25000; restoring 1600 read back as exactly 1600.
+
+**Select and edit are distinct operations — verified separately.** Selecting
+stage 0, then 3, then 5, then 1 in turn each read back correctly via
+`0x83`/`0x06`, and re-reading all six stages via `0x82` after those four
+selects showed the table's stored values **completely unchanged**. A select
+never edits; an edit never changes which stage is active. See
+`captures/incott-8k-wireless/write-roundtrip.hex` for both the six-stage
+value proof and the select-vs-edit proof.
+
+**THE FIRST DPI BUG (fixed earlier the same day)**: `incottEncodeSetDpi`
+used to hardcode the write's second byte as a constant `0x01` (previously
+exported as `INCOTT_SUB_SET_DPI`, now removed), so it could only ever write
+stage 1 of the table — writing while stage 3 was active, for example,
+silently edited the wrong stage. That byte is a **stage index**, not a fixed
+sub-command; see `INCOTT_DPI_STAGE_COUNT` and `incottEncodeSetDpi` in
+`src/incott/index.ts`.
+
+**THE SECOND DPI BUG (fixed the same day, from a real owner report)**: even
+after the first fix, `IncottHidClient.setDpi()` was the *only* way the driver
+could touch DPI. It read which stage was active and then wrote the
+requested DPI *into that stage* — so picking "3200" in the UI did not select
+the stage that already held 3200; it silently overwrote whichever stage
+happened to be active with 3200. Repeated use progressively destroyed the
+mouse's factory-programmed table: one owner's stage 2 was found changed from
+1600 to 800 this way. It also explains a confusing symptom in third-party
+tools, which display `factoryPresetTable[activeIndex]` — once the driver's
+overwrites had diverged the real table from the factory one, those tools
+showed stale/wrong values for stages the driver had never intentionally
+touched.
+
+**THE ROOT CAUSE IS A MISLABEL IN THE PRIOR ART.** IncottHIDApp's `09 03 06
+<idx>` write is labelled "set DPI" in that project, and its six "DPI presets"
+are described as if picking one changes the DPI value. They do not: `0x03`
+is the active-stage **select**, and IncottHIDApp's six presets are just the
+factory *stage values*, read back afterwards through `0x83`'s active-index
+report. Conflating "select a preset" with "edit the active stage's value" is
+exactly the bug this driver had. **Do not re-introduce this mislabel.**
+
+The fix: DPI is now modelled as four independent operations, matching
+OpenMouse's existing generic contract
+(`openmouse/src/device/controller.ts`, via `requireClientMethod`):
+
+- `setActiveDpiStage(stage)` -> `09 03 06 <idx>`, confirmed by re-reading
+  `0x83`/`0x06`. Never touches a stored value.
+- `setDpiStageValue(stage, dpi)` -> `09 02 <stage> <lo> <hi>`, confirmed by
+  re-reading `0x82`/`<stage>`. Edits one stage directly, by index.
+- `setDpi(dpi)` is kept, but now means exactly "set the ACTIVE stage's
+  value" — i.e. `setDpiStageValue(activeStage, dpi)` — since that is the only
+  meaning left for a plain "set DPI" call once a real select exists.
+- `readStatus()` reads which stage is active (`0x83`/`0x06`) and every one of
+  the six stages' stored values (`0x82`, sequentially — six queries, never
+  parallelized, see "Read-only transaction discipline" below), populating
+  `MouseStatus.dpiStages` / `MouseStatus.activeDpiStage` and
+  `MouseUiHints.dpiStageEditor` (`{ maxStages: 6, countEditable: false, minDpi:
+  50, maxDpi: 45000, stepDpi: 50 }` — `countEditable: false` because Incott's
+  six stages are a fixed hardware property, not something the app can add to
+  or remove from). `MouseStatus.dpi` is derived as the active stage's own
+  value, a genuine live read, not a write cache.
+
+`0x82` **echoes its sub-command** (verified: `09 82 03` replies `09 82 03
+…`), so it is registered in `SUB_ECHOING_QUERIES`
+(`src/drivers/incott/hid.ts`) alongside `0x83`/`0x84`/`0x85`/`0x86`/`0x8e`.
+`0x03` is a write with no reply, so it needs no entry there.
+
+This *supersedes* an earlier, narrower proof from 2026-09-07 against a
+G23V2Pro (`vendor-tool-session.hex`) that only ever exercised stage 1:
+`TX 09 02 01 0f 00` -> 800 DPI, `TX 09 02 01 f3 01` -> 25000 DPI. That capture
+also disproved a *different*, older assumption — that DPI was a preset index
+written under command `0x03` — and remains valid for that claim; see
+"Corrected 2026-09-07" further down.
+
+The writable range is still 50-45000 in steps of 50, per the vendor's own
+device definition (`js/gvarG23-v102.js`), pairing two PixArt sensor variants
+(PAW3395: 32000, PAW3950: 45000) — see "Sensor variant," an open question
+below.
+
+### Polling rate byte 2 is genuinely the data, not an echo (2026-09-08)
+
+`incottDecodePollingRate` reads byte 2 of the `0x81` response. This used to
+be an assumption ("the position that mirrors the write payload"); it is now
+**confirmed**: writing wire `1` (500 Hz) then wire `0` (1000 Hz) and reading
+back showed byte 2 follow the write, `0 -> 1 -> 0`. `0x81` does **not** echo a
+sub-command the way `0x82`-`0x86`/`0x8e` do — byte 2 here is data — so it
+correctly stays out of `SUB_ECHOING_QUERIES`.
+
+### Lift-off and motion sync: symmetric reads confirmed, packed nibble form cross-checked (2026-09-08)
+
+Every `0x04`/`0x05` setting has a symmetric read at the *same* sub-command on
+`0x84`/`0x85`:
+
+| Setting | Write | Read | Value at |
+|---|---|---|---|
+| Lift-off | `09 04 01 <hw>` | `09 84 01` | byte 3 |
+| Ripple | `09 04 02 <0\|1>` | `09 84 02` | byte 3 |
+| Angle snapping | `09 04 03 <0\|1>` | `09 84 03` | byte 3 |
+| Motion sync | `09 04 04 <0\|1>` | `09 84 04` | byte 3 |
+| Performance mode | `09 04 05 <v>` | `09 84 05` | byte 3 |
+| Debounce | `09 05 01 <ms>` | `09 85 01` | byte 3 |
+| Sleep | `09 05 03 <lo><hi>` | `09 85 03` | bytes 3-4 (LE16) |
+
+Ripple, angle snapping, debounce and sleep already used this symmetric form.
+Lift-off and motion sync used to read a packed byte instead: `0x84`/sub
+`0x00`, byte 7, high nibble for lift-off and low nibble for motion sync. That
+packed form is **not wrong** — motion sync read back 0/1/0 through *both*
+`0x84` sub `0x04` byte 3 and `0x84` sub `0x00` byte 7's low nibble, and they
+agreed at every step; lift-off round-tripped hw 0/1/2 through both forms
+identically too. It is just less direct, and the driver now uses the
+symmetric single-purpose reads (`incottDecodeLiftOffDirect`,
+`incottDecodeToggle(frame, INCOTT_SUB_MOTION_SYNC)`) as its primary path. The
+packed-nibble decoders (`incottDecodeLiftOff`, `incottDecodeMotionSync`) are
+kept and still tested as a documented cross-check, not removed.
+
+This section is about the **wire-value encoding** (hw 0/1/2 for lift-off,
+round-tripped cleanly). Which physical millimetre distance each lift-off hw
+value means is a *separate*, still-open question — see below.
+
+### Buttons: new capability, codec only (2026-09-08)
+
+The device has six buttons and a previously-undecoded read/write pair:
+
+- **Write:** `09 06 <button 0..5> <b0> <b1> <b2>`.
+- **Read:** `09 86 <button 0..5>` -> response bytes 3-5.
+
+Round-trip confirmed: writing `09 06 00 01 00 f0` to button 0, then reading
+`09 86 00`, returned `01 00 f0` — byte for byte. Reading all six buttons on
+the unit under test returned:
+
+```
+button 0 -> 01 00 f0        button 3 -> 01 00 f3
+button 1 -> 01 00 f1        button 4 -> 01 00 f4
+button 2 -> 01 00 f2        button 5 -> 07 00 03
+```
+
+`0x86` was previously `INCOTT_CMD_UNKNOWN_86`, decoded only for the vendor
+tool's own `09 86 09` query (payload still unexplained). It is now
+`INCOTT_CMD_QUERY_BUTTON`; `INCOTT_CMD_SET_BUTTON` (`0x06`) is the matching
+write.
+
+**This driver implements the codec ONLY** — `incottEncodeSetButtonBinding` /
+`incottDecodeButtonBinding` in `src/incott/index.ts` — encode/decode of the
+raw three-byte binding, plus a read for each of the six buttons. It
+deliberately does **not** attempt to model key codes, macros, or remapping
+semantics: the meaning of the three bytes is not established (button 5's
+payload shape, `07 00 03`, visibly differs from the other five's `01 00 fN`,
+suggesting it is a different *kind* of action — plausibly the DPI button —
+but this is an inference, not something the capture decodes), and
+OpenMouse's shared `MouseStatus` button-mapping contract
+(`buttonMappings`/`buttonOptions`) has its own shape this driver must not
+guess at. **Nothing here is wired into `IncottHidClient` or the UI.**
+
+### Battery (2026-09-07, DISPROVEN 2026-09-08 — see the top of this document)
+
+Byte 6 of the `0x8e`/sub `0x01` response looked, at the time, like the exact
+battery percentage: `TX 09 8e 01` -> `RX 09 8e 01 5a 04 84 38 01 00`, byte 6 =
+`0x38` = 56, and the vendor UI showed "60%" for this same reading (confirmed
+directly by the person who captured this session that the vendor's own
+display rounds to the nearest 10%, which made 56 look like a very plausible
+exact value). **This was disproven by a later, more thorough test**: charging
+a unit through a full cycle from roughly 60% to roughly 97% left this exact
+byte completely unchanged. See "Battery relocated to an unsolicited input
+report" at the top of this document for what replaced it. `incottDecodeBattery`
+is kept as a codec/regression fixture only; nothing in the driver decodes
+battery from this frame any more.
+
+### DPI (preset-index question) and battery: corrected 2026-09-07
+
+Both of these were previously "assumed" (carried over from IncottHIDApp) and
+were corrected against the vendor-tool capture, ahead of the six-stage-table
+discovery above:
+
+- **DPI is a linear little-endian uint16**, written under command `0x02`,
+  sub-command `0x01` — not an index into a 6-entry preset table written under
+  command `0x03`. Confirmed by two round-trips: `TX 09 02 01 0f 00` -> 800
+  DPI (wire 15) and `TX 09 02 01 f3 01` -> 25000 DPI (wire 499).
+  - `[400, 800, 1600, 2400, 3200, 6400]` (`INCOTT_DPI_DEFAULT_STAGE_PRESETS`)
+    is **not** the writable range — the vendor's device definition calls it
+    the six default DPI *stage presets*. As of the 2026-09-08 session, this
+    is also exactly what the six stages read back as on the unit under test,
+    i.e. it doubles as the factory-default value for each stage.
+  - `0x83`/sub `0x06` does **not** answer with a DPI value — it answers with
+    the **active stage index (0-5)**. The old decoder read byte 3 through the
+    six-entry preset table and got 800 DPI back, which matched the vendor UI
+    only by coincidence: the device happened to be on stage 1 of 6 at capture
+    time. See `incottDecodeDpiStageIndex`.
+
+- **Battery percentage is byte 6 of the `0x8e`/sub `0x01` response** — not
+  byte 8 of the `0x89` response (see "Disproven" below).
+
+### Disproven: `0x89` byte 8 was never a battery reading
+
+The original hypothesis (recorded in an earlier version of this document) was
+that byte 8 of the `0x89` response was the battery percentage, because it
+read a plausible-looking `0x5a` (90) on hardware. It is not: **that same byte
+read the identical constant `0x5a` on every capture ever taken, across every
+device state, in every capture session including the 2026-09-08 round.** A
+value that never changes regardless of device state cannot be a battery
+percentage — it is a constant of unknown meaning. This is why the app was
+permanently stuck at 90% battery: it was decoding a constant, not a reading.
+`0x89` still answers, and the driver still records that it does, but nothing
+decodes its payload any more.
+
+### Lesson: an opcode sweep using only sub `0x00` misses real sub-commands
+
+The original opcode sweep (`query-sweep-0x80-0x8f.hex`) concluded `0x8e`
+(battery) was unimplemented, and had no interpretation for `0x82` at all,
+because that sweep only ever sent sub-command `0x00` to every opcode:
+`0x8e` only answers on sub-command `0x01`, and `0x82`'s per-stage DPI reads
+only answer on subs `0x00`-`0x05` (each returning a *different* stage, not a
+single "the" answer) — a bare `09 82 00` looks like an ordinary, uninteresting
+reply unless you already know to try the other five sub-commands too. **This
+is exactly how `0x82`'s stage table and `0x8e`'s battery were both missed by
+the earlier sweep.** The vendor tool teaches the same lesson for `0x86`,
+which it queries as `09 86 09` — not a button index (buttons only go up to
+5) and still undecoded.
+
+`0x82`/`0x83`/`0x84`/`0x85`/`0x86`/`0x8e` all echo their sub-command at byte
+2 of the reply. `0x82`, `0x83`, `0x84`, `0x85` and `0x8e` are registered as
+such in `SUB_ECHOING_QUERIES` (`src/drivers/incott/hid.ts`), since the driver
+queries all of them; `0x86` echoes identically (`incottDecodeButtonBinding`
+checks it directly via `incottFrameMatches`) but is not in that set because
+the driver itself never issues a `0x86` query — see `INCOTT_CMD_QUERY_BUTTON`
+in `src/incott/index.ts`.
+
+## Performance mode: codec implemented, mapping unverified, not exposed in the UI
+
+The vendor tool has a three-way "Performance mode" control (labelled HP /
+Corded / LP, described as trading performance for battery life). The
+vendor-tool capture recorded two of the three writes:
+
+```
+TX 09 04 05 02
+TX 09 04 05 01
+```
+
+Command `0x04`, sub-command `0x05`, one byte value. `0` is presumed to exist
+(a three-way control implies three values) but was never directly observed.
+**Which label produced which value was never recorded** — only the raw
+writes exist. `incottEncodeSetPerformanceMode` /
+`incottDecodePerformanceMode` / `IncottHidClient.setPerformanceMode` /
+`getPerformanceMode` implement the raw 0-2 value; the read-back
+(`0x84`/`0x05`) was never captured on hardware and is a best-effort attempt
+by symmetry with the other `0x04`/`0x84` sub-command pairs, not a confirmed
+one.
+
+This is deliberately **not wired into `MouseStatus`/`MouseUiHints`**. The
+shared contract's closest fit — `powerModes`/`powerMode`/`setPowerMode`,
+which MCHOSE uses for an identical three-way mode — requires naming each
+value for display. Doing that here would mean guessing an order for
+HP/Corded/LP and presenting it to the user as fact, which the capture does
+not support. The codec and client method exist so a future contributor with
+a hardware-confirmed mapping can wire it up without redoing the protocol
+work.
+
+## READS: verified on hardware
+
+Every read command the driver issues was exercised directly against the
+device — see `captures/incott-8k-wireless/targeted-reads.hex`,
+`query-sweep-0x80-0x8f.hex`, `vendor-tool-session.hex`, and
+`write-roundtrip.hex`. Confirmed:
+
+- `0x81` answers the polling-rate query; byte 2 is confirmed data (see above).
+- `0x82` (with a sub-command 0-5) answers with that DPI stage's value.
+- `0x83` (with sub-command `0x06`) answers with the active DPI *stage index*
+  (0-5) — not a DPI value.
+- `0x84` (sensor) answers for sub-commands `0x00` (packed lift-off + motion
+  sync), `0x01` (lift-off, symmetric), `0x02` (ripple control), `0x03`
+  (angle snap), `0x04` (motion sync, symmetric), and (unverified read-back,
+  see above) `0x05` (performance mode).
+- `0x85` (timing) answers for sub-commands `0x01` (debounce) and `0x03`
+  (sleep).
+- `0x86` (with a sub-command 0-5) answers with that button's raw binding;
+  sub `0x09` (the vendor tool's own query) also answers but is undecoded.
+- `0x88` (receiver LED) and `0x89` (status, meaning still unknown) both
+  answer.
+- `0x8e` answers on sub-command `0x01` only. Byte 6 of that reply looked like
+  a battery percentage at first (see "Battery" below) but was DISPROVEN
+  2026-09-08 by a full charge cycle that left it unchanged — see "Battery
+  relocated to an unsolicited input report" at the top of this document. The
+  real battery level is a field of the mouse's unsolicited input report, not
+  this feature-report reply.
+- `0x8f` (identity) answers, though its byte layout is not decoded — see
+  Unresolved below.
+- `0x80` and `0x87` never answered in any capture session.
+
+## WRITES: verified vs. unverified
+
+**Verified by a real write + read-back + restore on hardware**
+(`write-roundtrip.hex`, 2026-09-08): DPI stage-value edit (`0x02`, both the
+byte layout and that byte 1 is a stage index), active-stage select (`0x03`,
+sub `0x06` — confirmed distinct from the `0x02` edit: selecting stages 0, 3,
+5, then 1 each read back correctly via `0x83`/`0x06`, and the six-stage table
+was re-read afterwards and found completely unchanged), lift-off
+(`0x04`/`0x01`, hw value round-trip — not the mm label, see below), motion
+sync (`0x04`/`0x04`), polling rate (`0x01`), and button bindings (`0x06`, new
+capability).
+
+**Verified by a write + read-back** (no restore recorded,
+`vendor-tool-session.hex`, 2026-09-07): DPI (an earlier, narrower proof),
+receiver LED (`0x08`), and performance mode (`0x04`/`0x05`, values only, no
+label mapping).
+
+**Still unverified against hardware writes**: `incottEncodeSetToggle` for
+ripple and angle snap specifically (motion sync is now verified; the write
+shape is identical for all three, but only motion sync was directly
+exercised), `incottEncodeSetDebounce`, and `incottEncodeSetSleep`. These were
+derived from the MIT-licensed IncottHIDApp's `device.go` (see Attribution)
+and have only ever been exercised against the fake-transport unit tests in
+`src/drivers/incott/hid.test.ts`. Every setter that has a working read-back
+in `src/drivers/incott/hid.ts` throws when the post-write read-back disagrees
+with the requested value.
+
+## Read-only transaction discipline
+
+The most important thing this device does: **the same query, sent unchanged,
+returned three different payloads across three separate capture runs** (see
+`captures/incott-8k-wireless/repeatability.hex`). The device latches a single
+shared response buffer, and a read can return a frame left over from a
+different, earlier query rather than the one just sent. A live capture during
+the 2026-09-08 session showed this concretely: a `0x81` query returned a
+previous query's payload behind a correct-looking header, which is exactly
+the failure mode `IncottTransactionQueue` exists to prevent.
+
+Because of this, every request in `IncottTransactionQueue`
+(`src/drivers/incott/hid.ts`) is serialized, discards whatever is already
+latched before sending, and accepts a reply only when its report ID, command
+byte, and — for `0x82`/`0x83`/`0x84`/`0x85`/`0x8e` (the queries the driver
+actually issues that are known to echo their sub-command) — sub-command byte
+all echo the request. The sub-command echo is deliberately **not** checked
+for `0x81`/`0x88`/`0x89`/`0x8f`: byte 2 of those replies is data, not an
+echoed sub-command, and matching it there would reject every polling rate but
+1000 Hz and every LED mode but 0. This distinction is the reason IncottHIDApp's
+own read loop (which matches on the command byte alone) is vulnerable to
+exactly the stale-frame bug this queue exists to prevent.
+
+## Unresolved unknowns
+
+Per the "record what didn't work" principle, these are open questions no
+capture session has resolved. **Do not resolve these by guessing.**
+
+- **Lift-off hw -> millimetre label mapping — needs a hardware check.** The
+  hw values 0/1/2 round-trip cleanly (confirmed 2026-09-08, see above), but
+  which physical distance each means is unknown. IncottHIDApp claims hardware
+  `0` = 1 mm, `1` = 2 mm, `2` = 0.7 mm (`INCOTT_LOD_WIRE_TO_TENTHS` in
+  `src/incott/index.ts`). The vendor's own device definition
+  (`js/gvarG23-v102.js`) instead pairs `lodUI = [0.7, 1, 2]` with
+  `lodHW = [0, 1, 2]`, i.e. hardware `0` = 0.7 mm — a different mapping.
+  Neither capture session recorded which on-screen label was selected for a
+  given write. **Left unchanged pending a hardware check**: set 0.7 mm in the
+  vendor tool, then read `0x84`/`0x01` (or the packed form) and see which
+  value comes back.
+- **Performance-mode value-to-label mapping.** See "Performance mode" above —
+  writes for values `1` and `2` were captured, but not which of HP / Corded /
+  LP produced either. Needs a hardware check: set each of the three vendor-UI
+  options in turn and read back which raw value each produces.
+- **Button payload semantics.** The three bytes `incottDecodeButtonBinding`
+  returns (`b0`/`b1`/`b2`) are deliberately unnamed: whether they encode a
+  key code, a macro reference, or a remap target is not established. Needs a
+  hardware check: write a series of known key bindings through the vendor
+  tool and see how the three bytes change.
+- **Which sensor is fitted.** PAW3395 caps at 32000 DPI, PAW3950 at 45000.
+  The 25000 DPI write confirmed on 2026-09-08 is below both known ceilings,
+  so it does not distinguish them. This driver assumes 45000 (the higher
+  ceiling) for every unit since the sensor variant cannot currently be read;
+  confirming the cap on a PAW3395 unit (and finding a way to detect which
+  sensor is fitted, if one exists) is an open question.
+- **What `0x86` sub `0x09` means.** The vendor tool queries this
+  specifically (`09 86 09`); its payload is undecoded and is not a button
+  index (buttons only go up to 5).
+- **The byte layout of the `0x8f` identity response.** The raw bytes are
+  captured and shown as-is in the details panel (see
+  `incottDecodeIdentity`), but no field within them (firmware version,
+  hardware revision, etc.) has been decoded.
+- **Whether `0x84`/`0x05` (the presumed performance-mode read-back) actually
+  answers at all.** It has never been captured on hardware; `IncottHidClient`
+  treats `null` from this query as "unknown," not as a failure, specifically
+  because of this uncertainty.
+
+## Attribution
+
+The protocol constants, opcode set, and command layouts this driver
+implements derive from the MIT-licensed
+[IncottHIDApp](https://github.com/romkazor/IncottHIDApp) (`device.go`). This
+driver reuses that project's protocol knowledge, not its code. The DPI range
+and the six default stage presets, the two PixArt sensor ceilings, and the
+lift-off UI values (`lodUI`/`lodHW`) referenced above come from the vendor's
+own device definition (`js/gvarG23-v102.js`) as seen through the
+incott.net/mouse/ configurator. The captures in `captures/incott-8k-wireless/`
+are original data: the 2026-09-07 read-only ones taken directly from
+hardware with node-hid, `vendor-tool-session.hex` taken by instrumenting the
+vendor's own WebHID configurator, and `write-roundtrip.hex` (2026-09-08)
+taken directly from hardware with node-hid while performing real,
+subsequently-restored writes — none of the three is reproduced from
+IncottHIDApp.
+
+## Lift-off distance mapping — resolved 2026-09-08
+
+Setting **0.7 mm** in Incott's own web configurator, then reading `09 84 01`,
+returned byte 3 = `2`. Hardware `2` is therefore 0.7 mm, confirming the mapping
+inherited from IncottHIDApp (`0` = 1 mm, `1` = 2 mm, `2` = 0.7 mm).
+
+This also closes a false lead recorded earlier: the vendor's device definition
+(`js/gvarG23-v102.js`) lists `lodUI = [0.7, 1, 2]` alongside `lodHW = [0, 1, 2]`,
+which reads as hardware `0` = 0.7 mm if the two arrays are assumed index-aligned.
+The device contradicts that, so the arrays are not a paired lookup. Recording it
+because it is exactly the kind of plausible-but-wrong inference worth warning the
+next contributor about.
+
+Only the 0.7 mm point was read back directly. Hardware `0` and `1` are 1 mm and
+2 mm in that order; the mapping is a bijection over {0,1,2} and the one claim that
+was testable proved correct, but neither of those two values has been read
+individually.

--- a/package.json
+++ b/package.json
@@ -148,6 +148,10 @@
     "./ksnake": {
       "types": "./dist/ksnake/index.d.ts",
       "import": "./dist/ksnake/index.js"
+    },
+    "./incott": {
+      "types": "./dist/incott/index.d.ts",
+      "import": "./dist/incott/index.js"
     }
   },
   "scripts": {

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -1,0 +1,1005 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { INCOTT_PRODUCT_ID, INCOTT_PRODUCT_ID_WIRED, INCOTT_REPORT_ID, INCOTT_USAGE_PAGE, INCOTT_VENDOR_ID } from "../../incott/index.ts";
+import {
+  IncottHidClient,
+  IncottTransactionQueue,
+  incottProbeCollection,
+  incottSelectCollection,
+  type FeatureTransport,
+  type IncottTransactionOptions,
+} from "./hid.ts";
+
+// ---------------------------------------------------------------------------
+// IncottTransactionQueue — ported from IncottHub's transaction.test.ts.
+// The device latches a single shared response buffer, so these lock down the
+// exact stale-frame regression the queue exists to prevent.
+// ---------------------------------------------------------------------------
+
+/** Builds a response frame with the report ID at byte 0. */
+const frame = (...values: readonly number[]): Uint8Array => {
+  const out = new Uint8Array(64);
+  out[0] = INCOTT_REPORT_ID;
+  values.forEach((value, index) => {
+    out[index + 1] = value;
+  });
+  return out;
+};
+
+/** A transport that replays a scripted list of frames, one per read. */
+class ScriptedTransport implements FeatureTransport {
+  sent: Uint8Array[] = [];
+  reads = 0;
+  private readonly script: readonly Uint8Array[];
+  constructor(script: readonly Uint8Array[]) {
+    this.script = script;
+  }
+  async sendFeatureReport(_reportId: number, data: BufferSource): Promise<void> {
+    this.sent.push(data as Uint8Array);
+  }
+  async receiveFeatureReport(_reportId: number): Promise<DataView> {
+    const next = this.script[this.reads] ?? new Uint8Array(64);
+    this.reads += 1;
+    return new DataView(next.buffer, next.byteOffset, next.byteLength);
+  }
+}
+
+/** Runs transactions with no real delay. */
+const immediate: IncottTransactionOptions = { settleMs: 0, attempts: 4, sleep: async () => {} };
+
+test("a matching response is returned to the caller", async () => {
+  const transport = new ScriptedTransport([frame(0x85, 0x01, 0x04), frame(0x85, 0x01, 0x04)]);
+  const queue = new IncottTransactionQueue(transport, immediate);
+  const result = await queue.request(new Uint8Array([0x85, 0x01]), 0x85, 0x01);
+  assert.equal(result?.[3], 0x04);
+});
+
+test("a stale frame from an earlier query is rejected, not decoded", async () => {
+  // This is the exact failure IncottHIDApp's read loop accepts: it matches on
+  // the command byte alone, so a leftover 0x85/0x01 frame satisfies a request
+  // for 0x85/0x03 and its payload is decoded as a sleep timer.
+  const transport = new ScriptedTransport([
+    frame(0x85, 0x01, 0x04), // flush read
+    frame(0x85, 0x01, 0x04), // stale: right command, wrong sub-command
+    frame(0x85, 0x03, 0x3c), // the real answer
+  ]);
+  const queue = new IncottTransactionQueue(transport, immediate);
+  const result = await queue.request(new Uint8Array([0x85, 0x03]), 0x85, 0x03);
+  assert.equal(result?.[2], 0x03, "must not accept the 0x85/0x01 frame");
+  assert.equal(result?.[3], 0x3c);
+});
+
+test("a response for an entirely different command is rejected", async () => {
+  const transport = new ScriptedTransport([
+    frame(0x84, 0x00),
+    frame(0x84, 0x00),
+    frame(0x88, 0x02),
+  ]);
+  const queue = new IncottTransactionQueue(transport, immediate);
+  const result = await queue.request(new Uint8Array([0x88]), 0x88, null);
+  assert.equal(result?.[1], 0x88);
+  assert.equal(result?.[2], 0x02);
+});
+
+test("null is returned when no matching frame arrives within the attempt budget", async () => {
+  const transport = new ScriptedTransport([frame(0x84, 0x00)]);
+  const queue = new IncottTransactionQueue(transport, immediate);
+  const result = await queue.request(new Uint8Array([0x85, 0x03]), 0x85, 0x03);
+  assert.equal(result, null);
+});
+
+test("the first read is discarded so a pending frame cannot satisfy the request", async () => {
+  const transport = new ScriptedTransport([
+    frame(0x85, 0x03, 0xff), // already latched before we sent anything
+    frame(0x85, 0x03, 0x3c),
+  ]);
+  const queue = new IncottTransactionQueue(transport, immediate);
+  const result = await queue.request(new Uint8Array([0x85, 0x03]), 0x85, 0x03);
+  assert.equal(result?.[3], 0x3c, "the pre-send frame must be flushed");
+});
+
+test("transactions are serialized so two requests never interleave", async () => {
+  const order: string[] = [];
+  const transport: FeatureTransport = {
+    async sendFeatureReport(_id, data) {
+      order.push(`send:${new Uint8Array(data as ArrayBuffer)[0]}`);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    },
+    async receiveFeatureReport() {
+      const value = frame(0x84, 0x00);
+      return new DataView(value.buffer, value.byteOffset, value.byteLength);
+    },
+  };
+  const queue = new IncottTransactionQueue(transport, immediate);
+  await Promise.all([
+    queue.request(new Uint8Array([0x84]), 0x84, null),
+    queue.request(new Uint8Array([0x85]), 0x85, null),
+  ]);
+  // The 0x85 send must not begin until the 0x84 transaction has finished.
+  assert.deepEqual(order, ["send:132", "send:133"]);
+});
+
+test("a transport error resolves to null instead of rejecting", async () => {
+  const transport: FeatureTransport = {
+    async sendFeatureReport() {},
+    async receiveFeatureReport() {
+      throw new Error("device disconnected");
+    },
+  };
+  const queue = new IncottTransactionQueue(transport, immediate);
+  assert.equal(await queue.request(new Uint8Array([0x84]), 0x84, null), null);
+});
+
+test("send writes without waiting for a response it will never get", async () => {
+  // Writes draw no reply. Routing them through request() would burn the whole
+  // attempt budget (10 reads x 50 ms) waiting for a frame that never arrives.
+  const transport = new ScriptedTransport([]);
+  const queue = new IncottTransactionQueue(transport, immediate);
+  await queue.send(new Uint8Array([0x03, 0x06, 0x02]));
+  assert.equal(transport.sent.length, 1);
+  assert.equal(transport.reads, 0, "send must not read");
+});
+
+test("send stays ordered with respect to requests", async () => {
+  const order: string[] = [];
+  const transport: FeatureTransport = {
+    async sendFeatureReport(_id, data) {
+      order.push(`send:${new Uint8Array(data as ArrayBuffer)[0]}`);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    },
+    async receiveFeatureReport() {
+      const value = frame(0x83, 0x06, 0x02);
+      return new DataView(value.buffer, value.byteOffset, value.byteLength);
+    },
+  };
+  const queue = new IncottTransactionQueue(transport, immediate);
+  await Promise.all([
+    queue.send(new Uint8Array([0x03, 0x06, 0x02])),
+    queue.request(new Uint8Array([0x83, 0x06]), 0x83, 0x06),
+  ]);
+  assert.deepEqual(order, ["send:3", "send:131"]);
+});
+
+// ---------------------------------------------------------------------------
+// IncottHidClient — a scripted fake HIDDevice standing in for the mouse.
+// ---------------------------------------------------------------------------
+
+function defaultState() {
+  return {
+    // Six-stage DPI table, wire values for 400/800/1600/2400/3200/6400 —
+    // the exact values verified on hardware 2026-09-08. Stage 1 (800 DPI) is
+    // active by default.
+    dpiStagesWire: [7, 15, 31, 47, 63, 127],
+    activeDpiStage: 1, // 0x83/0x06's answer.
+    pollingWire: 0, // 1000 Hz
+    lodWire: 0, // 10 tenths mm -> Medium
+    motionSync: 1,
+    ripple: 0,
+    angleSnap: 0,
+    performanceMode: 1,
+    debounceMs: 4,
+    sleepSeconds: 60,
+    receiverLed: 0,
+    batteryByte: 0x38 as number | null, // 56%, captured 2026-09-07
+    identity: [0x01, 0x0e, 0x02, 0xf0, 0xf1, 0x00, 0xff] as number[] | null,
+  };
+}
+
+type FakeState = ReturnType<typeof defaultState>;
+
+interface FakeOptions {
+  productId?: number;
+  productName?: string;
+  collections?: HIDCollectionInfo[];
+  state?: Partial<FakeState>;
+  /** Query commands (byte 0) the device stays silent on. */
+  silent?: number[];
+  /** Drop every SET on the floor, as if the write did not take. */
+  ignoreWrites?: boolean;
+  /**
+   * Simulates the wired mouse's dead look-alike 0xFF05 collection
+   * (hardware-verified 2026-09-08): every `sendFeatureReport` call throws,
+   * exactly like Windows' `HidD_SetFeature: (0x00000001) Incorrect function`
+   * on the real dead collection. See `open()`'s identity probe.
+   */
+  deadCollection?: boolean;
+}
+
+function vendorCollection(usagePage: number = INCOTT_USAGE_PAGE): HIDCollectionInfo {
+  return {
+    usagePage,
+    usage: 0x01,
+    type: 1,
+    children: [],
+    featureReports: [{ reportId: INCOTT_REPORT_ID, items: [] }],
+    inputReports: [],
+    outputReports: [],
+  } as unknown as HIDCollectionInfo;
+}
+
+function fakeDevice(options: FakeOptions = {}) {
+  const state: FakeState = { ...defaultState(), ...options.state };
+  const sent: Uint8Array[] = [];
+  let buffer = new Uint8Array(64);
+  let opened = false;
+  // Only "inputreport" is ever registered by this driver; a single slot is
+  // enough (open()/close() add and remove exactly one listener each).
+  let inputReportListener: ((event: HIDInputReportEvent) => void) | null = null;
+
+  const reply = (payload: Uint8Array): Uint8Array | null => {
+    const cmd = payload[0]!;
+    const sub = payload[1]!;
+    if (options.silent?.includes(cmd)) return null;
+    switch (cmd) {
+      case 0x81:
+        return frame(0x81, state.pollingWire);
+      case 0x82: {
+        // Per-stage DPI value read, little-endian at bytes 3-4. See
+        // incottDecodeDpiStage.
+        const wire = state.dpiStagesWire[sub];
+        return wire === undefined ? null : frame(0x82, sub, wire & 0xff, (wire >> 8) & 0xff);
+      }
+      case 0x83:
+        // Active DPI *stage index* (0-5). See incottDecodeDpiStageIndex.
+        return sub === 0x06 ? frame(0x83, 0x06, state.activeDpiStage) : null;
+      case 0x84:
+        // sub 0x00 is the legacy packed byte-7 form (still decodable via
+        // incottDecodeLiftOff/incottDecodeMotionSync, cross-checked against
+        // the symmetric reads below on hardware 2026-09-08); the driver's
+        // real read path uses subs 0x01/0x04 instead.
+        if (sub === 0x00) return frame(0x84, 0x00, 0, 0, 0, 0, (state.lodWire << 4) | state.motionSync);
+        if (sub === 0x01) return frame(0x84, 0x01, state.lodWire);
+        if (sub === 0x02) return frame(0x84, 0x02, state.ripple);
+        if (sub === 0x03) return frame(0x84, 0x03, state.angleSnap);
+        if (sub === 0x04) return frame(0x84, 0x04, state.motionSync);
+        if (sub === 0x05) return frame(0x84, 0x05, state.performanceMode);
+        return null;
+      case 0x85:
+        if (sub === 0x01) return frame(0x85, 0x01, state.debounceMs);
+        if (sub === 0x03) return frame(0x85, 0x03, state.sleepSeconds & 0xff, (state.sleepSeconds >> 8) & 0xff);
+        return null;
+      case 0x88:
+        return frame(0x88, state.receiverLed);
+      case 0x89:
+        // Real hardware returned this same constant byte on every capture, in
+        // every state — it is not a battery reading and nothing decodes it.
+        return frame(0x89, 0, 0, 0, 0, 0, 0, 0x5a);
+      case 0x8e:
+        // Battery: byte 6, only on sub-command 0x01 — see incottDecodeBattery.
+        return sub === 0x01 && state.batteryByte !== null
+          ? frame(0x8e, 0x01, 0x5a, 0x04, 0x84, state.batteryByte, 0x01, 0x00)
+          : null;
+      case 0x8f:
+        return state.identity === null ? null : frame(0x8f, ...state.identity);
+      default:
+        return null;
+    }
+  };
+
+  const apply = (payload: Uint8Array): void => {
+    const cmd = payload[0]!;
+    const sub = payload[1]!;
+    const value = payload[2]!;
+    // cmd 0x02: `sub` here is a DPI STAGE INDEX (0-5), not a fixed
+    // sub-command — the bug this driver used to have. See incottEncodeSetDpi.
+    if (cmd === 0x02 && sub >= 0 && sub < state.dpiStagesWire.length) {
+      state.dpiStagesWire[sub] = value | ((payload[3] ?? 0) << 8);
+    }
+    // cmd 0x03/sub 0x06: SELECTS the active stage — must never touch
+    // dpiStagesWire. This is the operation IncottHIDApp mislabels "set DPI"
+    // and the one the driver's setDpi() used to be conflated with.
+    else if (cmd === 0x03 && sub === 0x06 && value >= 0 && value < state.dpiStagesWire.length) {
+      state.activeDpiStage = value;
+    }
+    else if (cmd === 0x01) state.pollingWire = sub; // no sub-command: wire value sits at byte 1
+    else if (cmd === 0x04 && sub === 0x01) state.lodWire = value;
+    else if (cmd === 0x04 && sub === 0x02) state.ripple = value;
+    else if (cmd === 0x04 && sub === 0x03) state.angleSnap = value;
+    else if (cmd === 0x04 && sub === 0x04) state.motionSync = value;
+    else if (cmd === 0x04 && sub === 0x05) state.performanceMode = value;
+    else if (cmd === 0x05 && sub === 0x01) state.debounceMs = value;
+    else if (cmd === 0x05 && sub === 0x03) state.sleepSeconds = value | ((payload[3] ?? 0) << 8);
+    else if (cmd === 0x08) state.receiverLed = sub; // no sub-command: mode sits at byte 1
+  };
+
+  const device = {
+    vendorId: INCOTT_VENDOR_ID,
+    productId: options.productId ?? INCOTT_PRODUCT_ID,
+    productName: options.productName ?? "incott 8K wireless mouse",
+    get opened() {
+      return opened;
+    },
+    collections: options.collections ?? [vendorCollection()],
+    open: async () => {
+      opened = true;
+    },
+    close: async () => {
+      opened = false;
+    },
+    sendFeatureReport: async (_reportId: number, data: BufferSource) => {
+      const view = ArrayBuffer.isView(data)
+        ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        : new Uint8Array(data as ArrayBuffer);
+      const payload = new Uint8Array(view);
+      sent.push(payload);
+      if (options.deadCollection) {
+        // Real hardware attempts the write and only THEN fails it — Windows'
+        // HidD_SetFeature rejects it at the OS level. Recording the attempt
+        // before throwing keeps `sent` a faithful attempt count.
+        throw new Error("HidD_SetFeature: (0x00000001) Incorrect function");
+      }
+      if (payload[0]! < 0x80) {
+        if (!options.ignoreWrites) apply(payload);
+        return;
+      }
+      const answer = reply(payload);
+      if (answer) buffer = answer;
+    },
+    receiveFeatureReport: async (_reportId: number) => new DataView(new Uint8Array(buffer).buffer),
+    addEventListener: (type: string, listener: (event: HIDInputReportEvent) => void) => {
+      if (type === "inputreport") inputReportListener = listener;
+    },
+    removeEventListener: (type: string, listener: (event: HIDInputReportEvent) => void) => {
+      if (type === "inputreport" && inputReportListener === listener) inputReportListener = null;
+    },
+  };
+
+  return {
+    device: device as unknown as HIDDevice,
+    sent,
+    state,
+    /**
+     * Simulates the mouse's unsolicited input report arriving — only fires
+     * once `open()` has attached the listener (real WebHID would simply drop
+     * the event with nothing listening). `bytes` excludes the report id, the
+     * same WebHID convention `onInputReport` expects (see its doc comment).
+     */
+    fireInputReport: (bytes: readonly [number, number, ...number[]]) => {
+      if (!inputReportListener) return;
+      const data = new Uint8Array(bytes);
+      inputReportListener({
+        reportId: INCOTT_REPORT_ID,
+        data: new DataView(data.buffer, data.byteOffset, data.byteLength),
+      } as unknown as HIDInputReportEvent);
+    },
+  };
+}
+
+const fast: IncottTransactionOptions = { settleMs: 0, attempts: 3, sleep: async () => {} };
+
+test("isSupported matches the Incott vendor/product ids and a >=0xFF00 usage page", () => {
+  assert.equal(IncottHidClient.isSupported(fakeDevice().device), true);
+  assert.equal(IncottHidClient.isSupported(fakeDevice({ productId: INCOTT_PRODUCT_ID_WIRED }).device), true);
+  assert.equal(IncottHidClient.isSupported(fakeDevice({ productId: 0x1234 }).device), false);
+  assert.equal(IncottHidClient.isSupported({ ...fakeDevice().device, vendorId: 0x1532 } as HIDDevice), false);
+  assert.equal(IncottHidClient.isSupported(fakeDevice({ collections: [vendorCollection(0x0001)] }).device), false);
+  assert.equal(IncottHidClient.isSupported(fakeDevice({ collections: [] }).device), false);
+  // The fallback boundary: any page >= 0xFF00, not only 0xFF05.
+  assert.equal(IncottHidClient.isSupported(fakeDevice({ collections: [vendorCollection(0xff00)] }).device), true);
+});
+
+test("filters request both product ids on the vendor usage page", () => {
+  assert.deepEqual(IncottHidClient.filters, [
+    { vendorId: INCOTT_VENDOR_ID, productId: INCOTT_PRODUCT_ID, usagePage: INCOTT_USAGE_PAGE },
+    { vendorId: INCOTT_VENDOR_ID, productId: INCOTT_PRODUCT_ID_WIRED, usagePage: INCOTT_USAGE_PAGE },
+  ]);
+});
+
+test("getDebounceMaxMs, getDebounceOptions and getSleepOptions expose the verified ranges", () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.equal(client.getDebounceMaxMs(), 30);
+  assert.deepEqual(client.getDebounceOptions(), Array.from({ length: 31 }, (_, ms) => ms));
+  assert.deepEqual(client.getSleepOptions(), [10, 30, 60, 120, 300, 600, 900]);
+});
+
+test("readStatus decodes every field from the device's current state", async () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  // DPI is a genuine live read as of 2026-09-08 (see the class comment in
+  // hid.ts): no write needed first. Default state has stage 1 (800 DPI)
+  // active.
+  const status = await client.readStatus();
+  assert.equal(status.brand, "Incott");
+  // Normalized for display (see incottNormalizeProductName): the raw string
+  // remains available as client.device.productName.
+  assert.equal(status.name, "8K wireless");
+  assert.equal(device.productName, "incott 8K wireless mouse", "the raw product string stays available on the device");
+  assert.equal(status.connectionType, "Wireless");
+  assert.equal(status.dpi, 800);
+  assert.equal(status.pollingRateHz, 1000);
+  assert.deepEqual(status.supportedPollingRates, [125, 250, 500, 1000, 2000, 4000, 8000]);
+  assert.equal(status.activeProfile, null);
+  assert.equal(status.liftOffDistance, "Medium");
+  assert.deepEqual(status.supportedLiftOffDistances, ["Low", "Medium", "High"]);
+  assert.equal(status.motionSync, true);
+  assert.equal(status.rippleControl, false);
+  assert.equal(status.angleSnapping, false);
+  assert.equal(status.debounceMs, 4);
+  assert.equal(status.sleepTimeout, 60);
+  // Battery is read from the mouse's unsolicited input report, not from any
+  // feature-report query readStatus() issues (0x8e/byte 6 and 0x89/byte 8 are
+  // BOTH disproven constants — see incottDecodeBattery/INCOTT_CMD_QUERY_STATUS
+  // in src/incott/index.ts). This test never fires that input report, so
+  // battery must stay null/"Unknown" — see the dedicated input-report tests
+  // below for the populated case.
+  assert.equal(status.batteryPercent, null);
+  assert.equal(status.batteryState, "Unknown");
+  assert.deepEqual(status.firmware, ["Identity 01 0e 02 f0 f1 00 ff"]);
+  assert.equal(status.ui?.family, "incott");
+  assert.equal(status.ui?.showAdvancedSection, true);
+  assert.equal(status.ui?.hideSignalCard, true);
+  assert.equal(status.ui?.defaultDisplayName, "8K wireless");
+  assert.equal(status.ui?.hideUnsupportedPollingRates, true);
+  assert.equal(status.ui?.pollingNote, "Up to 8,000 Hz wireless; 1,000 Hz over the cable.");
+  // The mouse has a real internal battery even while wired, so the app's
+  // "hide battery when wired and unread" default must be overridden — see
+  // the comment on this flag in hid.ts.
+  assert.equal(status.ui?.forceShowBattery, true);
+  // Six-stage table, populated in full since every stage answered.
+  assert.deepEqual(status.dpiStages, [400, 800, 1600, 2400, 3200, 6400]);
+  assert.equal(status.activeDpiStage, 1);
+  assert.deepEqual(status.ui?.dpiStageEditor, {
+    maxStages: 6,
+    countEditable: false,
+    minDpi: 50,
+    maxDpi: 45000,
+    stepDpi: 50,
+  });
+});
+
+test("readStatus reports a live DPI reading without any write this session", async () => {
+  // Proves the 2026-09-08 fix: DPI used to be a write-only cache that started
+  // null every session (see git history); it is now read from the six-stage
+  // table (active stage index via 0x83/0x06, then that stage's value via
+  // 0x82) with no write required first.
+  const { device } = fakeDevice();
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.dpi, 800);
+  assert.equal(status.ui?.settingsReady, true);
+  assert.equal(status.ui?.valuesVerified, true);
+  assert.equal(status.pollingRateHz, 1000);
+  // Battery is independent of the feature-report DPI/polling reads (it comes
+  // from the input report instead), and no input report was fired here.
+  assert.equal(status.batteryPercent, null);
+});
+
+test("readStatus degrades gracefully when the active DPI stage cannot be read", async () => {
+  const { device } = fakeDevice({ silent: [0x83] });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.dpi, 0, "inert placeholder, never rendered because settingsReady is false");
+  assert.equal(status.ui?.settingsReady, false);
+  assert.equal(status.ui?.valuesVerified, false);
+  // Polling rate is still genuinely readable independent of DPI. Battery
+  // stays null regardless (no input report fired, and it never came from a
+  // feature-report query in the first place).
+  assert.equal(status.pollingRateHz, 1000);
+  assert.equal(status.batteryPercent, null);
+});
+
+test("readStatus degrades gracefully when the DPI stage's value cannot be read", async () => {
+  const { device } = fakeDevice({ silent: [0x82] });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.dpi, 0, "inert placeholder, never rendered because settingsReady is false");
+  assert.equal(status.ui?.settingsReady, false);
+  assert.equal(status.ui?.valuesVerified, false);
+  // Every one of the six stage reads failed, so the table is omitted rather
+  // than fabricated with placeholder entries.
+  assert.equal(status.dpiStages, undefined);
+});
+
+test("readStatus omits activeDpiStage but still reads the six-stage table when only the active-index query fails", async () => {
+  // The active-stage index (0x83) and the six per-stage values (0x82) are
+  // independent reads; one failing must not fabricate or suppress the other.
+  const { device } = fakeDevice({ silent: [0x83] });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.activeDpiStage, undefined);
+  assert.deepEqual(status.dpiStages, [400, 800, 1600, 2400, 3200, 6400]);
+});
+
+test("the wired product id (0x622C) reports connectionType Wired but battery state Unknown until an input report arrives", async () => {
+  // Hardware-verified 2026-09-08: plugged in over USB the mouse enumerates
+  // as 0x622C, which is the CONNECTION type (see incottIsWiredProduct) — NOT
+  // a source for batteryState any more. Being wired does imply charging in
+  // practice, but the input report is the authoritative source for the
+  // charging bit, and none has arrived in this test, so battery stays
+  // Unknown/null even though the mouse is wired. See the dedicated
+  // input-report tests below for the charging=true case.
+  const { device } = fakeDevice({ productId: INCOTT_PRODUCT_ID_WIRED });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.connectionType, "Wired");
+  assert.equal(status.batteryState, "Unknown");
+  assert.equal(status.batteryPercent, null);
+});
+
+test("the wireless product id (0x522C) reports connectionType Wireless and battery state Unknown until an input report arrives", async () => {
+  const { device } = fakeDevice({ productId: INCOTT_PRODUCT_ID });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.connectionType, "Wireless");
+  assert.equal(status.batteryState, "Unknown");
+});
+
+test("battery state is Unknown before any input report has arrived, regardless of product id or feature-report state", async () => {
+  // The old `state.batteryByte` fake-device field fed the disproven 0x8e
+  // feature-report battery read; it is kept here (still answering 0x38) to
+  // prove readStatus() no longer looks at it at all — see the dedicated
+  // 0x8e regression test further down for the sharper version of this claim.
+  const { device } = fakeDevice({ productId: INCOTT_PRODUCT_ID_WIRED, state: { batteryByte: null } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.batteryPercent, null);
+  assert.equal(status.batteryState, "Unknown");
+  assert.equal(status.connectionType, "Wired", "connection type is independent of the battery read");
+});
+
+test("supportedPollingRates and the polling footnote are narrower over the wired connection", async () => {
+  // Hardware-verified: the owner confirmed the mouse only reaches 1000 Hz
+  // over the cable; 2000/4000/8000 Hz are wireless-only. Offering them wired
+  // would let the shell stage a write the device silently refuses.
+  const { device } = fakeDevice({ productId: INCOTT_PRODUCT_ID_WIRED });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.deepEqual(status.supportedPollingRates, [125, 250, 500, 1000]);
+  assert.equal(status.ui?.hideUnsupportedPollingRates, true);
+  assert.equal(status.ui?.pollingNote, "Up to 1,000 Hz over the cable; 8,000 Hz needs the wireless dongle.");
+});
+
+test("supportedPollingRates offers the full ladder over the wireless connection", async () => {
+  const { device } = fakeDevice({ productId: INCOTT_PRODUCT_ID });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.deepEqual(status.supportedPollingRates, [125, 250, 500, 1000, 2000, 4000, 8000]);
+  assert.equal(status.ui?.pollingNote, "Up to 8,000 Hz wireless; 1,000 Hz over the cable.");
+});
+
+test("readStatus normalizes the wired product string down to its real model name", async () => {
+  // Verified 2026-09-08: the real model name is only present in the wired
+  // product string. The wireless dongle's string is a generic name with no
+  // model in it — readStatus tidies whichever raw string it gets without
+  // inventing a model when wireless.
+  const { device } = fakeDevice({ productId: INCOTT_PRODUCT_ID_WIRED, productName: "incott Esports G23V2Pro mouse" });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.name, "Esports G23V2Pro");
+  assert.equal(device.productName, "incott Esports G23V2Pro mouse", "the raw string stays available on the device");
+});
+
+test("firmware falls back to a plain notice when identity cannot be read", async () => {
+  const { device } = fakeDevice({ state: { identity: null } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.deepEqual(status.firmware, ["Identity unavailable"]);
+});
+
+test("readStatus degrades to identity-only fields rather than fabricate the polling rate when 0x81 never answers", async () => {
+  const { device } = fakeDevice({ silent: [0x81] });
+  const client = new IncottHidClient(device, fast);
+  const status = await client.readStatus();
+  assert.equal(status.name, "8K wireless");
+  assert.equal(status.brand, "Incott");
+  assert.equal(status.pollingRateHz, 0, "inert placeholder, never rendered because settingsReady is false");
+  assert.equal(status.ui?.settingsReady, false);
+  assert.equal(status.ui?.valuesVerified, false);
+});
+
+test("readStatus reflects a DPI value written earlier this session", async () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.setDpi(1600);
+  const status = await client.readStatus();
+  assert.equal(status.ui?.settingsReady, true);
+  assert.equal(status.ui?.valuesVerified, true);
+  assert.equal(status.dpi, 1600);
+});
+
+test("setDpi writes the linear wire value to the active stage and confirms by reading it back", async () => {
+  const { device, sent, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  // Captured 2026-09-08: TX 09 02 <stage> <lo> <hi> — `stage` is the active
+  // stage's index (default 1 here), not the hardcoded 0x01 this driver used
+  // to send regardless of which stage was active (see incottEncodeSetDpi).
+  assert.equal(await client.setDpi(800), 800);
+  assert.equal(state.dpiStagesWire[1], 15);
+  assert.equal(await client.setDpi(25000), 25000);
+  assert.equal(state.dpiStagesWire[1], 499);
+
+  const writes = sent.filter((payload) => payload[0] === 0x02);
+  assert.deepEqual([...writes[0]!.slice(0, 4)], [0x02, 0x01, 0x0f, 0x00]);
+  assert.deepEqual([...writes[1]!.slice(0, 4)], [0x02, 0x01, 0xf3, 0x01]);
+});
+
+test("setDpi writes to whichever stage is actually active, not always stage 1", async () => {
+  const { device, sent, state } = fakeDevice({ state: { activeDpiStage: 4 } });
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.setDpi(3200), 3200);
+  assert.equal(state.dpiStagesWire[4], 63);
+  const write = sent.find((payload) => payload[0] === 0x02)!;
+  assert.equal(write[1], 4, "the stage byte must follow the active stage, not a hardcoded constant");
+});
+
+test("setDpi throws when the mouse does not keep the new value", async () => {
+  // Now that DPI has a real read-back (see the class comment in hid.ts), a
+  // dropped write is detected and reported the same way every other setter
+  // in this client reports one.
+  const stuck = fakeDevice({ ignoreWrites: true });
+  const stuckClient = new IncottHidClient(stuck.device, fast);
+  await assert.rejects(stuckClient.setDpi(6400), /kept 800 DPI instead of 6400/);
+  assert.equal(stuck.state.dpiStagesWire[1], 15, "the fake device's wire value never actually moved");
+});
+
+test("setDpi throws when the active DPI stage cannot be determined", async () => {
+  const { device } = fakeDevice({ silent: [0x83] });
+  const client = new IncottHidClient(device, fast);
+  await assert.rejects(client.setDpi(800), /active DPI stage/);
+});
+
+test("setDpi rejects a value outside 50-45000 or off the 50-DPI step without touching the device", async () => {
+  const { device, sent } = fakeDevice();
+  await assert.rejects(new IncottHidClient(device, fast).setDpi(45050), RangeError);
+  await assert.rejects(new IncottHidClient(device, fast).setDpi(825), RangeError);
+  assert.equal(sent.length, 0);
+});
+
+test("setActiveDpiStage selects a stage without writing a value into it — the regression this driver used to have", async () => {
+  // THE BUG: setDpi() used to be the only way to change DPI, so the app
+  // called it for what the user meant as a stage select, and it silently
+  // overwrote the active stage's stored value. setActiveDpiStage must not
+  // reproduce that: selecting stage 4 must never emit a 0x02 (stage-value)
+  // write, and the stage table must be completely unchanged afterwards.
+  const { device, sent, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  const before = [...state.dpiStagesWire];
+  assert.equal(await client.setActiveDpiStage(4), 4);
+  assert.equal(state.activeDpiStage, 4);
+  assert.deepEqual(state.dpiStagesWire, before, "selecting a stage must not alter any stage's stored value");
+  assert.equal(sent.some((payload) => payload[0] === 0x02), false, "must not emit a stage-value write");
+  const write = sent.find((payload) => payload[0] === 0x03)!;
+  assert.deepEqual([...write.slice(0, 3)], [0x03, 0x06, 0x04], "09 03 06 <idx> — command, sub-command, stage index");
+});
+
+test("setActiveDpiStage round-trips indices 0-5 and confirms by re-reading the active index", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  for (const index of [0, 3, 5, 1]) {
+    assert.equal(await client.setActiveDpiStage(index), index);
+    assert.equal(state.activeDpiStage, index);
+  }
+});
+
+test("setActiveDpiStage throws when the mouse does not keep the new active index", async () => {
+  const stuck = fakeDevice({ ignoreWrites: true });
+  const client = new IncottHidClient(stuck.device, fast);
+  await assert.rejects(client.setActiveDpiStage(3), /kept DPI stage 1 instead of 3/);
+});
+
+test("setActiveDpiStage rejects a stage index outside 0-5 without touching the device", async () => {
+  const { device, sent } = fakeDevice();
+  await assert.rejects(new IncottHidClient(device, fast).setActiveDpiStage(6), RangeError);
+  await assert.rejects(new IncottHidClient(device, fast).setActiveDpiStage(-1), RangeError);
+  assert.equal(sent.length, 0);
+});
+
+test("setDpiStageValue edits the requested stage regardless of which stage is active", async () => {
+  const { device, sent, state } = fakeDevice({ state: { activeDpiStage: 1 } });
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.setDpiStageValue(4, 3200), 3200);
+  assert.equal(state.dpiStagesWire[4], 63);
+  assert.equal(state.dpiStagesWire[1], 15, "the active stage's own value must be untouched");
+  const write = sent.find((payload) => payload[0] === 0x02)!;
+  assert.deepEqual([...write.slice(0, 4)], [0x02, 0x04, 0x3f, 0x00]);
+});
+
+test("setDpiStageValue throws when the mouse does not keep the new value", async () => {
+  const stuck = fakeDevice({ ignoreWrites: true });
+  const client = new IncottHidClient(stuck.device, fast);
+  await assert.rejects(client.setDpiStageValue(2, 6400), /kept 1600 DPI instead of 6400 on stage 2/);
+});
+
+test("setDpiStageValue rejects an out-of-range stage or DPI value without touching the device", async () => {
+  const { device, sent } = fakeDevice();
+  await assert.rejects(new IncottHidClient(device, fast).setDpiStageValue(6, 800), RangeError);
+  await assert.rejects(new IncottHidClient(device, fast).setDpiStageValue(0, 825), RangeError);
+  assert.equal(sent.length, 0);
+});
+
+test("setPollingRate round-trips through the wire table", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.setPollingRate(8000), 8000);
+  assert.equal(state.pollingWire, 4);
+});
+
+test("setPollingRate rejects an unsupported rate", async () => {
+  await assert.rejects(new IncottHidClient(fakeDevice().device, fast).setPollingRate(333), /polling/i);
+});
+
+test("setLiftOffDistance maps the three named stops onto tenths of a millimetre", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.setLiftOffDistance("Low"), "Low");
+  assert.equal(state.lodWire, 2);
+  assert.equal(await client.setLiftOffDistance("High"), "High");
+  assert.equal(state.lodWire, 1);
+  const stuck = fakeDevice({ ignoreWrites: true });
+  await assert.rejects(new IncottHidClient(stuck.device, fast).setLiftOffDistance("Low"), /kept a Medium lift-off/);
+});
+
+test("setMotionSync, setAngleSnapping and setRippleControl are independent toggles", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.setMotionSync(false), false);
+  assert.equal(state.motionSync, 0);
+  assert.equal(await client.setAngleSnapping(true), true);
+  assert.equal(state.angleSnap, 1);
+  assert.equal(await client.setRippleControl(true), true);
+  assert.equal(state.ripple, 1);
+  // Setting one toggle must not disturb the others.
+  assert.equal(state.motionSync, 0);
+});
+
+test("toggles fail loudly when the mouse does not keep the new value", async () => {
+  const stuck = fakeDevice({ ignoreWrites: true });
+  const client = new IncottHidClient(stuck.device, fast);
+  await assert.rejects(client.setMotionSync(false), /kept Motion Sync on/);
+  await assert.rejects(client.setAngleSnapping(true), /kept angle snapping off/);
+  await assert.rejects(client.setRippleControl(true), /kept ripple control off/);
+});
+
+test("setDebounceTime and setSleepTimeout round-trip and reject out-of-range values", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.setDebounceTime(12), 12);
+  assert.equal(state.debounceMs, 12);
+  assert.equal(await client.setSleepTimeout(900), 900);
+  assert.equal(state.sleepSeconds, 900);
+  await assert.rejects(client.setDebounceTime(31), /debounce/i);
+  await assert.rejects(client.setSleepTimeout(0), /sleep/i);
+});
+
+test("setReceiverLed round-trips and rejects an unimplemented mode", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.setReceiverLed(2), 2);
+  assert.equal(state.receiverLed, 2);
+  await assert.rejects(client.setReceiverLed(3), /receiver/i);
+});
+
+test("getDpiOptions publishes the real 50-45000 linear range in steps of 50; presets are a separate convenience list", async () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  const options = client.getDpiOptions();
+  assert.equal(options.length, 900);
+  assert.equal(options[0], 50);
+  assert.equal(options[options.length - 1]!, 45000);
+  assert.equal(options.includes(12000), true, "an arbitrary in-range, on-step value must be selectable");
+  assert.equal(options.includes(825), false, "off the 50-DPI step");
+  assert.deepEqual(client.getDpiDefaultStagePresets(), [400, 800, 1600, 2400, 3200, 6400]);
+
+  assert.equal(device.opened, false);
+  await client.open();
+  assert.equal(device.opened, true);
+  await client.close();
+  assert.equal(device.opened, false);
+});
+
+test("setPerformanceMode writes the raw 0-2 value and round-trips through the best-effort read-back", async () => {
+  const { device, sent, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.setPerformanceMode(2), 2);
+  assert.equal(state.performanceMode, 2);
+  assert.deepEqual([...sent[0]!.slice(0, 3)], [0x04, 0x05, 0x02]);
+  assert.equal(await client.getPerformanceMode(), 2);
+});
+
+test("setPerformanceMode does not throw when the device never answers the read-back", async () => {
+  const { device } = fakeDevice({ silent: [0x84] });
+  const client = new IncottHidClient(device, fast);
+  // Nothing to compare against, so this must succeed rather than fabricate a failure.
+  assert.equal(await client.setPerformanceMode(1), 1);
+  assert.equal(await client.getPerformanceMode(), null);
+});
+
+test("setPerformanceMode throws when a confirmed read-back disagrees", async () => {
+  const { device } = fakeDevice({ ignoreWrites: true });
+  await assert.rejects(new IncottHidClient(device, fast).setPerformanceMode(2), /kept performance mode 1/);
+});
+
+test("setPerformanceMode rejects a value outside 0-2", async () => {
+  await assert.rejects(new IncottHidClient(fakeDevice().device, fast).setPerformanceMode(3), RangeError);
+});
+
+// ---------------------------------------------------------------------------
+// incottProbeCollection / incottSelectCollection — the wired dead-collection
+// fix. Hardware-verified 2026-09-08: the wired mouse exposes two
+// identical-looking 0xFF05 collections on the same interface; only one
+// answers feature reports, and the other fails Windows' HidD_SetFeature call
+// outright. Usage page alone cannot distinguish them — only probing can.
+// ---------------------------------------------------------------------------
+
+/** A transport whose sendFeatureReport always throws — the dead collection. */
+class ThrowingTransport implements FeatureTransport {
+  async sendFeatureReport(): Promise<void> {
+    throw new Error("HidD_SetFeature: (0x00000001) Incorrect function");
+  }
+  async receiveFeatureReport(): Promise<DataView> {
+    return new DataView(new Uint8Array(64).buffer);
+  }
+}
+
+/** A transport that answers the identity query like the live collection. */
+class IdentityTransport implements FeatureTransport {
+  sent: Uint8Array[] = [];
+  async sendFeatureReport(_reportId: number, data: BufferSource): Promise<void> {
+    this.sent.push(new Uint8Array(data as ArrayBuffer));
+  }
+  async receiveFeatureReport(): Promise<DataView> {
+    const value = frame(0x8f, 0x01, 0x0e, 0x02, 0xf0, 0xf1, 0x00, 0xff);
+    return new DataView(value.buffer, value.byteOffset, value.byteLength);
+  }
+}
+
+test("incottProbeCollection returns true when the collection answers the identity probe", async () => {
+  assert.equal(await incottProbeCollection(new IdentityTransport(), immediate), true);
+});
+
+test("incottProbeCollection returns false, never throws, when sendFeatureReport rejects", async () => {
+  await assert.doesNotReject(async () => {
+    assert.equal(await incottProbeCollection(new ThrowingTransport(), immediate), false);
+  });
+});
+
+test("incottProbeCollection returns false when the collection never replies", async () => {
+  const silent: FeatureTransport = {
+    async sendFeatureReport() {},
+    async receiveFeatureReport() {
+      return new DataView(new Uint8Array(64).buffer);
+    },
+  };
+  assert.equal(await incottProbeCollection(silent, immediate), false);
+});
+
+test("incottSelectCollection picks the second candidate when the first throws on sendFeatureReport", async () => {
+  // Mirrors the real wired scenario: ordered 0xFF05-first candidates, the
+  // first one dead, the second one live.
+  const dead = new ThrowingTransport();
+  const live = new IdentityTransport();
+  const chosen = await incottSelectCollection([dead, live], immediate);
+  assert.equal(chosen, live);
+});
+
+test("incottSelectCollection returns null when every candidate is dead", async () => {
+  const chosen = await incottSelectCollection([new ThrowingTransport(), new ThrowingTransport()], immediate);
+  assert.equal(chosen, null);
+});
+
+test("incottSelectCollection returns the sole candidate when it is the only one and it answers", async () => {
+  const live = new IdentityTransport();
+  assert.equal(await incottSelectCollection([live], immediate), live);
+});
+
+// ---------------------------------------------------------------------------
+// IncottHidClient.open() + readStatus() — the WebHID single-collection path.
+// ---------------------------------------------------------------------------
+
+test("open() probes the identity query and readStatus() still reads normally when the collection is live", async () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.open();
+  const status = await client.readStatus();
+  // The probe itself must not disturb a live collection's normal readout.
+  assert.equal(status.ui?.settingsReady, true);
+  assert.equal(status.dpi, 800);
+});
+
+test("open() never throws when the collection is dead, and readStatus() degrades gracefully without wasting the retry budget on every field", async () => {
+  const { device, sent } = fakeDevice({ deadCollection: true });
+  const client = new IncottHidClient(device, fast);
+  // Neither call may throw — this IS the graceful-degradation contract.
+  await client.open();
+  const sentAfterOpen = sent.length;
+  const status = await client.readStatus();
+  // Fast path: readStatus() must not have issued a single further send once
+  // open()'s probe already proved this collection dead (it would otherwise
+  // attempt ~12 more queries, each burning its own retry budget).
+  assert.equal(sent.length, sentAfterOpen, "readStatus must not query a collection already known to be dead");
+  assert.equal(status.ui?.settingsReady, false);
+  assert.equal(status.ui?.valuesVerified, false);
+  assert.equal(status.dpi, 0, "inert placeholder, never rendered because settingsReady is false");
+  assert.equal(status.pollingRateHz, 0);
+  assert.equal(status.batteryPercent, null);
+  assert.equal(status.batteryState, "Unknown");
+  assert.equal(status.dpiStages, undefined);
+  assert.equal(status.motionSync, null);
+  assert.equal(status.debounceMs, null);
+  // Identity, brand and name come from the USB descriptor / fallback string,
+  // not a feature report, so they remain genuinely available.
+  assert.equal(status.brand, "Incott");
+  assert.equal(status.name, "8K wireless");
+  assert.deepEqual(status.firmware, ["Identity unavailable"]);
+  assert.match(status.ui?.statusNote ?? "", /second, identical-looking collection/);
+});
+
+test("readStatus without ever calling open() is unaffected by the dead-collection fast path", async () => {
+  // Every pre-existing test in this file calls readStatus() without open()
+  // first; collectionVerified must stay null (not false) in that case so
+  // this fast path never engages for callers that never probed.
+  const { device } = fakeDevice({ silent: [0x81, 0x82, 0x83, 0x84, 0x85, 0x88, 0x89, 0x8e, 0x8f] });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.ui?.settingsReady, false);
+  assert.equal(status.ui?.statusNote, undefined, "no probe ran, so there is nothing to report as a dead collection");
+});
+
+// ---------------------------------------------------------------------------
+// Battery via the mouse's unsolicited input report (hardware-verified
+// 2026-09-08) — NOT the disproven 0x8e/byte-6 or 0x89/byte-8 feature-report
+// reads. See the class comment on IncottHidClient and incottDecodeInputStatus
+// in src/incott/index.ts.
+// ---------------------------------------------------------------------------
+
+test("battery is null and state Unknown before any input report has arrived, even after open()", async () => {
+  // Attaching the listener in open() must not itself fabricate a reading —
+  // only an actual input report may populate battery.
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.open();
+  const status = await client.readStatus();
+  assert.equal(status.batteryPercent, null);
+  assert.equal(status.batteryState, "Unknown");
+});
+
+test("an unsolicited discharging input report (0x5f) is cached and reported as 95% Discharging", async () => {
+  // Captured on hardware 2026-09-08: 09 5f 10 04 00 0f 0f 10 (node-hid).
+  // fireInputReport's bytes exclude the report id, matching the WebHID
+  // convention onInputReport expects: byte0 = 0x5f, byte1 = 0x10.
+  const { device, fireInputReport } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.open();
+  fireInputReport([0x5f, 0x10, 0x04, 0x00, 0x0f, 0x0f, 0x10]);
+  const status = await client.readStatus();
+  assert.equal(status.batteryPercent, 95);
+  assert.equal(status.batteryState, "Discharging");
+});
+
+test("an unsolicited charging input report (0xe1) is cached and reported as 97% Charging", async () => {
+  // Captured on hardware 2026-09-08: 09 e1 10 04 00 0f 0f 10 (node-hid).
+  const { device, fireInputReport } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.open();
+  fireInputReport([0xe1, 0x10, 0x04, 0x00, 0x0f, 0x0f, 0x10]);
+  const status = await client.readStatus();
+  assert.equal(status.batteryPercent, 97);
+  assert.equal(status.batteryState, "Charging");
+});
+
+test("the charging state comes from the input report's own bit, not from wired-ness", async () => {
+  // A wireless unit (0x522C) reporting a charging byte (e.g. on a charging
+  // dock/cable that does not change the enumerated product id) must still
+  // show Charging: the report is authoritative, not the product id.
+  const { device, fireInputReport } = fakeDevice({ productId: INCOTT_PRODUCT_ID });
+  const client = new IncottHidClient(device, fast);
+  await client.open();
+  fireInputReport([0xe1, 0x10, 0x04, 0x00, 0x0f, 0x0f, 0x10]);
+  const status = await client.readStatus();
+  assert.equal(status.connectionType, "Wireless");
+  assert.equal(status.batteryState, "Charging");
+  assert.equal(status.batteryPercent, 97);
+});
+
+test("close() removes the input-report listener; a report fired afterwards is not cached", async () => {
+  const { device, fireInputReport } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.open();
+  await client.close();
+  fireInputReport([0x5f, 0x10, 0x04, 0x00, 0x0f, 0x0f, 0x10]);
+  const status = await client.readStatus();
+  assert.equal(status.batteryPercent, null, "no listener was attached to receive this report");
+});
+
+test("REGRESSION: battery is not read from the 0x8e/0x01 feature-report reply, even when its byte 6 carries a plausible value", async () => {
+  // The default fake device answers 0x8e/0x01 with byte 6 = 0x38 (56) — the
+  // exact constant a full hardware charge cycle proved never changes (see
+  // INCOTT_CMD_QUERY_BATTERY in src/incott/index.ts). readStatus() must not
+  // query 0x8e for battery at all any more; battery stays null without an
+  // input report, and 56 in particular must never appear.
+  const { device } = fakeDevice({ state: { batteryByte: 0x38 } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.notEqual(status.batteryPercent, 56);
+  assert.equal(status.batteryPercent, null);
+  assert.equal(status.batteryState, "Unknown");
+});

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -1,0 +1,958 @@
+import type { MouseStatus, MouseUiHints } from "../mouse-types.ts";
+import {
+  incottDecodeDebounce,
+  incottDecodeDpiStage,
+  incottDecodeDpiStageIndex,
+  incottDecodeIdentity,
+  incottDecodeInputStatus,
+  incottDecodeLiftOffDirect,
+  incottDecodePerformanceMode,
+  incottDecodePollingRate,
+  incottDecodeReceiverLed,
+  incottDecodeSleep,
+  incottDecodeToggle,
+  incottEncodeQuery,
+  incottEncodeSetActiveDpiStage,
+  incottEncodeSetDebounce,
+  incottEncodeSetDpi,
+  incottEncodeSetLiftOff,
+  incottEncodeSetPerformanceMode,
+  incottEncodeSetPollingRate,
+  incottEncodeSetReceiverLed,
+  incottEncodeSetSleep,
+  incottEncodeSetToggle,
+  incottFrameMatches,
+  incottIsWiredProduct,
+  incottLiftOffLabel,
+  incottLiftOffTenths,
+  incottNormalizeProductName,
+  incottValidateDpi,
+  INCOTT_CMD_QUERY_DPI_STAGE,
+  INCOTT_CMD_QUERY_DPI_STAGE_VALUE,
+  INCOTT_CMD_QUERY_IDENTITY,
+  INCOTT_CMD_QUERY_POLLING,
+  INCOTT_CMD_QUERY_RECEIVER_LED,
+  INCOTT_CMD_QUERY_SENSOR,
+  INCOTT_CMD_QUERY_TIMING,
+  INCOTT_DEBOUNCE_MAX_MS,
+  INCOTT_DPI_DEFAULT_STAGE_PRESETS,
+  INCOTT_DPI_MAX,
+  INCOTT_DPI_MIN,
+  INCOTT_DPI_STAGE_COUNT,
+  INCOTT_DPI_STEP,
+  INCOTT_INPUT_REPORT_ID,
+  INCOTT_POLLING_STEPS_HZ,
+  INCOTT_POLLING_STEPS_HZ_WIRED,
+  INCOTT_PRODUCT_IDS,
+  INCOTT_SLEEP_OPTIONS,
+  INCOTT_REPORT_ID,
+  INCOTT_RESPONSE_LENGTH,
+  INCOTT_SUB_ANGLE_SNAP,
+  INCOTT_SUB_DEBOUNCE,
+  INCOTT_SUB_DPI_STAGE,
+  INCOTT_SUB_LOD,
+  INCOTT_SUB_MOTION_SYNC,
+  INCOTT_SUB_NONE,
+  INCOTT_SUB_PERFORMANCE,
+  INCOTT_SUB_RIPPLE,
+  INCOTT_SUB_SLEEP,
+  INCOTT_USAGE_PAGE,
+  INCOTT_VENDOR_ID,
+  INCOTT_VENDOR_USAGE_PAGE_MIN,
+  type IncottInputStatus,
+} from "../../incott/index.ts";
+
+type LiftOffLevel = "Low" | "Medium" | "High";
+
+/**
+ * The slice of HIDDevice this layer needs for feature-report exchanges, so
+ * tests can supply a fake instead of a real WebHID device. A real HIDDevice
+ * satisfies this structurally.
+ */
+export interface FeatureTransport {
+  sendFeatureReport(reportId: number, data: BufferSource): Promise<void>;
+  receiveFeatureReport(reportId: number): Promise<DataView>;
+}
+
+export interface IncottTransactionOptions {
+  /** Delay between sending a request and reading the response. */
+  settleMs?: number;
+  /** How many reads to attempt before giving up. */
+  attempts?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Serializes feature-report request/response pairs for the Incott protocol.
+ *
+ * The device exposes a single shared response buffer, so overlapping requests
+ * and leftover frames both produce values that belong to a different query —
+ * probing the same query three times in separate runs returned three
+ * different payloads on real hardware. Every request therefore runs alone,
+ * discards whatever was already latched, and accepts a frame only when its
+ * command and sub-command echo the request. Ported intact from IncottHub
+ * (`src/drivers/incott/transaction.ts`), including the stale-frame regression
+ * this exists to prevent — the prior-art Go implementation (IncottHIDApp)
+ * matches on the command byte alone and is fooled by exactly this.
+ */
+export class IncottTransactionQueue {
+  private readonly transport: FeatureTransport;
+  private readonly settleMs: number;
+  private readonly attempts: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private tail: Promise<unknown> = Promise.resolve();
+
+  constructor(transport: FeatureTransport, options: IncottTransactionOptions = {}) {
+    this.transport = transport;
+    this.settleMs = options.settleMs ?? 50;
+    this.attempts = options.attempts ?? 10;
+    this.sleep = options.sleep ?? defaultSleep;
+  }
+
+  /**
+   * Sends one request and returns the matching response frame, or null when
+   * no matching frame arrives. Never rejects: a device that stops answering
+   * yields null so the caller can render an em dash instead of a stale value.
+   */
+  request(payload: Uint8Array, cmd: number, sub: number | null): Promise<Uint8Array | null> {
+    const run = this.tail.then(() => this.exchange(payload, cmd, sub));
+    // Keep the chain alive even if one exchange throws.
+    this.tail = run.catch(() => undefined);
+    return run;
+  }
+
+  /**
+   * Sends a write, which the device does not answer. Queued alongside
+   * requests so ordering holds, but it never reads: waiting for a response
+   * that will never arrive would spend the entire attempt budget per write.
+   */
+  send(payload: Uint8Array): Promise<void> {
+    const run = this.tail.then(async () => {
+      try {
+        await this.transport.sendFeatureReport(INCOTT_REPORT_ID, toArrayBuffer(payload));
+      } catch {
+        // A failed write surfaces as a failed read-back in the client.
+      }
+    });
+    this.tail = run.catch(() => undefined);
+    return run;
+  }
+
+  private async exchange(
+    payload: Uint8Array,
+    cmd: number,
+    sub: number | null,
+  ): Promise<Uint8Array | null> {
+    try {
+      // Discard anything latched by a previous exchange before sending.
+      await this.read();
+      await this.transport.sendFeatureReport(INCOTT_REPORT_ID, toArrayBuffer(payload));
+      for (let attempt = 0; attempt < this.attempts; attempt += 1) {
+        if (this.settleMs > 0) await this.sleep(this.settleMs);
+        const frame = await this.read();
+        if (frame && incottFrameMatches(frame, cmd, sub)) return frame;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async read(): Promise<Uint8Array | null> {
+    try {
+      const view = await this.transport.receiveFeatureReport(INCOTT_REPORT_ID);
+      const out = new Uint8Array(INCOTT_RESPONSE_LENGTH);
+      const length = Math.min(view.byteLength, INCOTT_RESPONSE_LENGTH);
+      for (let index = 0; index < length; index += 1) out[index] = view.getUint8(index);
+      return out;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Sends the identity query (`09 8f 00`) directly against a transport and
+ * checks for a well-formed reply — byte 0 the report id (`0x09`), byte 1 the
+ * echoed command (`0x8f`). Never throws: a transport whose `sendFeatureReport`
+ * rejects, or that answers with something else entirely, both resolve to
+ * `false` (via `IncottTransactionQueue`'s own catch-and-return-null path),
+ * exactly like a device that is not there.
+ *
+ * WHY THIS EXISTS (BUG, hardware-verified 2026-09-08): wired, the mouse
+ * exposes TWO top-level collections on usage page `0xFF05` on the same
+ * interface — identical as far as vendor/product id and usage page go — but
+ * only one of them actually answers feature reports. The other rejects every
+ * one at the OS level (`HidD_SetFeature: (0x00000001) Incorrect function` on
+ * Windows). Usage page alone cannot tell them apart; only sending something
+ * and checking for a real reply can. See `incottSelectCollection` for the
+ * ordered probe-and-pick algorithm this backs, and the comment on
+ * `IncottHidClient.open()` for why a WebHID-based client can only apply this
+ * to the single collection it was handed, not choose between two.
+ */
+export async function incottProbeCollection(
+  transport: FeatureTransport,
+  options?: IncottTransactionOptions,
+): Promise<boolean> {
+  const queue = new IncottTransactionQueue(transport, options);
+  const frame = await queue.request(
+    incottEncodeQuery(INCOTT_CMD_QUERY_IDENTITY, INCOTT_SUB_NONE),
+    INCOTT_CMD_QUERY_IDENTITY,
+    null,
+  );
+  return frame !== null && frame[0] === INCOTT_REPORT_ID && frame[1] === INCOTT_CMD_QUERY_IDENTITY;
+}
+
+/**
+ * Picks the first candidate transport whose collection actually answers the
+ * identity probe, trying candidates in the given order and moving on to the
+ * next one when a candidate throws, never replies, or replies with garbage.
+ * Returns `null` when no candidate answers.
+ *
+ * Candidates must be pre-ordered by the CALLER: `0xFF05` first, then any
+ * page `>= INCOTT_VENDOR_USAGE_PAGE_MIN` (`0xFF00`) as a fallback — this
+ * function only probes in the order it is given, it does not itself inspect
+ * usage pages. This is the general form of the wired dead-collection fix
+ * (see `incottProbeCollection`): a transport layer that genuinely has more
+ * than one candidate to try (for example a Node-hid-based tool with access
+ * to every top-level collection's own path) can use this directly. WebHID
+ * cannot: it hands `IncottHidClient` exactly one `HIDDevice` per collection,
+ * already chosen by the browser's picker/filters before this driver ever
+ * sees it, so `IncottHidClient.open()` uses `incottProbeCollection` on
+ * itself instead of calling this with more than one candidate.
+ */
+export async function incottSelectCollection<T extends FeatureTransport>(
+  candidates: readonly T[],
+  options?: IncottTransactionOptions,
+): Promise<T | null> {
+  for (const candidate of candidates) {
+    try {
+      if (await incottProbeCollection(candidate, options)) return candidate;
+    } catch {
+      // Move on to the next candidate.
+    }
+  }
+  return null;
+}
+
+/**
+ * Byte 2 echoes the sub-command for the DPI-stage-value, sensor and timing
+ * queries, so it must be matched there. For polling, receiver LED and
+ * identity it carries data instead, and matching it would reject valid
+ * responses (every polling rate but 1000 Hz, every LED mode but 0, and
+ * identity entirely).
+ *
+ * `0x82` (DPI stage value) was added on 2026-09-08, confirmed directly on
+ * hardware: `09 82 03` replies `09 82 03 …`. `0x81` (polling) was
+ * DELIBERATELY re-confirmed NOT to belong here on the same date: writing wire
+ * `1` then wire `0` and reading back showed byte 2 of the `0x81` reply follow
+ * the write (`0 -> 1 -> 0`) — it is data, not an echoed sub-command, and
+ * matching it as one would reject every polling rate but 1000 Hz.
+ *
+ * `0x8e` (battery) used to be registered here (added 2026-09-07 alongside the
+ * original, now-disproven DPI/battery corrections — see
+ * `INCOTT_CMD_QUERY_BATTERY`) but this driver no longer queries `0x8e` for
+ * anything: battery is read from the mouse's unsolicited input report
+ * instead (see `onInputReport` below), so there is no live query left for
+ * this list to matter to. `incottDecodeBattery`'s own frame-matching in
+ * `src/incott/index.ts` is unaffected by this list either way.
+ *
+ * `0x86` (button reads) shows the identical sub-echo pattern but is not
+ * queried anywhere in this driver — see `INCOTT_CMD_QUERY_BUTTON` in
+ * `src/incott/index.ts` for where to add it if a button read is ever wired
+ * up here.
+ */
+const SUB_ECHOING_QUERIES: readonly number[] = [
+  INCOTT_CMD_QUERY_DPI_STAGE,
+  INCOTT_CMD_QUERY_DPI_STAGE_VALUE,
+  INCOTT_CMD_QUERY_SENSOR,
+  INCOTT_CMD_QUERY_TIMING,
+];
+
+function toggleWord(value: boolean | null): string {
+  return value === null ? "an unreadable state" : value ? "on" : "off";
+}
+
+/**
+ * WebHID client for the Incott protocol (vendor 0x093A, products 0x522C /
+ * 0x622C). Ported from IncottHub, adapted to mouse-protocol's driver
+ * interface: the client owns `device`, `open()` and `close()` directly
+ * instead of taking an externally-managed transport, matching every other
+ * driver in this registry.
+ *
+ * FOUR bugs fixed 2026-09-08 from an owner's hardware probes in BOTH wireless
+ * and wired modes (see `docs/incott-testing.md`):
+ *
+ *   1. WIRED MODE WAS COMPLETELY BROKEN. The wired mouse exposes two
+ *      identical-looking `0xFF05` collections; only one answers feature
+ *      reports, and usage page alone cannot tell them apart. See `open()`'s
+ *      identity probe and `incottProbeCollection`/`incottSelectCollection`.
+ *   2. `0x622C` means the connection is WIRED, not "charging" — charging is
+ *      a consequence of being plugged in, not what the id encodes. See
+ *      `incottIsWiredProduct` (renamed from `incottIsChargingProduct`) and
+ *      `MouseStatus.connectionType` below.
+ *   3. The polling-rate ceiling depends on the connection: the full
+ *      125-8000 Hz ladder is wireless-only, and the mouse only reaches
+ *      1000 Hz over the cable — see `INCOTT_POLLING_STEPS_HZ_WIRED`.
+ *   4. The real model name ("Esports G23V2Pro") is only in the WIRED product
+ *      string; wireless reports a generic name with no model in it at all.
+ *      See `incottNormalizeProductName`.
+ *
+ * Polling rate (0x81) is verified readable on hardware, but `readStatus()`
+ * must not throw (see the write-a-driver doc): when it cannot be read after
+ * the transaction queue's full retry budget, the client falls back to an
+ * identity-only status — real `name`, `brand`, and whatever else was
+ * genuinely readable — with `ui.settingsReady: false` and
+ * `ui.valuesVerified: false` so the app hides the settings grid instead of
+ * rendering fabricated values. `MouseStatus.pollingRateHz` is non-nullable,
+ * so the degraded path still assigns it a number; see the comment at that
+ * assignment for why that is not a fabricated reading.
+ *
+ * DPI USED to have no known read-back at all; that changed 2026-09-08. DPI
+ * lives in a six-stage table (see `INCOTT_DPI_STAGE_COUNT` in
+ * `src/incott/index.ts`) with FOUR independent operations, not one:
+ *
+ *   which stage is active   read: `0x83`/`0x06`     write: `0x03`/`0x06 <idx>`
+ *   what a stage holds      read: `0x82`/`<stage>`  write: `0x02 <stage> <lo> <hi>`
+ *
+ * `readStatus()` reads which stage is active (`incottDecodeDpiStageIndex`)
+ * and every one of the six stages' stored values (`incottDecodeDpiStage`),
+ * populating `dpiStages`/`activeDpiStage` for OpenMouse's shared multi-stage
+ * DPI editor (`MouseUiHints.dpiStageEditor`) and deriving `dpi` as the active
+ * stage's own value — a genuine live read, not a write cache.
+ *
+ * `setActiveDpiStage()` and `setDpiStageValue()` map onto the select and edit
+ * operations above respectively, matching OpenMouse's existing generic
+ * contract (`requireClientMethod` in `openmouse/src/device/controller.ts`).
+ * `setDpi()` is kept for the plain preset row and is defined as "set the
+ * ACTIVE stage's value" — i.e. it is exactly `setDpiStageValue` at whichever
+ * stage is currently active — since that is the only meaning left for it now
+ * that a real select operation exists.
+ *
+ * A SECOND DPI BUG, found from an owner report and fixed the same day
+ * (2026-09-08): `setDpi()` used to be the *only* way to touch DPI, so the app
+ * called it every time the user picked a value from the plain preset row —
+ * indistinguishable, from the user's point of view, from "select the stage
+ * that already holds this value." It never did that: it read the active
+ * stage and overwrote *that* stage's stored value with whatever was picked,
+ * one stage at a time destroying the mouse's factory-programmed table.
+ * (IncottHIDApp's own `0x03`/`0x06` write — which that project mislabels "set
+ * DPI" — is actually the active-stage SELECT and never touches the table;
+ * see `INCOTT_CMD_SET_DPI_STAGE` in `src/incott/index.ts`.) Wiring
+ * `dpiStages`/`activeDpiStage`/`dpiStageEditor` here gives the app a real
+ * select control (`setActiveDpiStage`) so `setDpi` is no longer asked to do a
+ * select's job.
+ *
+ * `valuesVerified` is true once both the polling-rate query and the active
+ * stage's DPI read have answered — see `readStatus()`.
+ *
+ * A FIFTH bug, fixed 2026-09-08: battery used to be read from the `0x8e`
+ * feature-report reply, byte 6. Charging a unit through a full cycle (roughly
+ * 60% to roughly 97%) while polling that reply showed byte 6 never move at
+ * all — a constant, not a live reading, the same failure mode `0x89` byte 8
+ * suffered before it (see `INCOTT_CMD_QUERY_BATTERY` in
+ * `src/incott/index.ts`). The real battery level lives in an UNSOLICITED
+ * INPUT report the mouse emits on report id 0x09 while it is actively being
+ * used — see `onInputReport` below and `incottDecodeInputStatus`. The device
+ * only emits these while in use, so `readStatus()` reports `batteryPercent:
+ * null` / `batteryState: "Unknown"` until the first one arrives; nothing here
+ * fabricates a number or falls back to the disproven feature-report bytes.
+ * `batteryState`'s charging flag comes from the report's own high bit
+ * (`raw > 100`), not from the product id: `incottIsWiredProduct` (0x622C)
+ * still means the CONNECTION is wired, which is what `connectionType` below
+ * uses, and being wired does imply charging in practice, but the input report
+ * is the authoritative source for the charging state, not an inference from
+ * the product id.
+ */
+export class IncottHidClient {
+  readonly device: HIDDevice;
+  private readonly queue: IncottTransactionQueue;
+  /**
+   * Cached decode of the mouse's unsolicited input report (battery plus a
+   * packed DPI-stage/polling-rate snapshot) — see `onInputReport` and the
+   * class comment's battery section. `null` until the first report arrives
+   * (the mouse only emits them while actively in use), which is exactly when
+   * `readStatus()` must report `batteryPercent: null` / `batteryState:
+   * "Unknown"` rather than a fabricated value.
+   */
+  private lastInputStatus: IncottInputStatus | null = null;
+  /**
+   * Whether `open()`'s identity probe got a well-formed reply from the
+   * collection WebHID handed this client. `null` until `open()` runs (every
+   * unit test that skips `open()` and calls `readStatus()` directly keeps
+   * this `null`, so it behaves exactly as before this field existed);
+   * `false` means this specific collection is the wired mouse's dead
+   * look-alike (see the class comment and `open()`).
+   */
+  private collectionVerified: boolean | null = null;
+
+  constructor(device: HIDDevice, options?: IncottTransactionOptions) {
+    this.device = device;
+    // A real HIDDevice satisfies FeatureTransport structurally.
+    this.queue = new IncottTransactionQueue(device, options);
+  }
+
+  /**
+   * Decodes the mouse's unsolicited input report and caches the result for
+   * `readStatus()` — see the class comment's battery section and
+   * `incottDecodeInputStatus` in `src/incott/index.ts`.
+   *
+   * BYTE-INDEX CONVENTION: WebHID's `inputreport` event carries `reportId`
+   * separately from `data`, and `data` EXCLUDES the report id — unlike this
+   * driver's feature-report frames, which include it because
+   * `receiveFeatureReport` returns it at byte 0 (see the top-of-file comment
+   * in `src/incott/index.ts` for that asymmetry, which this mirrors). So
+   * `event.data.getUint8(0)`/`getUint8(1)` are this report's bytes 1/2 in
+   * node-hid terms — node-hid's raw buffer includes the report id at index 0,
+   * which is how `captures/incott-8k-wireless/input-report-battery.hex` is
+   * indexed. Get this backwards and every field reads off by one byte.
+   *
+   * Filtered to report id `INCOTT_INPUT_REPORT_ID` (0x09): the mouse's other
+   * HID collections (mouse/keyboard boot reports, etc.) are not this vendor
+   * collection's traffic and must not be mistaken for it.
+   */
+  private readonly onInputReport = (event: HIDInputReportEvent): void => {
+    if (event.reportId !== INCOTT_INPUT_REPORT_ID) return;
+    if (event.data.byteLength < 2) return;
+    const decoded = incottDecodeInputStatus(event.data.getUint8(0), event.data.getUint8(1));
+    if (decoded) this.lastInputStatus = decoded;
+  };
+
+  /**
+   * Usage page alone cannot tell the wired mouse's two look-alike `0xFF05`
+   * collections apart (see the class comment and `open()`), so this stays
+   * permissive on purpose: it accepts ANY device on a vendor-defined usage
+   * page with a matching product id, including the one that turns out to be
+   * the dead collection. Rejecting it here would also reject the live one,
+   * since WebHID hands this method one collection at a time and both look
+   * identical from `vendorId`/`productId`/`usagePage` alone. The actual
+   * distinction is made by probing after `open()` — see `open()` and
+   * `readStatus()`'s graceful degradation when the probe fails.
+   */
+  static isSupported(device: HIDDevice): boolean {
+    if (device.vendorId !== INCOTT_VENDOR_ID) return false;
+    if (!INCOTT_PRODUCT_IDS.includes(device.productId)) return false;
+    return device.collections.some(
+      (collection) => (collection.usagePage ?? 0) >= INCOTT_VENDOR_USAGE_PAGE_MIN,
+    );
+  }
+
+  /**
+   * WebHID request filters for the vendor collection, one per product id —
+   * both the wireless dongle's `0x522C` (`INCOTT_PRODUCT_ID`) and the wired
+   * `0x622C` (`INCOTT_PRODUCT_ID_WIRED`), hardware-verified 2026-09-08, so
+   * the picker offers the mouse in either mode.
+   */
+  static get filters(): HIDDeviceFilter[] {
+    return INCOTT_PRODUCT_IDS.map((productId) => ({
+      vendorId: INCOTT_VENDOR_ID,
+      productId,
+      usagePage: INCOTT_USAGE_PAGE,
+    }));
+  }
+
+  /**
+   * The real writable range: 50-45000 DPI in steps of 50 (see `INCOTT_DPI_MIN`
+   * in `src/incott/index.ts`), returned densely so the shell's custom-DPI
+   * entry (which validates by exact membership, not by snapping to a nearby
+   * value) accepts any value in range — the same pattern already used for
+   * Razer's Viper V4 Pro (`100-50,000 in 50-DPI increments`) and for
+   * Zaunkoenig and Finalmouse. This is deliberately NOT
+   * `INCOTT_DPI_DEFAULT_STAGE_PRESETS` (the six round numbers the vendor
+   * calls default stage presets) — that list is too sparse for the shell to
+   * let a user dial in, say, 12000 DPI, which this mouse genuinely supports.
+   */
+  getDpiOptions(): number[] {
+    const count = (INCOTT_DPI_MAX - INCOTT_DPI_MIN) / INCOTT_DPI_STEP + 1;
+    return Array.from({ length: count }, (_, index) => INCOTT_DPI_MIN + index * INCOTT_DPI_STEP);
+  }
+
+  /** The vendor's six default DPI stage presets — a convenience list, not the writable range. See `INCOTT_DPI_DEFAULT_STAGE_PRESETS`. */
+  getDpiDefaultStagePresets(): number[] {
+    return [...INCOTT_DPI_DEFAULT_STAGE_PRESETS];
+  }
+
+  /** Longest debounce the firmware accepts, in milliseconds (verified: section 8 of the IncottHub spec). */
+  getDebounceMaxMs(): number {
+    return INCOTT_DEBOUNCE_MAX_MS;
+  }
+
+  /** The firmware accepts any integer 0-30 ms, so every value in range is offered. */
+  getDebounceOptions(): number[] {
+    return Array.from({ length: INCOTT_DEBOUNCE_MAX_MS + 1 }, (_, ms) => ms);
+  }
+
+  /** Curated presets within the verified 1-900s sleep-timer range; see INCOTT_SLEEP_OPTIONS. */
+  getSleepOptions(): number[] {
+    return [...INCOTT_SLEEP_OPTIONS];
+  }
+
+  /**
+   * Opens the device, then PROBES it with the identity query before trusting
+   * it for anything else — see `incottProbeCollection`.
+   *
+   * WIRED-MODE BUG, hardware-verified 2026-09-08: the wired mouse exposes
+   * two `0xFF05` collections on the same interface that are indistinguishable
+   * by vendor id, product id, or usage page; only one of them answers
+   * feature reports at all (the other fails every `HidD_SetFeature` call at
+   * the OS level). WebHID hands this client exactly ONE `HIDDevice`, already
+   * chosen by the browser's picker/filters before this driver ever sees
+   * it — a WebHID `HIDDevice` corresponds to a single collection, so there is
+   * no second candidate here for this method to fall back to the way
+   * `incottSelectCollection` can for a transport with real alternatives. All
+   * `open()` CAN do in the browser is find out, immediately and cheaply,
+   * whether the one collection it got is the live one.
+   *
+   * This never throws on a dead collection — it records the result in
+   * `collectionVerified` instead. `readStatus()` checks that flag and skips
+   * straight to a fully degraded, `ui.settingsReady: false` status (see
+   * there) rather than burning the full retry budget on roughly a dozen
+   * queries that a collection already known to be dead cannot answer either.
+   *
+   * Also attaches `onInputReport` (see the class comment's battery section):
+   * the mouse's battery lives only in an unsolicited input report it emits
+   * while actively in use, and WebHID delivers those solely as `inputreport`
+   * events on the device — there is no way to poll for one, so the listener
+   * must be attached here, before the device is ever read, or an in-use
+   * report could arrive and be missed before anything is listening.
+   */
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+    this.device.addEventListener("inputreport", this.onInputReport);
+    const identity = incottDecodeIdentity(await this.query(INCOTT_CMD_QUERY_IDENTITY, INCOTT_SUB_NONE));
+    this.collectionVerified = identity !== null;
+  }
+
+  async close(): Promise<void> {
+    this.device.removeEventListener("inputreport", this.onInputReport);
+    if (this.device.opened) await this.device.close();
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    // `connectionType`/`batteryState` derive from the product id, which is a
+    // USB descriptor field read at enumeration time — genuinely available
+    // even when the collection this client was handed turns out to be the
+    // wired mouse's dead one (see `open()`). Hardware-verified 2026-09-08:
+    // 0x622C enumerates ONLY when plugged in over USB; 0x522C is the 2.4 GHz
+    // dongle. This used to be read as a "charging" flag
+    // (`incottIsChargingProduct`) — the wrong axis: 0x622C means the
+    // CONNECTION is wired, and charging is a consequence of that, not what
+    // the id itself encodes. See `incottIsWiredProduct`.
+    const wired = incottIsWiredProduct(this.device.productId);
+    // The real model name ("Esports G23V2Pro") lives only in the WIRED
+    // product string; wireless reports a generic "incott 8K wireless mouse"
+    // with no model in it, and there is no way to read a model over the air
+    // — see `incottNormalizeProductName`'s doc comment. `this.device` stays
+    // public, so `client.device.productName` remains available as the
+    // untouched raw string for anything that wants it.
+    const rawName = this.device.productName || "Incott wireless mouse";
+    const name = incottNormalizeProductName(rawName);
+
+    // WIRED-MODE BUG, hardware-verified 2026-09-08 (see `open()`'s class
+    // comment): when `open()`'s identity probe found this collection dead,
+    // every one of the ~12 queries below would fail too, each only after
+    // burning its own retry budget. Skip straight to the degraded values
+    // instead of paying that cost for a foregone conclusion. `dead` stays
+    // `false` (not just falsy) whenever `open()` was never called or its
+    // probe succeeded, so every existing caller that reads status without
+    // opening first is unaffected.
+    const dead = this.collectionVerified === false;
+
+    // DPI is a genuine live read as of 2026-09-08 (see the class comment
+    // above): read which of the six stages is active, then every stage's own
+    // value. Per the driver's graceful-degradation contract, a device that
+    // stops answering yields `dpi: null` / an omitted `dpiStages` here rather
+    // than throwing or fabricating a value.
+    const activeDpiStage = dead
+      ? null
+      : incottDecodeDpiStageIndex(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_DPI_STAGE));
+    // Six sequential queries, deliberately NOT parallelized: the device has a
+    // single shared response buffer (see `IncottTransactionQueue`'s class
+    // comment), and concurrent requests would corrupt each other's replies.
+    // `this.query` already serializes through that queue, so a plain
+    // sequential loop is enough.
+    const dpiStageReads: Array<number | null> = [];
+    for (let stage = 0; stage < INCOTT_DPI_STAGE_COUNT; stage += 1) {
+      dpiStageReads.push(
+        dead ? null : incottDecodeDpiStage(await this.query(INCOTT_CMD_QUERY_DPI_STAGE_VALUE, stage), stage),
+      );
+    }
+    // `dpiStages` is populated only when every one of the six stages
+    // answered — a partial table is never fabricated with a placeholder for
+    // the stage(s) that did not.
+    const dpiStages = dpiStageReads.every((value): value is number => value !== null)
+      ? dpiStageReads
+      : null;
+    const dpi = activeDpiStage === null ? null : dpiStageReads[activeDpiStage] ?? null;
+    const pollingRateHz = dead
+      ? null
+      : incottDecodePollingRate(await this.query(INCOTT_CMD_QUERY_POLLING, INCOTT_SUB_NONE));
+    // The polling-rate (0x81) query is verified readable on hardware, but a
+    // device that stops answering must not throw readStatus() — the app
+    // degrades to identity-only fields instead (see `ui.settingsReady`
+    // below). `valuesVerified` also requires the active DPI stage's value to
+    // have answered.
+    const valuesVerified = dpi !== null && pollingRateHz !== null;
+
+    // Symmetric single-purpose reads, preferred over the packed byte-7
+    // nibble trick (`incottDecodeLiftOff`/`incottDecodeMotionSync`, still
+    // exported and tested): verified on hardware 2026-09-08 that both forms
+    // agree at every step (lift-off hw 0/1/2, motion sync 0/1/0).
+    const liftOffTenths = dead
+      ? null
+      : incottDecodeLiftOffDirect(await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_LOD));
+    const motionSync = dead
+      ? null
+      : incottDecodeToggle(await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_MOTION_SYNC), INCOTT_SUB_MOTION_SYNC);
+    const rippleControl = dead
+      ? null
+      : incottDecodeToggle(await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_RIPPLE), INCOTT_SUB_RIPPLE);
+    const angleSnapping = dead
+      ? null
+      : incottDecodeToggle(await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_ANGLE_SNAP), INCOTT_SUB_ANGLE_SNAP);
+    const debounceMs = dead
+      ? null
+      : incottDecodeDebounce(await this.query(INCOTT_CMD_QUERY_TIMING, INCOTT_SUB_DEBOUNCE));
+    const sleepTimeout = dead
+      ? null
+      : incottDecodeSleep(await this.query(INCOTT_CMD_QUERY_TIMING, INCOTT_SUB_SLEEP));
+    // Battery comes from `lastInputStatus` — the mouse's unsolicited input
+    // report, cached by `onInputReport` — NOT from a feature-report query.
+    // Deliberately independent of `dead`/the feature-report collection probe:
+    // the input report arrives on the device regardless of whether this
+    // client's feature-report collection turned out to be the wired mouse's
+    // dead look-alike (see `open()`), so a dead collection must not suppress
+    // a battery reading that genuinely came in. `null` here means "no report
+    // has arrived yet" (the mouse only emits them while actively in use), not
+    // a failed read — see the class comment's battery section and
+    // `incottDecodeInputStatus` in `src/incott/index.ts`. This REPLACES the
+    // disproven `0x8e`/sub `0x01` byte-6 read (itself a replacement for the
+    // also-disproven `0x89` byte 8) — see `INCOTT_CMD_QUERY_BATTERY` and
+    // `incottDecodeBattery`, both kept only as codecs/regression coverage.
+    const batteryPercent = this.lastInputStatus?.batteryPercent ?? null;
+    // The charging bit comes from the input report itself (raw > 100), not
+    // from the product id: `wired` (0x622C) is a genuinely reliable signal
+    // that being charged is *likely* (the mouse is plugged into USB), but the
+    // report is the authoritative source for whether it actually is charging
+    // right now, so it is used here instead of inferring the state from the
+    // connection.
+    const batteryCharging = this.lastInputStatus?.charging ?? null;
+    // Section 13 of the IncottHub spec: the identity byte layout is unknown,
+    // so the raw hex is shown rather than pretending to parse a version.
+    const identity = dead
+      ? null
+      : incottDecodeIdentity(await this.query(INCOTT_CMD_QUERY_IDENTITY, INCOTT_SUB_NONE));
+
+    // The owner confirmed on hardware that the mouse only reaches 1000 Hz
+    // over the cable — 2000/4000/8000 Hz are wireless-only (see
+    // `INCOTT_POLLING_STEPS_HZ_WIRED`). Publishing the full ladder while
+    // wired would let the shell offer a rate the device silently refuses,
+    // which `setPollingRate`'s read-back verification would then report as a
+    // failure on every attempt.
+    const supportedPollingRates = wired ? [...INCOTT_POLLING_STEPS_HZ_WIRED] : [...INCOTT_POLLING_STEPS_HZ];
+
+    const ui: MouseUiHints = {
+      family: "incott",
+      // The advanced section is the only place debounce, sleep, motion sync,
+      // angle snapping and ripple control render; Incott has no lighting, no
+      // onboard profiles, and no button remapping, so those cards stay hidden
+      // on their own (nothing populates the fields that gate them).
+      showAdvancedSection: true,
+      // No command reports link quality.
+      hideSignalCard: true,
+      defaultDisplayName: name,
+      // false only when the DPI and/or polling-rate query failed above (this
+      // includes the wired dead-collection fast path, since every query is
+      // forced to `null` there too); the app hides the settings grid rather
+      // than render the placeholder numbers assigned to `dpi`/`pollingRateHz`
+      // below in that case.
+      settingsReady: valuesVerified,
+      valuesVerified,
+      // OpenMouse's device-overview card (App.tsx) hides the battery column
+      // outright for a wired connection unless either a real percent is
+      // already known OR this flag is set — a sane default for mice with no
+      // battery at all while corded, but WRONG here: this mouse has an
+      // internal battery it charges over the same USB cable, and until the
+      // first unsolicited input report arrives (see the class comment's
+      // battery section) `batteryPercent` is genuinely `null` regardless of
+      // connection. Without this flag a freshly connected wired unit would
+      // show no battery card at all instead of the em dash the app renders
+      // for a null percent; with it, the card always shows (em dash first,
+      // then the real reading once a report arrives).
+      forceShowBattery: true,
+      // The mouse cannot accept a rate outside `supportedPollingRates` for
+      // its current connection, so hide the ones it would refuse rather than
+      // let the shell offer a write that read-back verification would then
+      // report as failed.
+      hideUnsupportedPollingRates: true,
+      pollingNote: wired
+        ? "Up to 1,000 Hz over the cable; 8,000 Hz needs the wireless dongle."
+        : "Up to 8,000 Hz wireless; 1,000 Hz over the cable.",
+      // Set only when open()'s probe found this specific collection dead —
+      // see the class comment on `open()`. Wired mice expose a second,
+      // identical-looking 0xFF05 collection that never answers; WebHID hands
+      // this client one collection at a time and cannot pick between them,
+      // so the only remedy today is to reconnect and hope the browser offers
+      // the other one.
+      ...(dead
+        ? { statusNote: "This HID collection never answered — wired mice expose a second, identical-looking collection that does not work. Try reconnecting." }
+        : {}),
+      // Six FIXED stages (`countEditable: false` hides the count picker —
+      // this hardware has no command to add or remove a stage). 45000 is the
+      // higher of the two known PixArt sensor ceilings paired in the
+      // vendor's own device definition (PAW3395: 32000, PAW3950: 45000);
+      // which one is fitted to a given unit cannot currently be read, so a
+      // PAW3395 unit is expected to have a write above 32000 refused by the
+      // existing read-back verification in `setDpi`/`setDpiStageValue`
+      // rather than this module guessing which sensor is present.
+      dpiStageEditor: { maxStages: INCOTT_DPI_STAGE_COUNT, countEditable: false, minDpi: INCOTT_DPI_MIN, maxDpi: INCOTT_DPI_MAX, stepDpi: INCOTT_DPI_STEP },
+    };
+
+    return {
+      brand: "Incott",
+      name,
+      ui,
+      // A genuine live read (the active stage's own value) when it
+      // succeeded. Otherwise this is inert placeholder data, not a
+      // fabricated reading: MouseStatus.dpi is non-nullable, so a number must
+      // go here, but `ui.settingsReady: false` above means the app never
+      // renders it.
+      dpi: dpi ?? 0,
+      // All six stages' stored values, only when every one of them answered
+      // — see the loop above. Omitted (not fabricated) on a partial read.
+      ...(dpiStages !== null ? { dpiStages } : {}),
+      ...(activeDpiStage !== null ? { activeDpiStage } : {}),
+      // Same reasoning as `dpi` above: a real reading of the polling-rate
+      // query (0x81) when it succeeded, otherwise inert placeholder data
+      // behind `ui.settingsReady: false`.
+      pollingRateHz: pollingRateHz ?? 0,
+      supportedPollingRates,
+      activeProfile: null,
+      connectionType: wired ? "Wired" : "Wireless",
+      batteryPercent,
+      // Derived from the input report's own charging bit (`batteryCharging`,
+      // see above), NOT from `wired`/the product id: `0x622C` reliably means
+      // the connection is wired, and being wired does imply charging, but the
+      // report — when one has arrived — is the authoritative source for
+      // whether the mouse is actually charging right now. "Unknown" is for
+      // when no input report has arrived yet, regardless of connection.
+      batteryState: batteryCharging === null ? "Unknown" : batteryCharging ? "Charging" : "Discharging",
+      liftOffDistance: liftOffTenths === null ? null : incottLiftOffLabel(liftOffTenths),
+      supportedLiftOffDistances: ["Low", "Medium", "High"],
+      motionSync,
+      rippleControl,
+      angleSnapping,
+      debounceMs,
+      sleepTimeout,
+      firmware: [identity ? `Identity ${identity.raw}` : "Identity unavailable"],
+    };
+  }
+
+  /**
+   * Sets the ACTIVE stage's stored DPI value — the only sane meaning left for
+   * a plain "set DPI" call now that a real stage-select operation exists (see
+   * `setActiveDpiStage` below and the class comment's account of the bug this
+   * used to have). This is exactly `setDpiStageValue(activeStage, dpi)`;
+   * confirms the write by reading that stage back, the same pattern every
+   * other setter in this client uses. Range/step are validated up front,
+   * before any device round-trip, so an invalid value never costs the query
+   * needed to find the active stage.
+   */
+  async setDpi(dpi: number): Promise<number> {
+    incottValidateDpi(dpi);
+    const stage = incottDecodeDpiStageIndex(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_DPI_STAGE));
+    if (stage === null) throw new Error("Could not read the active DPI stage to write.");
+    await this.write(incottEncodeSetDpi(stage, dpi));
+    const got = incottDecodeDpiStage(await this.query(INCOTT_CMD_QUERY_DPI_STAGE_VALUE, stage), stage);
+    if (got !== dpi) throw new Error(`The mouse kept ${got ?? "an unreadable"} DPI instead of ${dpi}.`);
+    return dpi;
+  }
+
+  /**
+   * SELECTS which of the six DPI stages is active (`09 03 06 <idx>`) —
+   * distinct from `setDpi`/`setDpiStageValue`, which EDIT a stage's stored
+   * value. Confirmed on hardware 2026-09-08 that a select never touches any
+   * stage's stored value (see `INCOTT_CMD_SET_DPI_STAGE` in
+   * `src/incott/index.ts`), so unlike every value setter in this client this
+   * one reads back `0x83`/`0x06` — the active index — not a DPI value.
+   */
+  async setActiveDpiStage(stage: number): Promise<number> {
+    if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
+      throw new RangeError(`DPI stage out of range: ${stage}`);
+    }
+    await this.write(incottEncodeSetActiveDpiStage(stage));
+    const got = incottDecodeDpiStageIndex(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_DPI_STAGE));
+    if (got !== stage) throw new Error(`The mouse kept DPI stage ${got ?? "an unreadable"} instead of ${stage}.`);
+    return stage;
+  }
+
+  /**
+   * EDITS one stage's stored DPI value directly, by index — unlike `setDpi`,
+   * which always targets whichever stage happens to be active right now.
+   * This is the write OpenMouse's shared multi-stage DPI editor uses when the
+   * user edits a specific stage row rather than the active-stage preset.
+   */
+  async setDpiStageValue(stage: number, dpi: number): Promise<number> {
+    if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
+      throw new RangeError(`DPI stage out of range: ${stage}`);
+    }
+    incottValidateDpi(dpi);
+    await this.write(incottEncodeSetDpi(stage, dpi));
+    const got = incottDecodeDpiStage(await this.query(INCOTT_CMD_QUERY_DPI_STAGE_VALUE, stage), stage);
+    if (got !== dpi) throw new Error(`The mouse kept ${got ?? "an unreadable"} DPI instead of ${dpi} on stage ${stage}.`);
+    return dpi;
+  }
+
+  async setPollingRate(hz: number): Promise<number> {
+    await this.write(incottEncodeSetPollingRate(hz));
+    const got = incottDecodePollingRate(await this.query(INCOTT_CMD_QUERY_POLLING, INCOTT_SUB_NONE));
+    if (got !== hz) throw new Error(`The mouse kept ${got ?? "an unreadable"} Hz instead of ${hz} Hz.`);
+    return hz;
+  }
+
+  async setLiftOffDistance(level: LiftOffLevel): Promise<LiftOffLevel> {
+    const tenths = incottLiftOffTenths(level);
+    await this.write(incottEncodeSetLiftOff(tenths));
+    // Symmetric single-purpose read (`0x84`/`0x01`), preferred over the
+    // packed byte-7 nibble form — see the comment in `readStatus()`.
+    const gotTenths = incottDecodeLiftOffDirect(await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_LOD));
+    const got = gotTenths === null ? null : incottLiftOffLabel(gotTenths);
+    if (got !== level) {
+      throw new Error(`The mouse kept a ${got ?? "unreadable"} lift-off distance instead of ${level}.`);
+    }
+    return level;
+  }
+
+  async setMotionSync(on: boolean): Promise<boolean> {
+    await this.write(incottEncodeSetToggle("motionSync", on));
+    // Symmetric single-purpose read (`0x84`/`0x04`), preferred over the
+    // packed byte-7 nibble form — see the comment in `readStatus()`.
+    const got = incottDecodeToggle(
+      await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_MOTION_SYNC),
+      INCOTT_SUB_MOTION_SYNC,
+    );
+    if (got !== on) throw new Error(`The mouse kept Motion Sync ${toggleWord(got)} instead of ${on ? "on" : "off"}.`);
+    return on;
+  }
+
+  async setAngleSnapping(on: boolean): Promise<boolean> {
+    await this.write(incottEncodeSetToggle("angleSnapping", on));
+    const got = incottDecodeToggle(
+      await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_ANGLE_SNAP),
+      INCOTT_SUB_ANGLE_SNAP,
+    );
+    if (got !== on) throw new Error(`The mouse kept angle snapping ${toggleWord(got)} instead of ${on ? "on" : "off"}.`);
+    return on;
+  }
+
+  async setRippleControl(on: boolean): Promise<boolean> {
+    await this.write(incottEncodeSetToggle("rippleControl", on));
+    const got = incottDecodeToggle(
+      await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_RIPPLE),
+      INCOTT_SUB_RIPPLE,
+    );
+    if (got !== on) throw new Error(`The mouse kept ripple control ${toggleWord(got)} instead of ${on ? "on" : "off"}.`);
+    return on;
+  }
+
+  async setDebounceTime(ms: number): Promise<number> {
+    await this.write(incottEncodeSetDebounce(ms));
+    const got = incottDecodeDebounce(await this.query(INCOTT_CMD_QUERY_TIMING, INCOTT_SUB_DEBOUNCE));
+    if (got !== ms) throw new Error(`The mouse kept ${got ?? "an unreadable"} ms debounce instead of ${ms} ms.`);
+    return ms;
+  }
+
+  async setSleepTimeout(seconds: number): Promise<number> {
+    await this.write(incottEncodeSetSleep(seconds));
+    const got = incottDecodeSleep(await this.query(INCOTT_CMD_QUERY_TIMING, INCOTT_SUB_SLEEP));
+    if (got !== seconds) {
+      throw new Error(`The mouse kept a ${got ?? "an unreadable"} s sleep timer instead of ${seconds} s.`);
+    }
+    return seconds;
+  }
+
+  /**
+   * Not called generically by the app (no shared receiver-LED control exists
+   * yet), kept for protocol parity with IncottHub.
+   *
+   * NOTE for whoever wires this up: the receiver LED is a property of the
+   * 2.4 GHz dongle and is meaningless when `incottIsWiredProduct(device.productId)`
+   * is true (checked 2026-09-08) — there is no dongle in that mode. Checked
+   * `MouseUiHints` in `src/drivers/mouse-types.ts` for an existing `hide*`
+   * flag to gate this with and found none scoped to the receiver LED
+   * specifically (the closest, `hideSignalCard`, is about link-quality
+   * telemetry, a different control); a new hint was deliberately NOT added to
+   * that shared contract for a control this driver does not yet advertise
+   * anywhere. Whoever wires a shared receiver-LED control into `MouseStatus`
+   * should either add a scoped `hide*` flag there at that time, or simply
+   * omit the wiring outright when wired, matching the other wireless-only
+   * behavior in this driver (see `INCOTT_POLLING_STEPS_HZ_WIRED`).
+   */
+  async setReceiverLed(mode: number): Promise<number> {
+    await this.write(incottEncodeSetReceiverLed(mode));
+    const got = incottDecodeReceiverLed(await this.query(INCOTT_CMD_QUERY_RECEIVER_LED, INCOTT_SUB_NONE));
+    if (got !== mode) throw new Error(`The mouse kept receiver LED mode ${got ?? "unreadable"} instead of ${mode}.`);
+    return mode;
+  }
+
+  /**
+   * The vendor tool's "Performance mode" control (HP / Corded / LP), captured
+   * writing `0x04`/`0x05` values `1` and `2` on 2026-09-07 — see
+   * `incottEncodeSetPerformanceMode`. Deliberately NOT wired into
+   * `MouseStatus`/`MouseUiHints`: the shared contract's closest fit
+   * (`powerModes`/`powerMode`/`setPowerMode`, which MCHOSE uses for an
+   * identical three-way mode) requires naming each value, and only the raw
+   * writes were ever captured — never which on-screen label produced which
+   * value. Surfacing named options here would mean guessing an order and
+   * presenting it as fact, which the capture does not support. Kept as a
+   * codec + client method so a future contributor with a hardware-confirmed
+   * mapping can wire it up without redoing the protocol work.
+   *
+   * A read-back was never captured on hardware; `incottDecodePerformanceMode`
+   * is a best-effort attempt by symmetry with the other `0x04`/`0x84`
+   * sub-commands (see its comment). If the device does not answer, `got` is
+   * `null` and this does not throw — there is nothing confirmed to compare
+   * against.
+   */
+  async setPerformanceMode(mode: number): Promise<number> {
+    await this.write(incottEncodeSetPerformanceMode(mode));
+    const got = incottDecodePerformanceMode(
+      await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_PERFORMANCE),
+    );
+    if (got !== null && got !== mode) {
+      throw new Error(`The mouse kept performance mode ${got} instead of ${mode}.`);
+    }
+    return mode;
+  }
+
+  /** See `setPerformanceMode`. Returns `null` when `0x84`/`0x05` does not answer (never confirmed on hardware). */
+  async getPerformanceMode(): Promise<number | null> {
+    return incottDecodePerformanceMode(await this.query(INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_PERFORMANCE));
+  }
+
+  /** Queries return an all-zero frame on failure, which every decoder rejects. */
+  private async query(cmd: number, sub: number): Promise<Uint8Array> {
+    const matchSub = SUB_ECHOING_QUERIES.includes(cmd) ? sub : null;
+    return (await this.queue.request(incottEncodeQuery(cmd, sub), cmd, matchSub)) ?? new Uint8Array(INCOTT_RESPONSE_LENGTH);
+  }
+
+  private async write(payload: Uint8Array): Promise<void> {
+    await this.queue.send(payload);
+  }
+}
+
+/**
+ * WebHID's `sendFeatureReport` types its `data` parameter as `BufferSource`.
+ * TypeScript's DOM lib makes `Uint8Array` generic over its backing buffer
+ * type, defaulting a bare `Uint8Array` annotation to `Uint8Array<ArrayBufferLike>`,
+ * which is not assignable to `BufferSource` (it admits `SharedArrayBuffer`).
+ * Copying into a fresh array-like-constructed Uint8Array narrows the backing
+ * buffer to a concrete `ArrayBuffer`, matching the pattern already used in
+ * `src/drivers/corsair/hid.ts` and `src/drivers/zaunkoenig/hid.ts`.
+ */
+function toArrayBuffer(payload: Uint8Array): ArrayBuffer {
+  return new Uint8Array(payload).buffer;
+}

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -144,7 +144,7 @@ export interface AtkReceiverInfo {
 }
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "Corsair" | "Microsoft";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "Corsair" | "Microsoft" | "Incott";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;

--- a/src/drivers/registry.ts
+++ b/src/drivers/registry.ts
@@ -47,9 +47,10 @@ import { MchoseHidClient } from "./mchose/hid.ts";
 import { MchoseDockHidClient } from "./mchose/dock-hid.ts";
 import { KsnakeHidClient } from "./ksnake/hid.ts";
 import { MicrosoftHidClient } from "./microsoft/hid.ts";
+import { IncottHidClient } from "./incott/hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient | PulsarXs1HidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient | MicrosoftHidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient | MicrosoftHidClient | IncottHidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -115,6 +116,9 @@ export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "MCHOSE", supports: (device) => MchoseDockHidClient.isSupported(device), create: (device) => new MchoseDockHidClient(device), score: () => 7 },
   { brand: "K-snake", supports: (device) => KsnakeHidClient.isSupported(device), create: (device) => new KsnakeHidClient(device), score: () => 5 },
   { brand: "Microsoft", supports: (device) => MicrosoftHidClient.isSupported(device), create: (device) => new MicrosoftHidClient(device), score: () => 5 },
+  // Shares vendor id 0x093a with Glorious (see vendors.ts), but claims only
+  // its own two product ids, so the two drivers never contend for a device.
+  { brand: "Incott", supports: (device) => IncottHidClient.isSupported(device), create: (device) => new IncottHidClient(device), score: () => 8 },
 ];
 
 function driverFor(device: HIDDevice): DeviceDriver | undefined {

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -1,5 +1,6 @@
 import { ATK_COMPX_PRODUCT_IDS } from "./atk/products.ts";
 import { MICROSOFT_PRODUCTS } from "../microsoft/index.ts";
+import { INCOTT_PRODUCT_IDS, INCOTT_USAGE_PAGE, INCOTT_VENDOR_ID } from "../incott/index.ts";
 import { EGG_WE_HID_FILTERS } from "./endgame/egg-we-control.ts";
 import { GEARHUB_PRODUCTS, GEARHUB_VENDOR_ID } from "@openmouse/protocol/gearhub";
 import { GWOLVES_PRODUCTS } from "./gwolves/products.ts";
@@ -107,6 +108,10 @@ export const VENDOR_ID = {
   ksnakeUsb: 0xa8a4, // K-snake X11 wired
   ksnakeDongle: 0xa8a5, // K-snake X11 2.4 GHz dongle
   microsoft: 0x045E,
+  // Shares 0x093a with Glorious's Pixart-based Model O 2 / I 2 family (see
+  // `glorious` above); GloriousHidClient.isSupported() only claims its own
+  // catalogued product ids, so the two never overlap.
+  incott: INCOTT_VENDOR_ID,
 } as const;
 
 /**
@@ -466,6 +471,19 @@ export const MICROSOFT_HID_FILTERS: HIDDeviceFilter[] = [...MICROSOFT_PRODUCTS].
   (productId) => ({ vendorId: VENDOR_ID.microsoft, productId, usagePage: 0x0C, usage: 0x01 }),
 );
 
+/**
+ * The Incott 8K wireless mouse (and its charging-state product id) answer the
+ * vendor protocol on usage page 0xFF05. Narrowed per product id and usage
+ * page, like the other 0x093a filter above, so the picker offers the
+ * protocol-carrying collection specifically rather than relying only on the
+ * broad Glorious VID-only filter that already happens to admit this VID.
+ */
+export const INCOTT_HID_FILTERS: HIDDeviceFilter[] = INCOTT_PRODUCT_IDS.map((productId) => ({
+  vendorId: INCOTT_VENDOR_ID,
+  productId,
+  usagePage: INCOTT_USAGE_PAGE,
+}));
+
 export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   ...ZAUNKOENIG_PRODUCT_IDS.map((productId) => ({
     vendorId: ZAUNKOENIG_VENDOR_ID,
@@ -544,4 +562,5 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.ksnakeUsb, productId: 0x2255, usagePage: 0xff01, usage: 0x10 },
   { vendorId: VENDOR_ID.ksnakeDongle, productId: 0x2255, usagePage: 0xff01, usage: 0x10 },
   ...MICROSOFT_HID_FILTERS,
+  ...INCOTT_HID_FILTERS,
 ];

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -1,0 +1,581 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  incottDecodeBattery,
+  incottDecodeButtonBinding,
+  incottDecodeDebounce,
+  incottDecodeDpiStage,
+  incottDecodeDpiStageIndex,
+  incottDecodeIdentity,
+  incottDecodeInputStatus,
+  incottDecodeLiftOff,
+  incottDecodeLiftOffDirect,
+  incottDecodeMotionSync,
+  incottDecodePerformanceMode,
+  incottDecodePollingRate,
+  incottDecodeReceiverLed,
+  incottDecodeSleep,
+  incottDecodeToggle,
+  incottEncodeQuery,
+  incottEncodeSetActiveDpiStage,
+  incottEncodeSetButtonBinding,
+  incottEncodeSetDebounce,
+  incottEncodeSetDpi,
+  incottEncodeSetLiftOff,
+  incottEncodeSetPerformanceMode,
+  incottEncodeSetPollingRate,
+  incottEncodeSetReceiverLed,
+  incottEncodeSetSleep,
+  incottEncodeSetToggle,
+  incottFrameMatches,
+  incottIsWiredProduct,
+  incottLiftOffLabel,
+  incottLiftOffTenths,
+  incottNormalizeProductName,
+  incottValidateDpi,
+  INCOTT_POLLING_STEPS_HZ,
+  INCOTT_POLLING_STEPS_HZ_WIRED,
+  INCOTT_PRODUCT_ID,
+  INCOTT_PRODUCT_ID_WIRED,
+} from "./index.ts";
+
+const bytes = (frame: Uint8Array): number[] => Array.from(frame);
+
+test("every payload is 8 bytes and omits the report ID", () => {
+  // WebHID's sendFeatureReport takes the report ID as a separate argument, so
+  // including it here would shift every field by one byte on the wire.
+  assert.equal(incottEncodeSetDpi(1, 800).length, 8);
+  assert.equal(incottEncodeSetPollingRate(1000).length, 8);
+  assert.equal(incottEncodeQuery(0x84).length, 8);
+});
+
+test("DPI is a little-endian uint16 wire value under command 0x02, byte 1 the stage index", () => {
+  // Captured 2026-09-08 against a real incott 8K wireless mouse, reading all
+  // six stages independently:
+  //   09 82 00 -> wire 0x07 -> 400 DPI      09 82 03 -> wire 0x2f -> 2400 DPI
+  //   09 82 01 -> wire 0x0f -> 800 DPI      09 82 04 -> wire 0x3f -> 3200 DPI
+  //   09 82 02 -> wire 0x1f -> 1600 DPI     09 82 05 -> wire 0x7f -> 6400 DPI
+  // and the write shape (`TX 09 02 <stage> <lo> <hi>`), confirmed by writing
+  // 25000 to stage 2 (wire 499 = 0x01f3) and reading it back exactly, then
+  // restoring 1600 (wire 31 = 0x1f) and reading that back too.
+  //
+  // THIS WAS WRONG until 2026-09-08: byte 1 used to be hardcoded to a
+  // constant `0x01`, so only stage 1 could ever be written — see
+  // `INCOTT_DPI_STAGE_COUNT`.
+  assert.deepEqual(bytes(incottEncodeSetDpi(1, 800)).slice(0, 4), [0x02, 0x01, 0x0f, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetDpi(2, 25000)).slice(0, 4), [0x02, 0x02, 0xf3, 0x01]);
+  assert.deepEqual(bytes(incottEncodeSetDpi(0, 400)).slice(0, 4), [0x02, 0x00, 0x07, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetDpi(5, 6400)).slice(0, 4), [0x02, 0x05, 0x7f, 0x00]);
+  // The wire round-trips: 0 -> 50 DPI, the documented minimum.
+  assert.deepEqual(bytes(incottEncodeSetDpi(3, 50)).slice(0, 4), [0x02, 0x03, 0x00, 0x00]);
+});
+
+test("DPI rejects values outside 50-45000 or not a multiple of 50", () => {
+  assert.throws(() => incottEncodeSetDpi(0, 49), RangeError);
+  assert.throws(() => incottEncodeSetDpi(0, 45050), RangeError);
+  assert.throws(() => incottEncodeSetDpi(0, 825), RangeError);
+  assert.throws(() => incottEncodeSetDpi(0, -50), RangeError);
+});
+
+test("DPI rejects a stage index outside 0-5", () => {
+  assert.throws(() => incottEncodeSetDpi(6, 800), RangeError);
+  assert.throws(() => incottEncodeSetDpi(-1, 800), RangeError);
+});
+
+test("incottValidateDpi throws exactly when incottEncodeSetDpi would reject the DPI value", () => {
+  assert.doesNotThrow(() => incottValidateDpi(800));
+  assert.doesNotThrow(() => incottValidateDpi(25000));
+  assert.throws(() => incottValidateDpi(825), RangeError);
+  assert.throws(() => incottValidateDpi(45050), RangeError);
+});
+
+test("polling rate carries its value in byte 1, not byte 2", () => {
+  // Unlike DPI and the sensor commands, polling has no sub-command: the wire
+  // value sits where a sub-command would normally go.
+  assert.deepEqual(bytes(incottEncodeSetPollingRate(1000)).slice(0, 2), [0x01, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetPollingRate(125)).slice(0, 2), [0x01, 0x03]);
+  assert.deepEqual(bytes(incottEncodeSetPollingRate(8000)).slice(0, 2), [0x01, 0x04]);
+  assert.deepEqual(bytes(incottEncodeSetPollingRate(2000)).slice(0, 2), [0x01, 0x06]);
+});
+
+test("polling rate rejects a rate the device does not implement", () => {
+  assert.throws(() => incottEncodeSetPollingRate(333), /polling/i);
+});
+
+test("lift-off distance maps tenths of a millimetre onto wire values", () => {
+  assert.deepEqual(bytes(incottEncodeSetLiftOff(10)).slice(0, 4), [0x04, 0x01, 0x00, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetLiftOff(20)).slice(0, 4), [0x04, 0x01, 0x01, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetLiftOff(7)).slice(0, 4), [0x04, 0x01, 0x02, 0x00]);
+});
+
+test("lift-off rejects a distance the device does not implement", () => {
+  assert.throws(() => incottEncodeSetLiftOff(15), /lift-off/i);
+});
+
+test("the three sensor toggles share command 0x04 and differ by sub-command", () => {
+  assert.deepEqual(bytes(incottEncodeSetToggle("rippleControl", true)).slice(0, 4), [0x04, 0x02, 0x01, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetToggle("angleSnapping", true)).slice(0, 4), [0x04, 0x03, 0x01, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetToggle("motionSync", true)).slice(0, 4), [0x04, 0x04, 0x01, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetToggle("motionSync", false)).slice(0, 4), [0x04, 0x04, 0x00, 0x00]);
+});
+
+test("debounce is a plain millisecond value bounded at 30", () => {
+  assert.deepEqual(bytes(incottEncodeSetDebounce(4)).slice(0, 4), [0x05, 0x01, 0x04, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetDebounce(0)).slice(0, 4), [0x05, 0x01, 0x00, 0x00]);
+  assert.throws(() => incottEncodeSetDebounce(31), /debounce/i);
+  assert.throws(() => incottEncodeSetDebounce(-1), /debounce/i);
+});
+
+test("sleep seconds are encoded little-endian across two bytes", () => {
+  assert.deepEqual(bytes(incottEncodeSetSleep(60)).slice(0, 5), [0x05, 0x03, 0x3c, 0x00, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetSleep(900)).slice(0, 5), [0x05, 0x03, 0x84, 0x03, 0x00]);
+});
+
+test("sleep rejects values outside the device's accepted range", () => {
+  assert.throws(() => incottEncodeSetSleep(0), /sleep/i);
+  assert.throws(() => incottEncodeSetSleep(901), /sleep/i);
+});
+
+test("receiver LED carries its mode in byte 1 like polling", () => {
+  assert.deepEqual(bytes(incottEncodeSetReceiverLed(0)).slice(0, 2), [0x08, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetReceiverLed(2)).slice(0, 2), [0x08, 0x02]);
+  assert.throws(() => incottEncodeSetReceiverLed(3), /receiver/i);
+});
+
+test("queries send the opcode with an optional sub-command and no arguments", () => {
+  assert.deepEqual(bytes(incottEncodeQuery(0x84)), [0x84, 0x00, 0, 0, 0, 0, 0, 0]);
+  assert.deepEqual(bytes(incottEncodeQuery(0x85, 0x03)), [0x85, 0x03, 0, 0, 0, 0, 0, 0]);
+});
+
+/** Builds a response frame with the report ID at byte 0, as WebHID returns it. */
+const frame = (...values: readonly number[]): Uint8Array => {
+  const out = new Uint8Array(64);
+  out[0] = 0x09;
+  values.forEach((value, index) => {
+    out[index + 1] = value;
+  });
+  return out;
+};
+
+test("incottFrameMatches requires the report ID, command, and sub-command to agree", () => {
+  assert.equal(incottFrameMatches(frame(0x85, 0x03), 0x85, 0x03), true);
+  assert.equal(incottFrameMatches(frame(0x85, 0x01), 0x85, 0x03), false);
+  assert.equal(incottFrameMatches(frame(0x84, 0x03), 0x85, 0x03), false);
+  // A null sub-command means "do not check byte 2".
+  assert.equal(incottFrameMatches(frame(0x89, 0x00), 0x89, null), true);
+});
+
+test("incottFrameMatches rejects a frame carrying the wrong report ID", () => {
+  const wrong = frame(0x85, 0x03);
+  wrong[0] = 0x08;
+  assert.equal(incottFrameMatches(wrong, 0x85, 0x03), false);
+});
+
+test("0x83/0x06 decodes the active DPI STAGE INDEX, not a DPI value", () => {
+  // Captured 2026-09-07 against the vendor tool: 09 83 06 01 -> stage 1 of 6.
+  // Decoding byte 3 as an index into the six default presets used to yield
+  // 800 DPI here, which matched the vendor UI only by coincidence.
+  assert.equal(incottDecodeDpiStageIndex(frame(0x83, 0x06, 0x01)), 1);
+  assert.equal(incottDecodeDpiStageIndex(frame(0x83, 0x06, 0x00)), 0);
+  assert.equal(incottDecodeDpiStageIndex(frame(0x83, 0x06, 0x05)), 5);
+});
+
+test("DPI stage index returns null outside 0-5", () => {
+  assert.equal(incottDecodeDpiStageIndex(frame(0x83, 0x06, 0x06)), null);
+});
+
+test("incottEncodeSetActiveDpiStage encodes 09 03 06 <idx> for every stage 0-5", () => {
+  // Command 0x03, sub-command INCOTT_SUB_DPI_STAGE (0x06), then the stage
+  // index — verified on hardware 2026-09-08 by selecting stages 0, 3, 5, then
+  // 1 and reading each back correctly via 0x83/0x06.
+  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(0)).slice(0, 3), [0x03, 0x06, 0x00]);
+  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(1)).slice(0, 3), [0x03, 0x06, 0x01]);
+  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(2)).slice(0, 3), [0x03, 0x06, 0x02]);
+  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(3)).slice(0, 3), [0x03, 0x06, 0x03]);
+  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(4)).slice(0, 3), [0x03, 0x06, 0x04]);
+  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(5)).slice(0, 3), [0x03, 0x06, 0x05]);
+});
+
+test("incottEncodeSetActiveDpiStage rejects a stage index outside 0-5", () => {
+  assert.throws(() => incottEncodeSetActiveDpiStage(6), RangeError);
+  assert.throws(() => incottEncodeSetActiveDpiStage(-1), RangeError);
+});
+
+test("selecting the active stage (0x03) is byte-for-byte distinct from editing a stage's value (0x02) — the bug this driver used to have", () => {
+  // THE BUG: setDpi() used to write the requested value into whichever stage
+  // was active, so "select the 3200 stage" and "overwrite the active stage
+  // with 3200" were conflated into one command. They are two different wire
+  // commands with different opcodes and different payload shapes: the select
+  // carries only a stage index (no DPI value at all), the edit carries a
+  // 2-byte DPI wire value and no fixed sub-command byte.
+  const select = incottEncodeSetActiveDpiStage(4);
+  const edit = incottEncodeSetDpi(4, 3200);
+  assert.notEqual(select[0], edit[0], "different command bytes (0x03 vs 0x02)");
+  assert.deepEqual(bytes(select).slice(0, 3), [0x03, 0x06, 0x04]);
+  assert.deepEqual(bytes(edit).slice(0, 4), [0x02, 0x04, 0x3f, 0x00]);
+});
+
+test("0x82/<stage> decodes all six DPI stage values, pinned to the real capture", () => {
+  // Captured on real hardware 2026-09-08, reading each stage independently:
+  //   09 82 00 -> 09 82 00 07 00 -> wire 0x07 -> 400 DPI
+  //   09 82 01 -> 09 82 01 0f 00 -> wire 0x0f -> 800 DPI
+  //   09 82 02 -> 09 82 02 1f 00 -> wire 0x1f -> 1600 DPI
+  //   09 82 03 -> 09 82 03 2f 00 -> wire 0x2f -> 2400 DPI
+  //   09 82 04 -> 09 82 04 3f 00 -> wire 0x3f -> 3200 DPI
+  //   09 82 05 -> 09 82 05 7f 00 -> wire 0x7f -> 6400 DPI
+  // Six independent points on `dpi = (wire + 1) * 50` — proof this is a
+  // linear value, not an index. This opcode used to be undecoded
+  // (`INCOTT_CMD_UNKNOWN_82`).
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x00, 0x07, 0x00), 0), 400);
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x01, 0x0f, 0x00), 1), 800);
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x02, 0x1f, 0x00), 2), 1600);
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x03, 0x2f, 0x00), 3), 2400);
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x04, 0x3f, 0x00), 4), 3200);
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x05, 0x7f, 0x00), 5), 6400);
+});
+
+test("0x82/<stage> round-trips a write of 25000 to stage 2 and a restore of 1600", () => {
+  // Captured 2026-09-08: TX 09 02 02 f3 01 (wire 499 = 25000/50 - 1) read
+  // back as RX 09 82 02 f3 01 -> exactly 25000, then TX 09 02 02 1f 00
+  // (restoring 1600) read back as RX 09 82 02 1f 00 -> exactly 1600. Every
+  // written value was restored on real hardware.
+  assert.deepEqual(bytes(incottEncodeSetDpi(2, 25000)).slice(0, 4), [0x02, 0x02, 0xf3, 0x01]);
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x02, 0xf3, 0x01), 2), 25000);
+  assert.deepEqual(bytes(incottEncodeSetDpi(2, 1600)).slice(0, 4), [0x02, 0x02, 0x1f, 0x00]);
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x02, 0x1f, 0x00), 2), 1600);
+});
+
+test("0x82/<stage> rejects a frame answering a different stage (sub-command echo)", () => {
+  // Verified on hardware 2026-09-08: 09 82 03 replies 09 82 03 ... — 0x82
+  // echoes its sub-command like 0x83/0x84/0x85/0x8e.
+  assert.equal(incottDecodeDpiStage(frame(0x82, 0x03, 0x0f, 0x00), 1), null);
+});
+
+test("polling rate decodes wire values through the shared table", () => {
+  assert.equal(incottDecodePollingRate(frame(0x81, 0x00)), 1000);
+  assert.equal(incottDecodePollingRate(frame(0x81, 0x04)), 8000);
+  assert.equal(incottDecodePollingRate(frame(0x81, 0x09)), null);
+});
+
+test("polling rate byte 2 follows a write, confirming the read on hardware 2026-09-08", () => {
+  // Writing wire 1 (500 Hz) then wire 0 (1000 Hz) and reading back showed
+  // byte 2 follow the write, 0 -> 1 -> 0 — confirming this is genuinely the
+  // polling-rate byte and not a coincidence.
+  assert.deepEqual(bytes(incottEncodeSetPollingRate(500)).slice(0, 2), [0x01, 0x01]);
+  assert.equal(incottDecodePollingRate(frame(0x81, 0x01)), 500);
+  assert.deepEqual(bytes(incottEncodeSetPollingRate(1000)).slice(0, 2), [0x01, 0x00]);
+  assert.equal(incottDecodePollingRate(frame(0x81, 0x00)), 1000);
+});
+
+test("lift-off distance decodes from the high nibble of byte 7", () => {
+  // Captured 2026-09-07: byte 7 = 0x01 -> high nibble 0 -> 1 mm.
+  assert.equal(incottDecodeLiftOff(frame(0x84, 0x00, 0, 0, 0, 0, 0x01)), 10);
+  assert.equal(incottDecodeLiftOff(frame(0x84, 0x00, 0, 0, 0, 0, 0x10)), 20);
+  assert.equal(incottDecodeLiftOff(frame(0x84, 0x00, 0, 0, 0, 0, 0x20)), 7);
+});
+
+test("lift-off returns null for an unrecognized nibble", () => {
+  assert.equal(incottDecodeLiftOff(frame(0x84, 0x00, 0, 0, 0, 0, 0x70)), null);
+});
+
+test("incottDecodeLiftOffDirect reads the symmetric 0x84/0x01 form and agrees with the packed nibble form", () => {
+  // Verified on hardware 2026-09-08: hw 0, 1, 2 round-tripped identically
+  // through both the symmetric single-purpose read (0x84/0x01 byte 3) and
+  // the packed byte-7 high-nibble read (incottDecodeLiftOff) above.
+  assert.equal(incottDecodeLiftOffDirect(frame(0x84, 0x01, 0x00)), 10);
+  assert.equal(incottDecodeLiftOffDirect(frame(0x84, 0x01, 0x01)), 20);
+  assert.equal(incottDecodeLiftOffDirect(frame(0x84, 0x01, 0x02)), 7);
+  // Cross-check against the packed-nibble form for the same three values.
+  assert.equal(incottDecodeLiftOffDirect(frame(0x84, 0x01, 0x00)), incottDecodeLiftOff(frame(0x84, 0x00, 0, 0, 0, 0, 0x00)));
+  assert.equal(incottDecodeLiftOffDirect(frame(0x84, 0x01, 0x01)), incottDecodeLiftOff(frame(0x84, 0x00, 0, 0, 0, 0, 0x10)));
+  assert.equal(incottDecodeLiftOffDirect(frame(0x84, 0x01, 0x02)), incottDecodeLiftOff(frame(0x84, 0x00, 0, 0, 0, 0, 0x20)));
+});
+
+test("incottDecodeLiftOffDirect rejects a frame with the wrong sub-command", () => {
+  assert.equal(incottDecodeLiftOffDirect(frame(0x84, 0x02, 0x00)), null);
+});
+
+test("motion sync decodes from the low nibble of the same byte", () => {
+  assert.equal(incottDecodeMotionSync(frame(0x84, 0x00, 0, 0, 0, 0, 0x01)), true);
+  assert.equal(incottDecodeMotionSync(frame(0x84, 0x00, 0, 0, 0, 0, 0x00)), false);
+  assert.equal(incottDecodeMotionSync(frame(0x84, 0x00, 0, 0, 0, 0, 0x20)), false);
+});
+
+test("motion sync via the symmetric 0x84/0x04 read (incottDecodeToggle) agrees with the packed nibble form", () => {
+  // Verified on hardware 2026-09-08: 0/1/0 round-tripped identically through
+  // both the symmetric read (0x84/0x04 byte 3, the driver's real read path)
+  // and the packed byte-7 low-nibble read (incottDecodeMotionSync) above.
+  assert.equal(incottDecodeToggle(frame(0x84, 0x04, 0x01), 0x04), true);
+  assert.equal(incottDecodeToggle(frame(0x84, 0x04, 0x00), 0x04), false);
+  assert.equal(incottDecodeToggle(frame(0x84, 0x04, 0x01), 0x04), incottDecodeMotionSync(frame(0x84, 0x00, 0, 0, 0, 0, 0x01)));
+  assert.equal(incottDecodeToggle(frame(0x84, 0x04, 0x00), 0x04), incottDecodeMotionSync(frame(0x84, 0x00, 0, 0, 0, 0, 0x00)));
+});
+
+test("motion sync returns null for a nibble that is neither on nor off", () => {
+  // 0x0f is a value the device has never been observed to send; it must not
+  // be read as a confident "off" the way `false` would be.
+  assert.equal(incottDecodeMotionSync(frame(0x84, 0x00, 0, 0, 0, 0, 0x0f)), null);
+});
+
+test("motion sync returns null when the frame does not match the sensor query", () => {
+  assert.equal(incottDecodeMotionSync(frame(0x83, 0x00, 0, 0, 0, 0, 0x01)), null);
+});
+
+test("lift-off and motion sync return null on frames truncated before byte 7", () => {
+  const truncated = new Uint8Array(7); // Only 7 bytes, no byte 7
+  truncated[0] = 0x09;
+  truncated[1] = 0x84;
+  truncated[2] = 0x00;
+  assert.equal(incottDecodeLiftOff(truncated), null);
+  assert.equal(incottDecodeMotionSync(truncated), null);
+});
+
+test("toggles decode from byte 3", () => {
+  assert.equal(incottDecodeToggle(frame(0x84, 0x03, 0x01)), true);
+  assert.equal(incottDecodeToggle(frame(0x84, 0x03, 0x00)), false);
+});
+
+test("toggles return null for a value that is neither on nor off", () => {
+  assert.equal(incottDecodeToggle(frame(0x84, 0x03, 0x7f)), null);
+});
+
+test("incottDecodeToggle rejects a stale frame with the wrong sub-command", () => {
+  // Frame carries ripple-control (0x02), but angle-snap (0x03) was requested.
+  const rippleFrame = frame(0x84, 0x02, 0x01);
+  assert.equal(incottDecodeToggle(rippleFrame, 0x03), null);
+  assert.equal(incottDecodeToggle(rippleFrame, 0x02), true);
+});
+
+test("debounce decodes within range and rejects impossible values", () => {
+  assert.equal(incottDecodeDebounce(frame(0x85, 0x01, 0x04)), 4);
+  assert.equal(incottDecodeDebounce(frame(0x85, 0x01, 0x00)), 0);
+  assert.equal(incottDecodeDebounce(frame(0x85, 0x01, 0x1e)), 30);
+  assert.equal(incottDecodeDebounce(frame(0x85, 0x01, 0x1f)), null);
+});
+
+test("sleep decodes a little-endian uint16", () => {
+  // Captured 2026-09-07: 3c 00 -> 60 seconds.
+  assert.equal(incottDecodeSleep(frame(0x85, 0x03, 0x3c, 0x00)), 60);
+  assert.equal(incottDecodeSleep(frame(0x85, 0x03, 0x84, 0x03)), 900);
+});
+
+test("sleep returns null outside the device's range", () => {
+  assert.equal(incottDecodeSleep(frame(0x85, 0x03, 0x00, 0x00)), null);
+  assert.equal(incottDecodeSleep(frame(0x85, 0x03, 0x85, 0x03)), null);
+});
+
+test("incottDecodeSleep returns null on frames truncated before byte 4", () => {
+  const truncated = new Uint8Array(4); // Only 4 bytes, no byte 4
+  truncated[0] = 0x09;
+  truncated[1] = 0x85;
+  truncated[2] = 0x03;
+  truncated[3] = 0x3c;
+  assert.equal(incottDecodeSleep(truncated), null);
+});
+
+test("receiver LED decodes from byte 2 and bounds the mode", () => {
+  assert.equal(incottDecodeReceiverLed(frame(0x88, 0x00)), 0);
+  assert.equal(incottDecodeReceiverLed(frame(0x88, 0x02)), 2);
+  assert.equal(incottDecodeReceiverLed(frame(0x88, 0x03)), null);
+});
+
+test("battery decodes byte 6 of the 0x8e/0x01 response, verified against the vendor tool", () => {
+  // Captured 2026-09-07 by instrumenting incott.net/mouse/:
+  //   TX 09 8e 01 -> RX 09 8e 01 5a 04 84 38 01 00, byte 6 = 0x38 = 56.
+  // The vendor UI showed "60%" for this exact reading because its own
+  // display rounds to the nearest 10% (confirmed by the person who captured
+  // it) — 56 is the real, exact value.
+  assert.equal(incottDecodeBattery(frame(0x8e, 0x01, 0x5a, 0x04, 0x84, 0x38, 0x01, 0x00)), 56);
+  assert.equal(incottDecodeBattery(frame(0x8e, 0x01, 0, 0, 0, 0x64, 0, 0)), 100);
+});
+
+test("battery returns null for a percentage that cannot be real, or a mismatched sub-command", () => {
+  assert.equal(incottDecodeBattery(frame(0x8e, 0x01, 0, 0, 0, 0x65, 0, 0)), null);
+  // 0x8e answers only on sub-command 0x01 — an earlier opcode sweep that only
+  // ever tried sub 0x00 concluded (wrongly) that 0x8e never answers at all.
+  assert.equal(incottDecodeBattery(frame(0x8e, 0x00, 0, 0, 0, 0x38, 0, 0)), null);
+});
+
+test("battery no longer decodes 0x89 byte 8, the disproven constant-0x5a hypothesis", () => {
+  // 09 89 00 00 00 00 00 00 5a read 0x5a (90) on every capture ever taken, in
+  // every device state — proof it is a constant, not a battery reading. See
+  // docs/incott-testing.md.
+  assert.equal(incottDecodeBattery(frame(0x89, 0, 0, 0, 0, 0, 0, 0x5a)), null);
+});
+
+// ---------------------------------------------------------------------------
+// incottDecodeInputStatus — the mouse's UNSOLICITED input report (report id
+// 0x09, but NOT a feature-report reply). This is what battery is genuinely
+// read from as of 2026-09-08: the 0x8e/byte-6 and 0x89/byte-8 hypotheses
+// above are BOTH disproven (a full charge cycle left 0x8e's byte 6 completely
+// unchanged), so `incottDecodeBattery` above is kept as a codec/regression
+// fixture only and is no longer how the driver reports battery.
+//
+// Byte-index convention for this function: `byte0`/`byte1` EXCLUDE the report
+// id, matching WebHID's `inputreport` event (`event.data` excludes it,
+// `event.reportId` carries it separately) — the same convention every
+// `incottEncode*` function in this module already uses for outgoing feature
+// reports. The two hex captures below were taken with node-hid, whose raw
+// buffer INCLUDES the report id at index 0, so node-hid buf[1] is this
+// function's byte0 and buf[2] is byte1.
+// ---------------------------------------------------------------------------
+
+test("input-report battery: discharging capture 0x5f decodes to 95%, not charging", () => {
+  // Captured 2026-09-08, node-hid: 09 5f 10 04 00 0f 0f 10
+  // node-hid buf[1] = 0x5f = 95 -> this function's byte0.
+  const status = incottDecodeInputStatus(0x5f, 0x10);
+  assert.deepEqual(status, { batteryPercent: 95, charging: false, dpiStageIndex: 1, pollingIndex: 0 });
+});
+
+test("input-report battery: charging capture 0xe1 decodes to 97%, charging", () => {
+  // Captured 2026-09-08, node-hid: 09 e1 10 04 00 0f 0f 10
+  // node-hid buf[1] = 0xe1 = 225 -> byte0. 225 > 100, so charging; 225 - 128 = 97.
+  const status = incottDecodeInputStatus(0xe1, 0x10);
+  assert.deepEqual(status, { batteryPercent: 97, charging: true, dpiStageIndex: 1, pollingIndex: 0 });
+});
+
+test("input-report byte 1 (0x10) decodes to DPI stage 1 and polling index 0, corroborating the feature reads", () => {
+  // On the unit under test, both nibbles of the captured byte 2 (this
+  // function's byte1) independently matched what the feature reads returned
+  // at the same moment: 09 83 06 -> stage 1, 09 81 byte 2 -> 0.
+  const status = incottDecodeInputStatus(0x5f, 0x10);
+  assert.equal(status?.dpiStageIndex, 1);
+  assert.equal(status?.pollingIndex, 0);
+});
+
+test("input-report decode rejects a percentage that would fall outside 0-100 once the charging offset is applied", () => {
+  // byte0 = 101 is "charging" (>100) but 101 - 128 is negative — not a real
+  // percentage, so this must be null rather than a fabricated negative value.
+  assert.equal(incottDecodeInputStatus(101, 0x00), null);
+});
+
+test("input-report decode rejects out-of-byte-range inputs", () => {
+  assert.equal(incottDecodeInputStatus(-1, 0x00), null);
+  assert.equal(incottDecodeInputStatus(256, 0x00), null);
+  assert.equal(incottDecodeInputStatus(0x00, 256), null);
+});
+
+test("button binding encodes the raw three-byte payload under command 0x06", () => {
+  // Captured 2026-09-08: the vendor tool wrote `09 06 00 01 00 f0` to button
+  // 0. This is a codec for the raw bytes only — see incottEncodeSetButtonBinding.
+  assert.deepEqual(bytes(incottEncodeSetButtonBinding(0, [0x01, 0x00, 0xf0])).slice(0, 5), [0x06, 0x00, 0x01, 0x00, 0xf0]);
+});
+
+test("button binding rejects a button index outside 0-5", () => {
+  assert.throws(() => incottEncodeSetButtonBinding(6, [0, 0, 0]), RangeError);
+  assert.throws(() => incottEncodeSetButtonBinding(-1, [0, 0, 0]), RangeError);
+});
+
+test("button binding decodes all six buttons, pinned to the real capture", () => {
+  // Captured on real hardware 2026-09-08, reading each of the six buttons
+  // (left, right, middle, forward, back, DPI, in some physical order):
+  //   09 86 00 -> bytes 3-5 = 01 00 f0
+  //   09 86 01 -> bytes 3-5 = 01 00 f1
+  //   09 86 02 -> bytes 3-5 = 01 00 f2
+  //   09 86 03 -> bytes 3-5 = 01 00 f3
+  //   09 86 04 -> bytes 3-5 = 01 00 f4
+  //   09 86 05 -> bytes 3-5 = 07 00 03
+  // Button 0's read-back matches byte-for-byte what the vendor tool wrote
+  // (`09 06 00 01 00 f0`) — the round-trip proof this codec is correct.
+  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x00, 0x01, 0x00, 0xf0), 0), { button: 0, b0: 0x01, b1: 0x00, b2: 0xf0 });
+  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x01, 0x01, 0x00, 0xf1), 1), { button: 1, b0: 0x01, b1: 0x00, b2: 0xf1 });
+  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x02, 0x01, 0x00, 0xf2), 2), { button: 2, b0: 0x01, b1: 0x00, b2: 0xf2 });
+  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x03, 0x01, 0x00, 0xf3), 3), { button: 3, b0: 0x01, b1: 0x00, b2: 0xf3 });
+  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x04, 0x01, 0x00, 0xf4), 4), { button: 4, b0: 0x01, b1: 0x00, b2: 0xf4 });
+  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x05, 0x07, 0x00, 0x03), 5), { button: 5, b0: 0x07, b1: 0x00, b2: 0x03 });
+});
+
+test("button binding rejects a frame answering a different button (sub-command echo)", () => {
+  assert.equal(incottDecodeButtonBinding(frame(0x86, 0x02, 0x01, 0x00, 0xf2), 0), null);
+});
+
+test("button binding returns null on a frame truncated before byte 5", () => {
+  const truncated = new Uint8Array(5); // Only 5 bytes, no byte 5
+  truncated[0] = 0x09;
+  truncated[1] = 0x86;
+  truncated[2] = 0x00;
+  assert.equal(incottDecodeButtonBinding(truncated, 0), null);
+});
+
+test("identity returns the raw payload for display", () => {
+  // Captured 2026-09-07: 09 8f 01 0e 02 f0 f1 00 ff.
+  const identity = incottDecodeIdentity(frame(0x8f, 0x01, 0x0e, 0x02, 0xf0, 0xf1, 0x00, 0xff));
+  assert.equal(identity?.raw, "01 0e 02 f0 f1 00 ff");
+});
+
+test("identity returns null when the frame is not an identity response", () => {
+  assert.equal(incottDecodeIdentity(frame(0x84, 0x00)), null);
+});
+
+test("incottIsWiredProduct is true only for the wired product id (0x622C), hardware-verified 2026-09-08", () => {
+  assert.equal(incottIsWiredProduct(INCOTT_PRODUCT_ID_WIRED), true);
+  assert.equal(incottIsWiredProduct(INCOTT_PRODUCT_ID), false);
+});
+
+test("INCOTT_POLLING_STEPS_HZ_WIRED is the hardware-verified 1000 Hz wired ceiling, a strict subset of the wireless ladder", () => {
+  assert.deepEqual(INCOTT_POLLING_STEPS_HZ_WIRED, [125, 250, 500, 1000]);
+  for (const hz of INCOTT_POLLING_STEPS_HZ_WIRED) {
+    assert.equal(INCOTT_POLLING_STEPS_HZ.includes(hz), true);
+  }
+  assert.equal(INCOTT_POLLING_STEPS_HZ.includes(8000), true, "8000 Hz stays wireless-only");
+  assert.equal(INCOTT_POLLING_STEPS_HZ_WIRED.includes(8000), false);
+});
+
+test("incottNormalizeProductName strips a leading 'incott' and trailing 'mouse'", () => {
+  // The real model name is only present in the wired product string —
+  // hardware-verified 2026-09-08.
+  assert.equal(incottNormalizeProductName("incott Esports G23V2Pro mouse"), "Esports G23V2Pro");
+  // The wireless dongle's string is generic; normalizing it does not invent
+  // a model, it only tidies the same generic words.
+  assert.equal(incottNormalizeProductName("incott 8K wireless mouse"), "8K wireless");
+});
+
+test("incottNormalizeProductName leaves a string with neither word untouched", () => {
+  assert.equal(incottNormalizeProductName("G23V2Pro"), "G23V2Pro");
+});
+
+test("incottNormalizeProductName is case-insensitive on both stripped words", () => {
+  assert.equal(incottNormalizeProductName("Incott Esports G23V2Pro Mouse"), "Esports G23V2Pro");
+});
+
+test("incottNormalizeProductName falls back to the raw string rather than return an empty name", () => {
+  assert.equal(incottNormalizeProductName("incott mouse"), "incott mouse");
+  assert.equal(incottNormalizeProductName(""), "");
+});
+
+test("incottNormalizeProductName does not strip 'mouse' or 'incott' from the middle of the string", () => {
+  assert.equal(incottNormalizeProductName("incott Field mouse Edition mouse"), "Field mouse Edition");
+});
+
+test("incottLiftOffLabel and incottLiftOffTenths round-trip the three stops", () => {
+  assert.equal(incottLiftOffLabel(7), "Low");
+  assert.equal(incottLiftOffLabel(10), "Medium");
+  assert.equal(incottLiftOffLabel(20), "High");
+  assert.equal(incottLiftOffLabel(15), null);
+  assert.equal(incottLiftOffTenths("Low"), 7);
+  assert.equal(incottLiftOffTenths("Medium"), 10);
+  assert.equal(incottLiftOffTenths("High"), 20);
+});
+
+test("performance mode writes the raw 0-2 value captured from the vendor tool", () => {
+  // Captured 2026-09-07 as the owner switched the vendor tool's Performance
+  // mode control: TX 09 04 05 02 and TX 09 04 05 01. Which label (HP / Corded
+  // / LP) produced which value is UNVERIFIED — only the raw writes exist.
+  assert.deepEqual(bytes(incottEncodeSetPerformanceMode(2)).slice(0, 3), [0x04, 0x05, 0x02]);
+  assert.deepEqual(bytes(incottEncodeSetPerformanceMode(1)).slice(0, 3), [0x04, 0x05, 0x01]);
+  assert.deepEqual(bytes(incottEncodeSetPerformanceMode(0)).slice(0, 3), [0x04, 0x05, 0x00]);
+});
+
+test("performance mode rejects a value outside 0-2", () => {
+  assert.throws(() => incottEncodeSetPerformanceMode(3), RangeError);
+  assert.throws(() => incottEncodeSetPerformanceMode(-1), RangeError);
+});
+
+test("performance mode decodes byte 3 of the 0x84/0x05 response (unverified: never captured on hardware)", () => {
+  assert.equal(incottDecodePerformanceMode(frame(0x84, 0x05, 0x01)), 1);
+  assert.equal(incottDecodePerformanceMode(frame(0x84, 0x05, 0x02)), 2);
+  assert.equal(incottDecodePerformanceMode(frame(0x84, 0x05, 0x03)), null);
+  // Wrong sub-command: must not be read as a performance-mode reply.
+  assert.equal(incottDecodePerformanceMode(frame(0x84, 0x03, 0x01)), null);
+});

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -1,0 +1,893 @@
+/**
+ * Incott HID protocol — transport-independent codec.
+ *
+ * Derived from IncottHIDApp (`romkazor/IncottHIDApp`, MIT licensed; this
+ * module reuses its protocol knowledge, not its code) and verified against
+ * an "incott 8K wireless mouse" (093A:522C) on real hardware. Ported from
+ * IncottHub (https://github.com/vladidraganov/IncottHub), which documents the
+ * verification in `docs/superpowers/specs/2026-09-07-incotthub-design.md`
+ * sections 4, 5, 8 and 13.
+ *
+ * DPI and battery were corrected on 2026-09-07 against a second, higher-trust
+ * source: the owner instrumented Incott's own WebHID configurator
+ * (incott.net/mouse/, hooking HIDDevice.prototype.sendFeatureReport /
+ * receiveFeatureReport) and captured real traffic to a G23V2Pro. That capture
+ * is ground truth and disproved two assumptions this driver inherited from
+ * IncottHIDApp — see `captures/incott-8k-wireless/vendor-tool-session.hex`
+ * and `docs/incott-testing.md`.
+ *
+ * A THIRD round of verification on 2026-09-08 used node-hid directly against
+ * an "incott 8K wireless mouse" and, uniquely among the capture sessions
+ * above, performed real WRITES and read every one back before restoring the
+ * original value. It fixed the DPI stage-index write bug (see
+ * `INCOTT_DPI_STAGE_COUNT`), confirmed `0x82` is the per-stage DPI value read
+ * and that it echoes its sub-command, confirmed the polling-rate byte at
+ * `0x81`, confirmed the packed byte-7 nibble reads for lift-off and motion
+ * sync agree with their symmetric `0x84` single-purpose reads, and added a
+ * button-binding codec. See
+ * `captures/incott-8k-wireless/write-roundtrip.hex` and
+ * `docs/incott-testing.md`.
+ *
+ * A FIFTH round, 2026-09-08, RELOCATED battery entirely. Charging a unit
+ * through a full cycle (roughly 60% to roughly 97%) while polling the
+ * `0x8e`/sub `0x01` feature-report reply showed byte 6 never move at all —
+ * the exact frame `09 8e 01 5a 04 84 38 01` the entire time. A constant is
+ * not a battery reading; see `INCOTT_CMD_QUERY_BATTERY` and
+ * `incottDecodeBattery` for what this disproves and why the codec is kept
+ * anyway (regression coverage), and `docs/incott-testing.md` for the write-up.
+ * The real level lives in an UNSOLICITED INPUT report the mouse emits on
+ * report id 0x09 while it is actively being used — not a feature-report
+ * reply to any request this driver sends. See `incottDecodeInputStatus` for
+ * the codec and `src/drivers/incott/hid.ts`'s `onInputReport` for how the
+ * WebHID client listens for it and caches the result.
+ *
+ * A FOURTH fix, same day, closed a second DPI bug found by an owner report:
+ * `IncottHidClient.setDpi` was reading the active stage and then writing the
+ * requested DPI *into* that stage, silently overwriting whatever value the
+ * stage held — repeated use progressively destroyed the mouse's factory
+ * table (one owner's stage 2 was found changed from 1600 to 800 this way).
+ * DPI is genuinely four independent operations, not one: select the active
+ * stage (`INCOTT_CMD_SET_DPI_STAGE`/`incottEncodeSetActiveDpiStage`, `09 03
+ * 06 <idx>`), edit a stage's value (`INCOTT_CMD_SET_DPI`/`incottEncodeSetDpi`,
+ * `09 02 <idx> <lo> <hi>`), read which stage is active
+ * (`INCOTT_CMD_QUERY_DPI_STAGE`, `09 83 06`), and read a stage's value
+ * (`INCOTT_CMD_QUERY_DPI_STAGE_VALUE`, `09 82 <idx>`). Select and edit were
+ * verified as genuinely distinct operations: selecting stages 0, 3, 5, then 1
+ * in turn each read back correctly via `0x83`/`0x06`, and reading all six
+ * stages via `0x82` before and after showed the table's contents completely
+ * unchanged by those selects. See `INCOTT_CMD_SET_DPI_STAGE` for the full
+ * writeup, `src/drivers/incott/hid.ts` for how the driver now exposes
+ * `setActiveDpiStage`/`setDpiStageValue` as OpenMouse's existing generic
+ * multi-stage DPI editor contract, and
+ * `captures/incott-8k-wireless/write-roundtrip.hex` /
+ * `docs/incott-testing.md` for the capture.
+ *
+ * All traffic is HID feature reports on report ID 0x09. Requests are 9 bytes
+ * `[0x09, cmd, sub, ...args]`; WebHID's `sendFeatureReport` takes the report
+ * ID as a separate argument, so the payloads this module builds are 8 bytes
+ * and omit it. Responses are read with `receiveFeatureReport(0x09)`, which
+ * returns the report ID at byte 0, so decoders index frames that include it.
+ *
+ * Opcodes are paired: `0x0N` sets a value, `0x8N` queries it. The device
+ * latches a single shared response buffer — see `incottFrameMatches` and
+ * `src/drivers/incott/hid.ts` for how the driver layer avoids decoding a
+ * frame left over from a previous query.
+ *
+ * This module must not import WebHID types or talk to a device; see
+ * `src/drivers/incott/hid.ts` for the WebHID client.
+ */
+
+export const INCOTT_VENDOR_ID = 0x093a;
+/** The 2.4 GHz dongle's product id — "incott 8K wireless mouse" in its product string. */
+export const INCOTT_PRODUCT_ID = 0x522c;
+/**
+ * The WIRED product id — hardware-verified 2026-09-08 by plugging the mouse
+ * in over USB and reading `device.productId` directly: it enumerates as
+ * `0x622C`, not `0x522C`. This used to be named `INCOTT_PRODUCT_ID_CHARGING`
+ * and `incottIsChargingProduct` treated it as a charging FLAG — that was the
+ * wrong axis. `0x622C` means the CONNECTION is wired; charging is a
+ * consequence of being plugged in, not the thing this id actually encodes.
+ * See `incottIsWiredProduct` (the renamed helper) and
+ * `IncottHidClient.readStatus`, which now derives both `connectionType` and
+ * `batteryState: "Charging"` from wired-ness rather than from a constant
+ * that claimed to mean "charging."
+ */
+export const INCOTT_PRODUCT_ID_WIRED = 0x622c;
+export const INCOTT_PRODUCT_IDS: readonly number[] = [
+  INCOTT_PRODUCT_ID,
+  INCOTT_PRODUCT_ID_WIRED,
+];
+
+/** The vendor collection that answers protocol requests. */
+export const INCOTT_USAGE_PAGE = 0xff05;
+/** Any vendor-defined page, used as a fallback when 0xFF05 is absent. */
+export const INCOTT_VENDOR_USAGE_PAGE_MIN = 0xff00;
+
+export const INCOTT_REPORT_ID = 0x09;
+/** Payload length excluding the report ID (WebHID sends it separately). */
+export const INCOTT_PAYLOAD_LENGTH = 8;
+/** Length requested from receiveFeatureReport, including the report ID. */
+export const INCOTT_RESPONSE_LENGTH = 64;
+
+/** Set opcodes. Query opcodes are the same value with bit 7 set. */
+export const INCOTT_CMD_SET_POLLING = 0x01;
+/**
+ * Writes the actual DPI value (see `incottEncodeSetDpi`), NOT a preset index.
+ * Proven on hardware 2026-09-07 against a real G23V2Pro; this used to be
+ * `0x03`, which was never verified and is not what the vendor tool sends.
+ */
+export const INCOTT_CMD_SET_DPI = 0x02;
+export const INCOTT_CMD_SET_SENSOR = 0x04;
+export const INCOTT_CMD_SET_TIMING = 0x05;
+/**
+ * Button binding write, `09 06 <button 0..5> <...payload>` — round-trip
+ * confirmed on hardware 2026-09-08: the vendor tool wrote
+ * `09 06 00 01 00 f0` to button 0, and reading it back via `0x86`/sub `00`
+ * afterwards returned the identical three payload bytes. See
+ * `incottEncodeSetButtonBinding` — this only encodes the raw binding; the
+ * meaning of its bytes (key code vs. macro vs. remap) is NOT established, so
+ * nothing here interprets them.
+ */
+export const INCOTT_CMD_SET_BUTTON = 0x06;
+export const INCOTT_CMD_SET_RECEIVER_LED = 0x08;
+
+/**
+ * Selects which of the six DPI stages is ACTIVE: `09 03 06 <idx>` (command
+ * `0x03`, sub-command `INCOTT_SUB_DPI_STAGE`, then the stage index). Pairs
+ * with `INCOTT_CMD_QUERY_DPI_STAGE` (`0x83`), which reads the active index
+ * back at the same sub-command — see `incottEncodeSetActiveDpiStage`.
+ *
+ * This is a SELECT, not an EDIT: it never touches the six-stage table's
+ * stored values. Verified on hardware 2026-09-08 — selecting stage 0, 3, 5,
+ * then 1 in turn each read back identically via `0x83`/`0x06`, and reading
+ * all six stages via `0x82` before and after showed the table completely
+ * unchanged by those selects.
+ *
+ * IMPORTANT MISLABEL TO NOT REPEAT: IncottHIDApp calls this command "set
+ * DPI" and treats its six "DPI presets" as if picking one changes the DPI
+ * value. It does not — it only changes which already-stored stage answers
+ * as active. The bug this driver used to have (`setDpi` writing the
+ * requested value into whichever stage happened to be active, silently
+ * overwriting the factory table one stage at a time) came directly from
+ * conflating this select with `INCOTT_CMD_SET_DPI` (`0x02`), the command
+ * that actually edits a stage's stored value. See `incottEncodeSetDpi` and
+ * `docs/incott-testing.md`.
+ */
+export const INCOTT_CMD_SET_DPI_STAGE = 0x03;
+
+/**
+ * Returns the active DPI *stage index* (0-5), not a DPI value — see
+ * `incottDecodeDpiStageIndex`. Still `0x83`; only the interpretation of its
+ * payload changed.
+ */
+export const INCOTT_CMD_QUERY_DPI_STAGE = 0x83;
+/**
+ * Reads the numeric DPI value stored in one of the six stages,
+ * `09 82 <stage 0..5>` -> little-endian uint16 at RESPONSE bytes 3-4 (same
+ * `wire = dpi/50 - 1` encoding as the write). Verified on hardware
+ * 2026-09-08 by reading all six stages back as 400/800/1600/2400/3200/6400
+ * (wire 0x07/0x0f/0x1f/0x2f/0x3f/0x7f), then writing 25000 to stage 2 and
+ * reading it back as exactly 25000, then restoring 1600 and reading that
+ * back too — six independent points on `dpi = (wire + 1) * 50`, plus a
+ * write/restore round-trip. This was previously `INCOTT_CMD_UNKNOWN_82`: an
+ * earlier opcode sweep only ever tried sub `0x00` and got back an
+ * uninterpreted payload (`09 82 00 07 00 …`) — the same "sub-commands are
+ * not optional" lesson `0x8e` (battery) taught. See `incottDecodeDpiStage`.
+ */
+export const INCOTT_CMD_QUERY_DPI_STAGE_VALUE = 0x82;
+export const INCOTT_CMD_QUERY_POLLING = 0x81;
+export const INCOTT_CMD_QUERY_SENSOR = 0x84;
+export const INCOTT_CMD_QUERY_TIMING = 0x85;
+export const INCOTT_CMD_QUERY_RECEIVER_LED = 0x88;
+/**
+ * Answers, but byte 8 of the reply returned the same constant `0x5a` (90) on
+ * every capture ever taken, across every device state and both capture
+ * sessions (2026-09-07 read-only sweep and the later vendor-tool traffic).
+ * That is disproof, not confirmation, that byte 8 is a battery percentage —
+ * see `docs/incott-testing.md`. Nothing in this driver decodes this response
+ * any more. DISPROVEN A SECOND TIME on 2026-09-08: `0x8e`/sub `0x01` byte 6
+ * (see below), the value this comment used to point to as "the real battery
+ * percentage," is ALSO a constant — see `INCOTT_CMD_QUERY_BATTERY`. The real
+ * battery level lives in an unsolicited input report; see
+ * `incottDecodeInputStatus`. Kept only because the opcode itself still
+ * answers and its real meaning is an open question worth recording.
+ */
+export const INCOTT_CMD_QUERY_STATUS = 0x89;
+export const INCOTT_CMD_QUERY_IDENTITY = 0x8f;
+/**
+ * Battery percentage, but ONLY on sub-command `0x01` — the original opcode
+ * sweep swept every command with sub `0x00` and concluded `0x8e` was
+ * unimplemented because it never answered. Sub-commands are not optional on
+ * this opcode (or on `0x86`, which the vendor tool queries as `09 86 09`).
+ *
+ * DISPROVEN 2026-09-08, the same way `0x89` byte 8 was disproven before it
+ * (see `INCOTT_CMD_QUERY_STATUS`): charging a unit through a full cycle from
+ * roughly 60% to roughly 97% while polling this response showed byte 6 NEVER
+ * CHANGE — the identical frame `09 8e 01 5a 04 84 38 01` the entire time,
+ * `0x38` = 56 throughout. A value that does not move while the real battery
+ * level visibly does cannot be a battery reading; it is a constant of unknown
+ * meaning, exactly like `0x89` byte 8 before it. `incottDecodeBattery` is
+ * kept only as a codec (its mechanical byte-6 decode is unchanged and still
+ * tested) and for the driver-level regression test that battery is no longer
+ * sourced from here — see `IncottHidClient.readStatus` and
+ * `docs/incott-testing.md`. The real battery percentage is a field of the
+ * unsolicited input report the mouse emits while in use — see
+ * `incottDecodeInputStatus`.
+ */
+export const INCOTT_CMD_QUERY_BATTERY = 0x8e;
+export const INCOTT_SUB_BATTERY = 0x01;
+
+/**
+ * The report id the mouse's UNSOLICITED input reports arrive on — the same
+ * value as `INCOTT_REPORT_ID` (`0x09`), which this module otherwise uses only
+ * for feature-report request/response pairs. These input reports are NOT a
+ * reply to anything this driver sends: the device emits them on its own,
+ * only while it is actively being used (moved or clicked), carrying battery
+ * and a packed DPI-stage/polling-rate snapshot. See `incottDecodeInputStatus`
+ * and `src/drivers/incott/hid.ts`'s `onInputReport`.
+ */
+export const INCOTT_INPUT_REPORT_ID = INCOTT_REPORT_ID;
+
+/**
+ * Button binding read, `09 86 <button 0..5>` -> response bytes 3-5 = the raw
+ * three-byte binding written by `INCOTT_CMD_SET_BUTTON` at the same index.
+ * Round-trip confirmed on hardware 2026-09-08 (see `INCOTT_CMD_SET_BUTTON`).
+ * The device has six buttons; reading indices 0-5 on the unit under test
+ * returned:
+ *   0 -> 01 00 f0    3 -> 01 00 f3
+ *   1 -> 01 00 f1    4 -> 01 00 f4
+ *   2 -> 01 00 f2    5 -> 07 00 03
+ * (left, right, middle, forward, back, DPI — physically, in some order).
+ * This was previously `INCOTT_CMD_UNKNOWN_86`, decoded only for the vendor
+ * tool's own `09 86 09` query (still unexplained, kept as
+ * `INCOTT_SUB_UNKNOWN_86_VENDOR_QUERY`). See `incottDecodeButtonBinding` —
+ * only the raw three bytes are exposed; what `type`/`code` mean inside them
+ * is NOT established and is not guessed at here.
+ */
+export const INCOTT_CMD_QUERY_BUTTON = 0x86;
+/** Button count: left, right, middle, forward, back, DPI. */
+export const INCOTT_BUTTON_COUNT = 6;
+/**
+ * The vendor tool's own query, `09 86 09` — not a button index (buttons only
+ * go up to 5). Its payload is still undecoded.
+ */
+export const INCOTT_SUB_UNKNOWN_86_VENDOR_QUERY = 0x09;
+
+/** Sub-command for the DPI *active stage index* query (`0x83`). */
+export const INCOTT_SUB_DPI_STAGE = 0x06;
+/**
+ * Number of DPI stages the table holds. Both the `0x02` write and the `0x82`
+ * read take a stage index in this range as their second payload byte — see
+ * `incottEncodeSetDpi` and `incottDecodeDpiStage`.
+ *
+ * THIS WAS WRONG until 2026-09-08: the driver used to hardcode that byte as a
+ * constant `INCOTT_SUB_SET_DPI = 0x01`, which could only ever write stage 1
+ * of the table. Reading stages 0-5 on real hardware returned six independent
+ * points on the DPI line (wire 0x07/0x0f/0x1f/0x2f/0x3f/0x7f ->
+ * 400/800/1600/2400/3200/6400), proving the byte is a stage index, not a
+ * fixed sub-command.
+ */
+export const INCOTT_DPI_STAGE_COUNT = 6;
+export const INCOTT_SUB_LOD = 0x01;
+export const INCOTT_SUB_RIPPLE = 0x02;
+export const INCOTT_SUB_ANGLE_SNAP = 0x03;
+export const INCOTT_SUB_MOTION_SYNC = 0x04;
+/**
+ * Captured writes as the owner switched the vendor tool's "Performance mode"
+ * control (labelled HP / Corded / LP, described as trading performance for
+ * battery life): `TX 09 04 05 02` and `TX 09 04 05 01`. Only two of the three
+ * values were observed being written, and — critically — WHICH label was
+ * selected for either write was never recorded, so the value-to-label
+ * mapping is UNVERIFIED. See `incottEncodeSetPerformanceMode`.
+ */
+export const INCOTT_SUB_PERFORMANCE = 0x05;
+export const INCOTT_SUB_DEBOUNCE = 0x01;
+export const INCOTT_SUB_SLEEP = 0x03;
+export const INCOTT_SUB_NONE = 0x00;
+
+/**
+ * DPI lives in a six-stage table, each stage a linear value — not an index
+ * into a preset table. The wire value is little-endian at payload bytes 2-3
+ * (write) / response bytes 3-4 (read):
+ *   wire = dpi / 50 - 1        dpi = (wire + 1) * 50
+ *
+ * Verified on hardware 2026-09-08 by reading all six stages back as
+ * 400/800/1600/2400/3200/6400 (wire 0x07/0x0f/0x1f/0x2f/0x3f/0x7f) — six
+ * independent points on this line — then writing 25000 to stage 2 (wire 499)
+ * and reading back exactly 25000, then restoring 1600 and reading that back
+ * too. (An earlier, narrower proof from 2026-09-07 against a G23V2Pro only
+ * ever exercised stage 1: `TX 09 02 01 0f 00` -> 800 DPI, `TX 09 02 01 f3 01`
+ * -> 25000 DPI.) See `incottEncodeSetDpi` and `incottDecodeDpiStage`.
+ *
+ * The vendor's own device definition (js/gvarG23-v102.js) pairs two PixArt
+ * sensor variants with different ceilings, both counting up from 50 in steps
+ * of 50:
+ *   sensor 0x3395 (PAW3395): 32000
+ *   sensor 0x3950 (PAW3950): 45000
+ * There is no known way to read which sensor variant is fitted to a given
+ * unit, so `INCOTT_DPI_MAX` uses the higher of the two known ceilings. A
+ * PAW3395 unit is expected to refuse anything above 32000; the existing
+ * write-cache/read-back verification in `IncottHidClient.setDpi` is relied on
+ * to report that honestly rather than this module guessing which sensor is
+ * present.
+ */
+export const INCOTT_DPI_MIN = 50;
+export const INCOTT_DPI_MAX = 45000;
+export const INCOTT_DPI_STEP = 50;
+
+/**
+ * NOT the writable DPI range (see `INCOTT_DPI_MIN`/`INCOTT_DPI_MAX` above for
+ * that) — the vendor's device definition calls this list the six DEFAULT
+ * STAGE PRESETS. `0x83`/`0x06` reports which of these six stages is active as
+ * an index 0-5 (see `incottDecodeDpiStageIndex`), not a DPI value. Kept as a
+ * convenience list of round numbers; do not use it to validate or decode a
+ * DPI write.
+ */
+export const INCOTT_DPI_DEFAULT_STAGE_PRESETS: readonly number[] = [400, 800, 1600, 2400, 3200, 6400];
+
+/**
+ * The full polling-rate ladder, available only over the 2.4 GHz wireless
+ * connection (`INCOTT_PRODUCT_ID`, `0x522C`). See
+ * `INCOTT_POLLING_STEPS_HZ_WIRED` for the lower ceiling the owner confirmed
+ * on hardware when the mouse is plugged in.
+ */
+export const INCOTT_POLLING_STEPS_HZ: readonly number[] = [125, 250, 500, 1000, 2000, 4000, 8000];
+/**
+ * Wired ceiling — HARDWARE-VERIFIED: the owner confirmed the mouse only
+ * reaches 1000 Hz over the USB cable (`INCOTT_PRODUCT_ID_WIRED`, `0x622C`);
+ * 2000/4000/8000 Hz are wireless-only. Offering one of those over the cable
+ * would produce a write the device silently refuses, which
+ * `IncottHidClient.setPollingRate`'s read-back verification would then
+ * report as a failure on every attempt — so `readStatus()` publishes this
+ * narrower list instead of the full one whenever `incottIsWiredProduct` is
+ * true. See `docs/incott-testing.md`.
+ */
+export const INCOTT_POLLING_STEPS_HZ_WIRED: readonly number[] = [125, 250, 500, 1000];
+export const INCOTT_POLLING_WIRE_TO_HZ: Readonly<Record<number, number>> = {
+  0: 1000, 1: 500, 2: 250, 3: 125, 4: 8000, 5: 4000, 6: 2000,
+};
+export const INCOTT_POLLING_HZ_TO_WIRE: Readonly<Record<number, number>> = {
+  1000: 0, 500: 1, 250: 2, 125: 3, 8000: 4, 4000: 5, 2000: 6,
+};
+
+/**
+ * Lift-off distance is carried in tenths of a millimetre.
+ *
+ * VERIFIED ON HARDWARE 2026-09-08. Setting 0.7 mm in Incott's own web
+ * configurator and then reading `0x84`/sub `0x01` returned byte 3 = `2`,
+ * so hardware 2 = 0.7 mm. That confirms IncottHIDApp's mapping, which is
+ * what `INCOTT_LOD_WIRE_TO_TENTHS` below encodes.
+ *
+ * It also disproves a reading of the vendor's own device definition
+ * (js/gvarG23-v102.js), which pairs `lodUI = [0.7, 1, 2]` with
+ * `lodHW = [0, 1, 2]`. Those two arrays are NOT index-aligned — taking
+ * them as a pair implies hardware 0 = 0.7 mm, which the device
+ * contradicts. Do not 'fix' this mapping from that file.
+ *
+ * Remaining nuance: only the 0.7 mm point was read directly. Hardware 0
+ * and 1 are 1 mm and 2 mm in that order per IncottHIDApp; since the
+ * mapping is a bijection over {0,1,2} and its 0.7 mm claim proved correct,
+ * the other two follow, but neither has been read back individually.
+ */
+export const INCOTT_LOD_STEPS_TENTHS: readonly number[] = [7, 10, 20];
+export const INCOTT_LOD_WIRE_TO_TENTHS: Readonly<Record<number, number>> = { 0: 10, 1: 20, 2: 7 };
+export const INCOTT_LOD_TENTHS_TO_WIRE: Readonly<Record<number, number>> = { 10: 0, 20: 1, 7: 2 };
+
+export const INCOTT_DEBOUNCE_MIN_MS = 0;
+export const INCOTT_DEBOUNCE_MAX_MS = 30;
+export const INCOTT_SLEEP_MIN_S = 1;
+export const INCOTT_SLEEP_MAX_S = 900;
+
+/** 0, 1 and 2 are the only values ever written; 0 is presumed to exist (a three-way control implies three values) but was never directly observed. */
+export const INCOTT_PERFORMANCE_MODE_MIN = 0;
+export const INCOTT_PERFORMANCE_MODE_MAX = 2;
+
+/**
+ * A curated subset of the verified 1-900s sleep-timer range to offer in the
+ * app's dropdown, in the same style as GEARHUB_SLEEP_OPTIONS and
+ * MCHOSE_SLEEP_OPTIONS: the firmware accepts any integer second count in
+ * range (see `incottEncodeSetSleep`), this is just a sane list of presets.
+ * 900s (15 minutes) is the documented maximum.
+ */
+export const INCOTT_SLEEP_OPTIONS: readonly number[] = [10, 30, 60, 120, 300, 600, 900];
+
+export const INCOTT_RECEIVER_LED_MODES: readonly string[] = [
+  "Connect & polling rate",
+  "Battery status",
+  "Battery warning",
+];
+
+export type IncottToggleKind = "motionSync" | "angleSnapping" | "rippleControl";
+
+export const INCOTT_TOGGLE_SUB: Readonly<Record<IncottToggleKind, number>> = {
+  motionSync: INCOTT_SUB_MOTION_SYNC,
+  angleSnapping: INCOTT_SUB_ANGLE_SNAP,
+  rippleControl: INCOTT_SUB_RIPPLE,
+};
+
+/**
+ * Builds a request payload. The report ID is deliberately absent: WebHID's
+ * sendFeatureReport takes it as a separate argument.
+ */
+function payload(...values: readonly number[]): Uint8Array {
+  const out = new Uint8Array(INCOTT_PAYLOAD_LENGTH);
+  values.forEach((value, index) => {
+    out[index] = value & 0xff;
+  });
+  return out;
+}
+
+/**
+ * Throws `RangeError` unless `dpi` is a value the six-stage table can hold.
+ * Split out from `incottEncodeSetDpi` so `IncottHidClient.setDpi` can reject
+ * an invalid value before touching the device — determining which stage is
+ * active requires a query, and an obviously-invalid DPI should never cost a
+ * round-trip.
+ */
+export function incottValidateDpi(dpi: number): void {
+  if (
+    !Number.isInteger(dpi) ||
+    dpi < INCOTT_DPI_MIN ||
+    dpi > INCOTT_DPI_MAX ||
+    dpi % INCOTT_DPI_STEP !== 0
+  ) {
+    throw new RangeError(`DPI out of range: ${dpi}`);
+  }
+}
+
+/**
+ * EDITS the DPI value stored in one stage — distinct from
+ * `incottEncodeSetActiveDpiStage`, which only SELECTS which stage is active
+ * and never touches a stored value. `stage` is a table index 0-5, NOT a
+ * sub-command — see `INCOTT_DPI_STAGE_COUNT` for the hardware proof that this
+ * byte varies (the driver used to hardcode it as a constant `0x01`, which
+ * could only ever reach stage 1). The value itself is a plain little-endian
+ * uint16 "wire" value — see the comment on `INCOTT_DPI_MIN` for the
+ * conversion and the captured proof.
+ */
+export function incottEncodeSetDpi(stage: number, dpi: number): Uint8Array {
+  if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
+    throw new RangeError(`DPI stage out of range: ${stage}`);
+  }
+  incottValidateDpi(dpi);
+  const wire = dpi / INCOTT_DPI_STEP - 1;
+  return payload(INCOTT_CMD_SET_DPI, stage, wire & 0xff, (wire >> 8) & 0xff);
+}
+
+/**
+ * Selects which of the six DPI stages is active — `09 03 06 <idx>`. Does NOT
+ * write a DPI value and does NOT alter any stage's stored value; see
+ * `INCOTT_CMD_SET_DPI_STAGE` for the hardware proof (select 0/3/5/1, table
+ * unchanged) and for why this is a distinct operation from
+ * `incottEncodeSetDpi`, which edits a stage's stored value.
+ */
+export function incottEncodeSetActiveDpiStage(stage: number): Uint8Array {
+  if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
+    throw new RangeError(`DPI stage out of range: ${stage}`);
+  }
+  return payload(INCOTT_CMD_SET_DPI_STAGE, INCOTT_SUB_DPI_STAGE, stage);
+}
+
+export function incottEncodeSetPollingRate(hz: number): Uint8Array {
+  const wire = INCOTT_POLLING_HZ_TO_WIRE[hz];
+  if (wire === undefined) throw new RangeError(`Unsupported polling rate: ${hz} Hz`);
+  // No sub-command: the wire value occupies the sub-command slot.
+  return payload(INCOTT_CMD_SET_POLLING, wire);
+}
+
+export function incottEncodeSetLiftOff(tenthsMm: number): Uint8Array {
+  const wire = INCOTT_LOD_TENTHS_TO_WIRE[tenthsMm];
+  if (wire === undefined) throw new RangeError(`Unsupported lift-off distance: ${tenthsMm}`);
+  return payload(INCOTT_CMD_SET_SENSOR, INCOTT_SUB_LOD, wire);
+}
+
+export function incottEncodeSetToggle(kind: IncottToggleKind, on: boolean): Uint8Array {
+  return payload(INCOTT_CMD_SET_SENSOR, INCOTT_TOGGLE_SUB[kind], on ? 0x01 : 0x00);
+}
+
+/**
+ * Encodes a raw three-byte button binding write, `09 06 <button 0..5>
+ * <b0> <b1> <b2>`. Codec only, by design (see `INCOTT_CMD_SET_BUTTON`): the
+ * meaning of the three bytes (key code, macro reference, remap target — the
+ * fields are unnamed here on purpose) is NOT established, so this neither
+ * interprets nor validates them beyond fitting in a byte. Round-trip
+ * confirmed on hardware 2026-09-08: writing `01 00 f0` to button 0 read back
+ * byte for byte via `incottDecodeButtonBinding`.
+ */
+export function incottEncodeSetButtonBinding(button: number, raw: readonly [number, number, number]): Uint8Array {
+  if (!Number.isInteger(button) || button < 0 || button >= INCOTT_BUTTON_COUNT) {
+    throw new RangeError(`Button index out of range: ${button}`);
+  }
+  return payload(INCOTT_CMD_SET_BUTTON, button, raw[0], raw[1], raw[2]);
+}
+
+/**
+ * See the comment on `INCOTT_SUB_PERFORMANCE`: the value-to-label mapping
+ * (HP / Corded / LP) is UNVERIFIED. This function only encodes the raw
+ * 0-2 value the vendor tool was observed writing.
+ */
+export function incottEncodeSetPerformanceMode(mode: number): Uint8Array {
+  if (!Number.isInteger(mode) || mode < INCOTT_PERFORMANCE_MODE_MIN || mode > INCOTT_PERFORMANCE_MODE_MAX) {
+    throw new RangeError(`Performance mode out of range: ${mode}`);
+  }
+  return payload(INCOTT_CMD_SET_SENSOR, INCOTT_SUB_PERFORMANCE, mode);
+}
+
+export function incottEncodeSetDebounce(ms: number): Uint8Array {
+  if (!Number.isInteger(ms) || ms < INCOTT_DEBOUNCE_MIN_MS || ms > INCOTT_DEBOUNCE_MAX_MS) {
+    throw new RangeError(`Debounce out of range: ${ms} ms`);
+  }
+  return payload(INCOTT_CMD_SET_TIMING, INCOTT_SUB_DEBOUNCE, ms);
+}
+
+export function incottEncodeSetSleep(seconds: number): Uint8Array {
+  if (!Number.isInteger(seconds) || seconds < INCOTT_SLEEP_MIN_S || seconds > INCOTT_SLEEP_MAX_S) {
+    throw new RangeError(`Sleep timer out of range: ${seconds} s`);
+  }
+  return payload(INCOTT_CMD_SET_TIMING, INCOTT_SUB_SLEEP, seconds & 0xff, (seconds >> 8) & 0xff);
+}
+
+export function incottEncodeSetReceiverLed(mode: number): Uint8Array {
+  if (!Number.isInteger(mode) || mode < 0 || mode >= INCOTT_RECEIVER_LED_MODES.length) {
+    throw new RangeError(`Receiver LED mode out of range: ${mode}`);
+  }
+  return payload(INCOTT_CMD_SET_RECEIVER_LED, mode);
+}
+
+export function incottEncodeQuery(cmd: number, sub: number = INCOTT_SUB_NONE): Uint8Array {
+  return payload(cmd, sub);
+}
+
+export interface IncottDeviceIdentity {
+  /** Space-separated hex of the identity payload, for the details panel. */
+  raw: string;
+}
+
+/**
+ * A response frame is trustworthy only when the report ID, the command echo
+ * and (when one was sent) the sub-command echo all agree with the request.
+ * The device latches a single shared response buffer, so a frame left over
+ * from an earlier query will otherwise be decoded as a real value.
+ */
+export function incottFrameMatches(frame: Uint8Array, cmd: number, sub: number | null): boolean {
+  if (frame.length < 3) return false;
+  if (frame[0] !== INCOTT_REPORT_ID) return false;
+  if (frame[1] !== cmd) return false;
+  if (sub !== null && frame[2] !== sub) return false;
+  return true;
+}
+
+/**
+ * `0x83`/`0x06` returns which of the six DPI stages is currently active
+ * (0-5) at response byte 3 — proven wrong to be a DPI-value index on
+ * hardware 2026-09-07: decoding byte 3 through `INCOTT_DPI_DEFAULT_STAGE_PRESETS`
+ * used to yield 800 DPI, which matched the vendor UI only by coincidence (the
+ * device happened to be on stage 1 of 6). Combine with
+ * `incottDecodeDpiStage` at this index to get the actual DPI value — see
+ * `IncottHidClient.readStatus`.
+ */
+export function incottDecodeDpiStageIndex(frame: Uint8Array): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_DPI_STAGE)) return null;
+  const index = frame[3];
+  return index !== undefined && index >= 0 && index <= 5 ? index : null;
+}
+
+/**
+ * `09 82 <stage>` -> the DPI value stored in that stage, little-endian at
+ * response bytes 3-4. This opcode used to be `INCOTT_CMD_UNKNOWN_82` — see
+ * the comment on `INCOTT_CMD_QUERY_DPI_STAGE_VALUE` for the hardware proof
+ * (six independent stage reads plus a write/read-back/restore round-trip on
+ * stage 2). `0x82` echoes its sub-command like `0x83`/`0x84`/`0x85`/`0x8e`
+ * (verified: `09 82 03` replies `09 82 03 …`), so `incottFrameMatches`
+ * checking byte 2 against `stage` is safe here.
+ */
+export function incottDecodeDpiStage(frame: Uint8Array, stage: number): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_DPI_STAGE_VALUE, stage)) return null;
+  if (frame.length < 5) return null;
+  const wire = frame[3]! | (frame[4]! << 8);
+  const dpi = (wire + 1) * INCOTT_DPI_STEP;
+  return dpi >= INCOTT_DPI_MIN && dpi <= INCOTT_DPI_MAX ? dpi : null;
+}
+
+/**
+ * The polling value sits in byte 2, mirroring the write, which also carries
+ * its value in the sub-command slot. CONFIRMED on hardware 2026-09-08: writing
+ * wire `1` then wire `0` and reading back showed byte 2 follow, `0 -> 1 -> 0`.
+ * `0x81` does NOT echo a sub-command the way `0x82`-`0x86`/`0x8e` do — byte 2
+ * here is data, not an echo — which is why it stays out of
+ * `SUB_ECHOING_QUERIES` in `src/drivers/incott/hid.ts`.
+ */
+export function incottDecodePollingRate(frame: Uint8Array): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_POLLING, null)) return null;
+  return INCOTT_POLLING_WIRE_TO_HZ[frame[2] ?? -1] ?? null;
+}
+
+/**
+ * Reads lift-off from the packed byte 7 of the `0x84`/sub `0x00` response
+ * (high nibble). Superseded as the driver's primary read by
+ * `incottDecodeLiftOffDirect` (see `INCOTT_SUB_LOD`'s symmetric
+ * `0x84`/`0x01` read), which is clearer, but kept and still exercised: it was
+ * cross-checked against the symmetric read on hardware 2026-09-08 — hardware
+ * values 0, 1, 2 round-tripped identically through both forms — so this is
+ * not wrong, just less direct.
+ */
+export function incottDecodeLiftOff(frame: Uint8Array): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_NONE)) return null;
+  if (frame.length < 8) return null;
+  return INCOTT_LOD_WIRE_TO_TENTHS[frame[7] >> 4] ?? null;
+}
+
+/**
+ * Symmetric single-purpose read for lift-off: `09 84 01` -> response byte 3
+ * is the raw hardware value (0-2), matching the sub-command the `0x04`/`0x01`
+ * write uses (see `incottEncodeSetLiftOff`). PREFERRED over
+ * `incottDecodeLiftOff`'s packed byte-7 nibble read: verified on hardware
+ * 2026-09-08 by round-tripping hw 0, 1, 2 through both this form and the
+ * nibble form and finding they agree at every step. The hw-to-millimetre
+ * label mapping is still an open question — see `INCOTT_LOD_WIRE_TO_TENTHS`.
+ */
+export function incottDecodeLiftOffDirect(frame: Uint8Array): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_LOD)) return null;
+  const wire = frame[3];
+  return wire !== undefined ? (INCOTT_LOD_WIRE_TO_TENTHS[wire] ?? null) : null;
+}
+
+/**
+ * Reads motion sync from the packed byte 7 of the `0x84`/sub `0x00` response
+ * (low nibble). Superseded as the driver's primary read by
+ * `incottDecodeToggle(frame, INCOTT_SUB_MOTION_SYNC)` (the symmetric
+ * `0x84`/`0x04` read), which is clearer, but kept and still exercised: it was
+ * cross-checked against the symmetric read on hardware 2026-09-08 — 0/1/0
+ * round-tripped identically through both forms — so this is not wrong, just
+ * less direct.
+ */
+export function incottDecodeMotionSync(frame: Uint8Array): boolean | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_NONE)) return null;
+  if (frame.length < 8) return null;
+  const nibble = frame[7] & 0x0f;
+  return nibble === 0x01 ? true : nibble === 0x00 ? false : null;
+}
+
+export function incottDecodeToggle(frame: Uint8Array, sub?: number): boolean | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_SENSOR, sub ?? null)) return null;
+  const value = frame[3];
+  if (value === 0x01) return true;
+  if (value === 0x00) return false;
+  return null;
+}
+
+/**
+ * A read-back for performance mode was never captured on hardware — only the
+ * writes documented on `INCOTT_SUB_PERFORMANCE` were observed. This mirrors
+ * the read/write symmetry every other `0x04`/`0x84` sensor sub-command uses
+ * (lift-off, ripple, angle snap and motion sync all pair a `0x04` write with
+ * an `0x84` read at the same sub-command and a value at byte 3), so it is a
+ * reasonable attempt, not a confirmed one. Callers must treat `null` as
+ * "unknown," not as a failed write.
+ */
+export function incottDecodePerformanceMode(frame: Uint8Array): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_SENSOR, INCOTT_SUB_PERFORMANCE)) return null;
+  const value = frame[3];
+  return value !== undefined && value >= INCOTT_PERFORMANCE_MODE_MIN && value <= INCOTT_PERFORMANCE_MODE_MAX
+    ? value
+    : null;
+}
+
+export function incottDecodeDebounce(frame: Uint8Array): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_TIMING, INCOTT_SUB_DEBOUNCE)) return null;
+  const value = frame[3] ?? -1;
+  return value >= 0 && value <= INCOTT_DEBOUNCE_MAX_MS ? value : null;
+}
+
+export function incottDecodeSleep(frame: Uint8Array): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_TIMING, INCOTT_SUB_SLEEP)) return null;
+  if (frame.length < 5) return null;
+  const value = frame[3] | (frame[4] << 8);
+  return value >= INCOTT_SLEEP_MIN_S && value <= INCOTT_SLEEP_MAX_S ? value : null;
+}
+
+export function incottDecodeReceiverLed(frame: Uint8Array): number | null {
+  if (frame[0] !== INCOTT_REPORT_ID || frame[1] !== INCOTT_CMD_QUERY_RECEIVER_LED) return null;
+  const value = frame[2] ?? -1;
+  return value >= 0 && value < INCOTT_RECEIVER_LED_MODES.length ? value : null;
+}
+
+/**
+ * DISPROVEN AS A BATTERY READING, 2026-09-08 — kept as a codec only (its
+ * mechanical byte-6 decode is unchanged and still exercised by tests) and for
+ * `IncottHidClient.readStatus`'s regression test that battery is no longer
+ * sourced from this frame. See `INCOTT_CMD_QUERY_BATTERY` for the full
+ * write-up: a full charge cycle from roughly 60% to roughly 97% left this
+ * frame's byte 6 completely unchanged (`09 8e 01 5a 04 84 38 01`, `0x38` = 56
+ * throughout), the same disproof `0x89` byte 8 suffered earlier. Originally
+ * "proven" on hardware 2026-09-07 against a single static capture
+ * (`TX 09 8e 01` -> `RX 09 8e 01 5a 04 84 38 01 00`) that only ever showed one
+ * reading was never distinguished from a constant until the later
+ * full-cycle test. The real battery percentage is a field of the unsolicited
+ * input report the mouse emits while in use — see `incottDecodeInputStatus`
+ * and `IncottHidClient`'s class comment.
+ */
+export function incottDecodeBattery(frame: Uint8Array): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_BATTERY, INCOTT_SUB_BATTERY)) return null;
+  const value = frame[6];
+  return value !== undefined && value >= 0 && value <= 100 ? value : null;
+}
+
+/**
+ * Raw byte 1 (this module's convention — see below) of the mouse's
+ * unsolicited input report, above which the mouse is charging. At or below
+ * this, the raw byte IS the battery percentage; above it, subtract
+ * `INCOTT_INPUT_BATTERY_CHARGING_OFFSET` to get the percentage. See
+ * `incottDecodeInputStatus`.
+ */
+export const INCOTT_INPUT_BATTERY_CHARGING_THRESHOLD = 100;
+/** See `INCOTT_INPUT_BATTERY_CHARGING_THRESHOLD`. */
+export const INCOTT_INPUT_BATTERY_CHARGING_OFFSET = 128;
+
+/**
+ * Decoded fields of the mouse's unsolicited vendor-collection INPUT report
+ * (report id `INCOTT_INPUT_REPORT_ID`) — see `incottDecodeInputStatus`.
+ */
+export interface IncottInputStatus {
+  /** 0-100. */
+  batteryPercent: number;
+  /** True when `byte0 > INCOTT_INPUT_BATTERY_CHARGING_THRESHOLD`. */
+  charging: boolean;
+  /** High nibble of byte 1: which of the six DPI stages is active (0-5). Corroborates, but does not replace, the `0x83`/`0x06` feature-report read. */
+  dpiStageIndex: number;
+  /** Low nibble of byte 1: index into `INCOTT_POLLING_WIRE_TO_HZ`. Corroborates, but does not replace, the `0x81` feature-report read. */
+  pollingIndex: number;
+}
+
+/**
+ * Decodes the mouse's UNSOLICITED input report — battery plus a packed
+ * DPI-stage/polling-rate snapshot. This is NOT a feature-report reply (no
+ * request triggers it): the device emits it on report id
+ * `INCOTT_INPUT_REPORT_ID` on its own, only while it is actively being used.
+ *
+ * BYTE-INDEX CONVENTION, mirroring the asymmetry this module's top-of-file
+ * comment already documents for feature reports (WebHID's `sendFeatureReport`
+ * takes the report id separately, so encoded payloads omit it, while
+ * `receiveFeatureReport` returns it at byte 0, so decoded frames include it):
+ * this function's `byte0`/`byte1` parameters EXCLUDE the report id, matching
+ * WebHID's `inputreport` event, whose `data` DataView excludes it too
+ * (`event.reportId` carries it separately). So `byte0` is
+ * `event.data.getUint8(0)`, `byte1` is `event.data.getUint8(1)`.
+ *
+ * node-hid's raw input buffer, by contrast, INCLUDES the report id at index
+ * 0 — the two hardware captures below were taken that way, so in node-hid
+ * terms `byte0` is `buf[1]` and `byte1` is `buf[2]`. Get this backwards and
+ * every field reads off by one byte. See
+ * `captures/incott-8k-wireless/input-report-battery.hex` and
+ * `src/drivers/incott/hid.ts`'s `onInputReport`, which unwraps the WebHID
+ * event into this convention before calling this function.
+ *
+ * Hardware-verified 2026-09-08 across a full charge cycle (~60% to ~97%):
+ * ```
+ * discharging: 09 5f 10 04 00 0f 0f 10   (node-hid)  byte0=0x5f=95  -> 95%
+ * charging:    09 e1 10 04 00 0f 0f 10   (node-hid)  byte0=0xe1=225 -> charging, 225-128=97%
+ * ```
+ * `raw > 100` means charging (subtract `INCOTT_INPUT_BATTERY_CHARGING_OFFSET`
+ * for the percent); `raw <= 100` means discharging (raw IS the percent). This
+ * is the same convention IncottHIDApp's `parseStatus` uses, and unlike that
+ * project's other claims, this one is now independently hardware-verified in
+ * both states — see `docs/incott-testing.md`.
+ *
+ * Byte 1's `0x10` on the unit under test decoded to DPI stage 1 / polling
+ * index 0, and both independently matched what the feature reads returned at
+ * the same moment (`09 83 06` -> stage 1, `09 81` byte 2 -> 0) — a
+ * corroborating cross-check only; `IncottHidClient` still treats the feature
+ * reads as authoritative for DPI stage and polling rate.
+ *
+ * Returns `null` when either byte is out of range, or when the derived
+ * percent would fall outside 0-100 (a malformed or unrelated report).
+ */
+export function incottDecodeInputStatus(byte0: number, byte1: number): IncottInputStatus | null {
+  if (byte0 === undefined || byte0 < 0 || byte0 > 255) return null;
+  if (byte1 === undefined || byte1 < 0 || byte1 > 255) return null;
+  const charging = byte0 > INCOTT_INPUT_BATTERY_CHARGING_THRESHOLD;
+  const batteryPercent = charging ? byte0 - INCOTT_INPUT_BATTERY_CHARGING_OFFSET : byte0;
+  if (batteryPercent < 0 || batteryPercent > 100) return null;
+  return {
+    batteryPercent,
+    charging,
+    dpiStageIndex: (byte1 >> 4) & 0x0f,
+    pollingIndex: byte1 & 0x0f,
+  };
+}
+
+/**
+ * Raw three-byte binding read back from a button. Field names are
+ * deliberately generic (`b0`/`b1`/`b2`), not `type`/`code`: what each byte
+ * means (key code, macro reference, remap target) is NOT established. This
+ * is a codec for the wire bytes only — see `INCOTT_CMD_QUERY_BUTTON`.
+ */
+export interface IncottButtonBinding {
+  button: number;
+  b0: number;
+  b1: number;
+  b2: number;
+}
+
+/**
+ * `09 86 <button 0..5>` -> response bytes 3-5 = the raw binding. Round-trip
+ * confirmed on hardware 2026-09-08 (see `INCOTT_CMD_QUERY_BUTTON`). Codec
+ * only: nothing here interprets `b0`/`b1`/`b2` as a key, macro, or action —
+ * that mapping is unverified and out of scope for this driver.
+ */
+export function incottDecodeButtonBinding(frame: Uint8Array, button: number): IncottButtonBinding | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_BUTTON, button)) return null;
+  if (frame.length < 6) return null;
+  return { button, b0: frame[3]!, b1: frame[4]!, b2: frame[5]! };
+}
+
+export function incottDecodeIdentity(frame: Uint8Array): IncottDeviceIdentity | null {
+  if (frame[0] !== INCOTT_REPORT_ID || frame[1] !== INCOTT_CMD_QUERY_IDENTITY) return null;
+  const raw = Array.from(frame.slice(2, 9))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join(" ");
+  return { raw };
+}
+
+/**
+ * True when this product id is the WIRED one (`0x622C`) rather than the 2.4
+ * GHz dongle's (`0x522C`, `INCOTT_PRODUCT_ID`) — hardware-verified 2026-09-08,
+ * see `INCOTT_PRODUCT_ID_WIRED`. Formerly `incottIsChargingProduct`: it
+ * always returned exactly this, but under a name that mislabelled the
+ * connection as a charging flag. Charging is real for this product id, but
+ * it is a CONSEQUENCE of being plugged in, not what the id itself encodes —
+ * see `IncottHidClient.readStatus`, which now sets `connectionType` from
+ * this helper directly and derives `batteryState: "Charging"` from it rather
+ * than from a same-named constant.
+ */
+export function incottIsWiredProduct(productId: number): boolean {
+  return productId === INCOTT_PRODUCT_ID_WIRED;
+}
+
+/**
+ * Tidies the raw HID product string for display: drops a single leading
+ * vendor word ("incott") and a single trailing "mouse", case-insensitively,
+ * leaving whatever sits between. Falls back to the untouched raw string if
+ * stripping both would leave nothing.
+ *
+ * "incott Esports G23V2Pro mouse" -> "Esports G23V2Pro"
+ * "incott 8K wireless mouse"      -> "8K wireless"
+ *
+ * WHY THIS EXISTS: the real model name ("Esports G23V2Pro") is only present
+ * in the WIRED product string — hardware-verified 2026-09-08. The wireless
+ * dongle's product string ("incott 8K wireless mouse") is a generic name
+ * with no model in it at all, and there is no way to read the model while
+ * connected wirelessly: this driver does NOT infer or guess a model in that
+ * case, since doing so would be a fabricated value. This function only
+ * TIDIES whatever raw string the device actually reported; it never invents
+ * one.
+ *
+ * The identity query's reply (`09 8f 00` -> `01 0e 02 f0 f1 00 ff`, see
+ * `incottDecodeIdentity`) has NOT been decoded — its byte layout is unknown
+ * — so it is not currently a source for the model name either, wired or
+ * wireless. If a future capture decodes it, this comment is the place to
+ * update.
+ */
+export function incottNormalizeProductName(raw: string): string {
+  const words = raw.trim().split(/\s+/).filter((word) => word.length > 0);
+  if (words.length === 0) return raw;
+  const start = words[0]!.toLowerCase() === "incott" ? 1 : 0;
+  const endExclusive = words.length > start && words[words.length - 1]!.toLowerCase() === "mouse"
+    ? words.length - 1
+    : words.length;
+  const trimmed = words.slice(start, Math.max(start, endExclusive)).join(" ");
+  return trimmed.length > 0 ? trimmed : raw;
+}
+
+/** Maps the lift-off wire value (in tenths of a millimetre) to the shared Low/Medium/High stops. */
+export function incottLiftOffLabel(tenthsMm: number): "Low" | "Medium" | "High" | null {
+  if (tenthsMm === 7) return "Low";
+  if (tenthsMm === 10) return "Medium";
+  if (tenthsMm === 20) return "High";
+  return null;
+}
+
+/** Maps a Low/Medium/High stop back to tenths of a millimetre for `incottEncodeSetLiftOff`. */
+export function incottLiftOffTenths(level: "Low" | "Medium" | "High"): number {
+  return level === "Low" ? 7 : level === "Medium" ? 10 : 20;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,4 @@ export * as gwolves from "./gwolves/index.js";
 export * as glorious from "./glorious/index.js";
 export * as ksnake from "./ksnake/index.js";
 export * as valkyrie from "./valkyrie/index.js";
+export * as incott from "./incott/index.js";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       "@openmouse/protocol/endgame-gear-op1": ["./src/endgame-gear/op1.ts"],
       "@openmouse/protocol/finalmouse": ["./src/finalmouse/index.ts"],
       "@openmouse/protocol/gearhub": ["./src/gearhub/index.ts"],
+      "@openmouse/protocol/incott": ["./src/incott/index.ts"],
       "@openmouse/protocol/keychron": ["./src/keychron/index.ts"],
       "@openmouse/protocol/lamzu": ["./src/lamzu/index.ts"],
       "@openmouse/protocol/logitech": ["./src/logitech/index.ts"],


### PR DESCRIPTION
# Add Incott driver (G23V2Pro / 8K wireless, PixArt 093A:522C / 622C)

Adds support for Incott wireless mice to `mouse-protocol`: a transport-independent
codec under `src/incott/` and a WebHID client under `src/drivers/incott/`,
registered in the registry, discovery filters and brand union.

Companion PR to `openmouse` adds the client to `NEEDS_OPEN` in
`src/device/controller.ts` (required, per the architecture guide).

## Hardware

Tested on an **Incott G23V2Pro** — PixArt PAW3950 sensor, vendor collection
`0xFF05`, feature reports on report id `0x09`.

- wireless via 2.4 GHz dongle: product id `0x522C`
- wired over USB: product id `0x622C`

The sensor id (`0x3950`) is not guessed — it was read from the device's own
onboard-profile export, which also confirmed several decoded values
independently.

## What works

| Setting | Read | Write |
|---|---|---|
| DPI (six stages, 50–45000, step 50) | ✅ | ✅ |
| Active DPI stage | ✅ | ✅ |
| Polling rate (125–8000 Hz; 1000 Hz ceiling when wired) | ✅ | ✅ |
| Lift-off distance (0.7 / 1 / 2 mm) | ✅ | ✅ |
| Motion sync, angle snapping, ripple control | ✅ | ✅ |
| Debounce (0–30 ms) | ✅ | ✅ |
| Sleep timer (1–900 s) | ✅ | ✅ |
| Receiver LED (hidden when wired) | ✅ | ✅ |
| Battery + charging state | ✅ | — |

## Verification

Every claim above was checked against the device, not inherited. Raw captures
are committed under `captures/incott-8k-wireless/`; `docs/incott-testing.md`
records the full method.

- **DPI** — reading all six stages returned wire values `0x07 0x0f 0x1f 0x2f
  0x3f 0x7f`, i.e. 400/800/1600/2400/3200/6400: six independent points on
  `dpi = (wire + 1) × 50`. Writing 25000 to a stage read back exactly, and
  restoring 1600 read back exactly.
- **Persistence** — six settings were written with distinctive values, the mouse
  was powered off and on, and all six survived. They are committed to flash, not
  held in RAM.
- **Polling byte** — writing wire 1 then wire 0 moved response byte 2 of `0x81`
  and nothing else, identifying the field.
- **Lift-off mapping** — setting 0.7 mm in the vendor configurator and reading
  `0x84`/`0x01` returned `2`, confirming hardware 2 = 0.7 mm. Independently
  confirmed a third time by the onboard export (`lod:2`).
- **Battery** — captured in both states: `0x5f` = 95% discharging, `0xe1` = 225 →
  charging at 97%. Byte 2 of the same report packs the active DPI stage and
  polling index, and both matched the feature reads taken at that moment.

## Hypotheses that were disproven

Recorded because the reverse-engineering guide asks for what did not work.

- **Battery is not in any feature report.** Two candidates were tried and both
  falsified by a full charge cycle in which neither moved: `0x8e`/`0x01` byte 6
  (constant `0x38`) and `0x89` byte 8 (constant `0x5a`). Battery arrives only in
  an unsolicited input report, which the device emits while in use.
- **DPI is not a six-entry preset index.** Prior art treats `09 03 06 <idx>` as
  "set DPI"; it actually selects the active stage. Editing a stage's value is a
  different command (`09 02 <stage> <lo> <hi>`). Conflating them silently
  overwrites the user's stored table.
- **An opcode sweep using only sub-command `0x00` is misleading.** It reported
  `0x82` and `0x8e` as unimplemented. `0x82` is the DPI stage table and `0x8e`
  carries battery; both answer only on specific sub-commands.
- **Two `0xFF05` collections exist when wired**, and the first one rejects
  feature reports at the OS level. The driver probes candidates with an identity
  query and keeps whichever actually answers, rather than trusting the usage page.

## Not implemented

Deliberately out of scope for a first driver: button remapping, onboard profiles
(1–4), independent X/Y DPI, per-stage DPI colours, performance mode (HP /
Corded / LP), and sensor mode. The device's own profile export documents these
fields, so they are understood but not built. A codec exists for buttons and
performance mode but is not exposed, because their payload semantics are not
established.

## Known-unverified

- The `0x8f` identity payload (`01 0e 02 f0 f1 00 ff`) is not decoded. The model
  name is taken from the HID product string, which only names the model over the
  cable (`incott Esports G23V2Pro mouse`); wirelessly the dongle reports a
  generic name.
- Only the 0.7 mm lift-off point was read back directly. The other two follow
  from the mapping being a bijection over three values, but were not read
  individually.
- Performance mode values 0–2 read and write, but which is HP / Corded / LP is
  not confirmed, so it is not surfaced.

## Attribution

The initial command set was derived from
[IncottHIDApp](https://github.com/romkazor/IncottHIDApp) (MIT). No code from that
project is included, and several of its assumptions are corrected here — see the
disproven list above.

## Checks

- `npm run check` clean in `mouse-protocol` (build + tests + pack)
- `tsc --noEmit` and `vite build` clean in `openmouse`
- 1346 tests passing, including codec tests pinned to captured bytes, a
  stale-frame regression, and a regression asserting that selecting a DPI stage
  does not write a value into it

The browser UI has been exercised by the device owner; I have not driven it
end-to-end myself, so I would welcome a second pair of eyes there.
