### PR TITLE
Add the MCHOSE A7 V3 protocol and a read-only driver

### DIFF
--- a/docs/mchose-protocol.md
+++ b/docs/mchose-protocol.md
@@ -227,12 +227,12 @@ MCHOSE's own firmware-version table cross-checks this: the Ultra reports
 
 ## Dead ends, so the next person can skip them
 
-- **The `0x4d`-magic framing in the same bundle is a different product line.**
-  It is a real MCHOSE protocol (`[4d][ver][flags][len][cmdLo][cmdHi][biz][seq]…`
-  plus an XOR checksum, commands `0x00xx` read / `0x01xx` write) but the A7 V2
-  has no report `0x4d`, and every variant of it was rejected by the hardware.
-  A second framing in that bundle starting `0xaa` belongs to the keyboard and
-  audio paths.
+- **The `0x4d`-magic framing in the same bundle is a different *generation*.**
+  The A7 V2 has no report `0x4d` and rejected every variant of it, which is
+  correct — but it was first written up here as belonging to some other product
+  line, and that was wrong. It is MCHOSE's newer mouse protocol, and the A7 V3
+  family speaks it; see [the V3 section](#the-a7-v3-generation) below. A third
+  framing in that bundle starting `0xaa` is the MagDock's, in `src/mchose/dock.ts`.
 - **CompX framing does not apply.** The older MCHOSE A5/AX5 line (VID `0x2023`,
   reverse-engineered by [`Klegus/mchose-macos`](https://github.com/Klegus/mchose-macos)
   from MCHOSE's `DriverCore.exe`) speaks CompX over usage page `0xffff` with
@@ -444,3 +444,154 @@ watching **only** the wired byte move.
 With the mouse on its cable the receiver stays enumerated but has nothing behind
 it, so its config read simply fails — a driver must degrade rather than treat
 that as an error.
+
+## The A7 V3 generation
+
+Everything above is the **A7 V2** protocol. MCHOSE's newer mice — the A7 V3
+family and its siblings — use a second, unrelated protocol on the *same vendor
+id and the same usage page*. M HUB ships both UIs side by side, with a model
+list (`W8` in the bundle) picking which one a device gets.
+
+**Nothing in this section has been confirmed on hardware.** It is a reading of
+the vendor bundle, which is why `src/drivers/mchose/v3-hid.ts` only reads.
+
+| | A7 V2 | A7 V3 |
+| --- | --- | --- |
+| transport | feature reports `0x11` / `0x12` | **output report `0x4d`**; replies arrive as input reports |
+| encoding | every body byte XOR `0xff` | plain bytes, XOR checksum |
+| command id | one byte | **two bytes, little-endian** |
+| settings | one 64-byte blob (`0x67`) | several focused commands |
+| collection | `0xff01` / `0x0001` | `0xff01` / `0x0001` — *the same one* |
+
+That last row is the trap. Before the V3 landed, the V2 driver matched on the
+usage page alone and would happily have opened an A7 V3 and talked inverted
+feature reports at it. The two matchers are now kept apart by product id: the V3
+driver takes an allowlist, the V2 driver subtracts it.
+
+### Framing
+
+The first byte is both the `'M'` magic and the HID report id, so
+`sendReport(0x4d, body)` sends the remaining 63:
+
+```
+frame[0] = 0x4d   report id
+body[0]  = 0x01   protocol version
+body[1]  = flags  1 when a trailing checksum is present
+body[2]  = data length
+body[3]  = command low byte
+body[4]  = command high byte
+body[5]  = business code
+body[6]  = sequence
+body[7…] = data, then the checksum at body[7 + length]
+```
+
+The checksum is an XOR of `body[1]` through `body[6 + length]`. Replies use the
+same layout and are paired to their request by command id — M HUB does not check
+their checksum, though the codec here does when the reply claims to carry one.
+
+### Commands
+
+Reads are `0x00xx` and `0x09xx`; a write is its read plus `0x0100`.
+
+| Id | Payload | Meaning |
+| --- | --- | --- |
+| `0x0900` | — | vid, pid, profile count, macro sizes, link state, charge state, battery, mode |
+| `0x0002` | — | profile, DPI/rate indices, sleep, sensor flags, angle, debounce |
+| `0x0003` | `[profile, axis]` | stage count, active stage, six uint16 stages |
+| `0x0001` | `[profile, 0, 6]` | button table |
+| `0x0009` | `[profile]` | lift-off index |
+| `0x0901` | — | firmware version |
+| `0x090c` | `[index, offset u16, 22]` | macro storage, 22 bytes per read |
+| `0x0101` `0x0102` `0x0103` `0x0104` `0x0105` `0x0109` | | the matching writes, plus a single-stage DPI write and a factory reset |
+
+`0x0900` reports **the mouse's own product id** even behind a receiver, which is
+the only way to tell the models apart: `0x1014` and `0x1018` are shared by the
+whole 8 kHz generation and `0x1016` by the two 1 kHz ones.
+
+### The settings block (`0x0002` / `0x0102`)
+
+| Offset | Field |
+| --- | --- |
+| 0 | profile index |
+| 1 | wired: high nibble polling slot, low nibble DPI stage |
+| 2 | wireless: same shape |
+| 3 | sleep, in minutes |
+| 4 | sleep mode (bit 0) |
+| 5 | sensor flags |
+| 6 | angle tuning, two's-complement signed |
+| 7 | left debounce, ms |
+| 8 | right debounce, ms |
+
+Two differences from the V2 worth naming. Debounce is **per button** here, left
+and right separately. And the polling nibble is *not* an index into the model's
+rate list: the firmware's table has a slot M HUB never offers, so the vendor
+maps `slot > 1 ? slot - 1 : slot` on the way in and `option > 0 ? option + 1 :
+option` on the way out. Those are deliberately not inverses — slot 1 reads back
+as option 1 but is never written — which is consistent with a hidden 250 Hz step
+sitting between 125 and 500.
+
+Unlike the V2's `0x57`, this write replaces the whole block; there is no
+read-modify-write on the device side, so a caller must read, edit and send back.
+
+### The sensor byte — **not laid out like the V2's**
+
+| Bit | Mask | A7 V3 | A7 V2 (for contrast) |
+| --- | --- | --- | --- |
+| 0-1 | `0x03` | **performance mode** | lift-off step |
+| 2 | `0x04` | ripple control | ripple control |
+| 3 | `0x08` | linear correction | linear correction |
+| 4 | `0x10` | motion sync | motion sync |
+| 5-6 | `0x60` | **lift-off step** | mode / unexplained |
+| 7 | `0x80` | **glass-surface mode** | always set on the test hardware |
+
+Lift-off and the performance mode have swapped ends of the byte. Read a V3 byte
+with the V2's masks and a lift-off level comes out as a power mode; there is a
+test pinning exactly that.
+
+Two bits only reach four lift-off steps, and five models ship a five-step ladder
+(0.7 / 0.9 / 1.2 / 1.4 / 1.7 mm). Those keep lift-off behind `0x0009` instead —
+`liftOffCommand` in the product table marks them, and a test asserts the flag
+matches the ladder length rather than being maintained by hand.
+
+### Models
+
+From the bundle's own table. Every one of these shares the wire format; the A7
+V3 family is what the driver was written for and the rest are included so a
+shared receiver resolves to the right ceiling instead of the wrong one.
+
+| Model | PID | DPI max | Lift-off |
+| --- | --- | --- | --- |
+| A5 V3 Pro | `0x4035` | 26 000 | 1 / 2 mm |
+| A5 V3 Ultra+ | `0x4026` | 42 000 | 0.7 / 1 / 2 mm |
+| A5 V3 Ultra+ (3955) | `0x4034` | 50 000 | five steps |
+| K7 V2 Pro+ | `0x4027` | 42 000 | 0.7 / 1 / 2 mm |
+| K7 V2 Ultra+ | `0x4028` | 50 000 | five steps |
+| A7 V3 | `0x4030` | 26 000 | 1 / 2 mm |
+| A7 V3 Pro | `0x4031` | 42 000 | 0.7 / 1 / 2 mm |
+| A7 V3 Pro+ | `0x4032` | 42 000 | 0.7 / 1 / 2 mm |
+| **A7 V3 Ultra+** | `0x4033` | 50 000 | five steps |
+| K5 Pro | `0x4037` | 26 000 | 1 / 2 mm |
+| K5 Ultra | `0x4038` | 50 000 | five steps |
+| R7 Ultra | `0x4036` | 50 000 | five steps |
+| V7 | `0x402a` | 26 000 | 1 / 2 mm, 1 kHz |
+| G3 V3 | `0x4029` | 12 000 | 1 / 2 mm, 1 kHz |
+
+The bundle's per-model `dpiMagicNum` and `dpiSlider` tables are UI slider
+geometry, not wire encoding — DPI goes out as a plain little-endian uint16.
+
+### What is left for someone with the hardware
+
+The reads are the whole driver today. To turn it into a full one:
+
+1. Confirm the frame is accepted at all — `0x0900` is the cheapest probe, and
+   its reply carries a known vendor id to check against.
+2. Confirm the reply arrives on the input report rather than as a feature read.
+3. Time the writes. The V2 needed 400 ms to 2 s per command and three attempts
+   for its slowest; nothing here has been timed.
+4. Then the encoders in `src/mchose/v3.ts` can be wired to setters. Start with a
+   value that is trivially reversible, verify by reading it back, and restore
+   the entry state — the same order the V2 work used.
+
+Do not skip step 3. The V2's stale-reply buffer meant a read taken too early
+returned a *different command's* payload, and one of those nearly went back out
+as a config write.

--- a/src/drivers/mchose/hid.ts
+++ b/src/drivers/mchose/hid.ts
@@ -38,6 +38,7 @@ import {
   MCHOSE_BUTTONS,
   MCHOSE_BUTTON_ACTIONS,
   mchoseFindProduct,
+  mchoseV3IsProductId,
   mchosePollingRates,
   type MchoseBattery,
   type MchoseConfig,
@@ -100,6 +101,11 @@ export class MchoseHidClient {
       // The MagDock is the same vendor but a different protocol entirely, and
       // has its own driver; it must never be claimed as a mouse.
       && device.productId !== MCHOSE_DOCK_PRODUCT_ID
+      // The A7 V3 generation puts a *different* protocol on this same usage
+      // page, so the collection alone no longer identifies a V2. Subtracting
+      // the known V3 ids rather than listing the V2's keeps this open to
+      // unlisted V2-era models, which is how it found the test hardware.
+      && !mchoseV3IsProductId(device.productId)
       && device.collections.some(search);
   }
 

--- a/src/drivers/mchose/v3-hid.test.ts
+++ b/src/drivers/mchose/v3-hid.test.ts
@@ -1,0 +1,218 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { MchoseV3HidClient } from "./v3-hid.ts";
+import { MchoseHidClient } from "./hid.ts";
+import { MchoseDockHidClient } from "./dock-hid.ts";
+import { MCHOSE_V3_BODY_LENGTH, MCHOSE_V3_COMMAND } from "@openmouse/protocol/mchose";
+
+/** What an A7 V3 Ultra+ behind its receiver would answer, command by command. */
+const ANSWERS: Readonly<Record<number, number[]>> = {
+  [MCHOSE_V3_COMMAND.readDeviceInfo]: [
+    0x37, 0x38, 0x33, 0x40, 0x03, 0x01, 0x00, 0x04, 0x20, 0x00, 0x01, 0x00, 0x57, 0x02,
+  ],
+  // Profile 1, wired slot 3 / wireless slot 6, stage 2, ten-minute sleep,
+  // sensor 0x45 (lift-off 2, ripple on, eSports), −15°, 8/4 ms debounce.
+  [MCHOSE_V3_COMMAND.readSettings]: [
+    0x01, 0x32, 0x62, 0x0a, 0x01, 0x45, 0xf1, 0x08, 0x04,
+  ],
+  [MCHOSE_V3_COMMAND.readDpi]: [
+    0x01, 0x00, 0x04, 0x01, 0x00,
+    0x90, 0x01, 0x20, 0x03, 0x40, 0x06, 0x80, 0x0c, 0x00, 0x19, 0x50, 0xc3,
+  ],
+  // The Ultra+ keeps lift-off behind its own command: step 4 of five.
+  [MCHOSE_V3_COMMAND.readLiftOff]: [0x04],
+  [MCHOSE_V3_COMMAND.readVersion]: [0x01, 0x07],
+  [MCHOSE_V3_COMMAND.readButtons]: [
+    0x01, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x02,
+    0x00, 0x00, 0x04,
+    0x02, 0x00, 0x42,
+    0xff, 0x00, 0x00,
+    0x05, 0x00, 0x01,
+  ],
+};
+
+function frame(command: number, data: readonly number[]): Uint8Array {
+  const body = new Uint8Array(MCHOSE_V3_BODY_LENGTH);
+  body[0] = 0x01;
+  body[1] = 0x01;
+  body[2] = data.length;
+  body[3] = command & 0xff;
+  body[4] = (command >> 8) & 0xff;
+  body.set(data, 7);
+  let sum = 0;
+  for (let index = 1; index <= 6 + data.length; index += 1) sum ^= body[index]!;
+  body[7 + data.length] = sum;
+  return body;
+}
+
+interface FakeOptions {
+  productId?: number;
+  productName?: string;
+  /** Commands the device refuses to answer. */
+  silent?: number[];
+  /** Emit an unrelated input report before every real answer. */
+  noisy?: boolean;
+}
+
+function fakeMouse(options: FakeOptions = {}) {
+  const listeners: Array<(event: unknown) => void> = [];
+  const sent: number[] = [];
+
+  const emit = (body: Uint8Array): void => {
+    const event = { data: new DataView(body.buffer.slice(0)) };
+    for (const listener of [...listeners]) listener(event);
+  };
+
+  const device = {
+    vendorId: 0x3837,
+    productId: options.productId ?? 0x1014,
+    productName: options.productName ?? "MCHOSE Receiver",
+    opened: true,
+    collections: [
+      { usagePage: 0xff01, usage: 0x0001, type: 0, children: [], input: 0, output: 0, feature: 0 },
+    ],
+    open: async () => {},
+    close: async () => {},
+    addEventListener: (_type: string, fn: (event: unknown) => void) => { listeners.push(fn); },
+    removeEventListener: (_type: string, fn: (event: unknown) => void) => {
+      const at = listeners.indexOf(fn);
+      if (at >= 0) listeners.splice(at, 1);
+    },
+    sendReport: async (id: number, data: ArrayBuffer | ArrayLike<number>) => {
+      assert.equal(id, 0x4d, "every V3 command rides output report 0x4d");
+      const body = data instanceof Uint8Array ? data : new Uint8Array(data as ArrayBuffer);
+      const command = body[3]! | (body[4]! << 8);
+      sent.push(command);
+      if (options.silent?.includes(command)) return;
+      const answer = ANSWERS[command];
+      if (!answer) return;
+      queueMicrotask(() => {
+        // The mouse pushes movement and battery down the same pipe; a driver
+        // that took the first input report it saw would decode noise.
+        if (options.noisy) emit(frame(0x09f0, [0xde, 0xad]));
+        emit(frame(command, answer));
+      });
+    },
+  } as unknown as HIDDevice;
+
+  return { device, sent };
+}
+
+describe("MCHOSE A7 V3 driver", () => {
+  it("claims the V3 mice and receivers", () => {
+    assert.ok(MchoseV3HidClient.isSupported(fakeMouse().device));
+    assert.ok(MchoseV3HidClient.isSupported(fakeMouse({ productId: 0x4033 }).device));
+    assert.ok(MchoseV3HidClient.isSupported(fakeMouse({ productId: 0x1018 }).device));
+  });
+
+  it("leaves the A7 V2 and the MagDock to their own drivers", () => {
+    // The V2 shares this exact usage page, so only the id keeps them apart.
+    const v2 = fakeMouse({ productId: 0x4021, productName: "MCHOSE A7 V2 Ultra+" });
+    assert.equal(MchoseV3HidClient.isSupported(v2.device), false);
+    assert.ok(MchoseHidClient.isSupported(v2.device), "the V2 driver still wants it");
+
+    const dock = fakeMouse({ productId: 0x1012 });
+    assert.equal(MchoseV3HidClient.isSupported(dock.device), false);
+  });
+
+  it("does not let the A7 V2 driver claim a V3 device", () => {
+    // Before the V3 landed, the V2 matched on the usage page alone and would
+    // have talked inverted feature reports at a mouse that speaks none.
+    for (const productId of [0x4033, 0x1014, 0x1018]) {
+      const device = fakeMouse({ productId }).device;
+      assert.equal(
+        MchoseHidClient.isSupported(device), false,
+        `0x${productId.toString(16)} belongs to the V3 driver`,
+      );
+      assert.equal(MchoseDockHidClient.isSupported(device), false);
+    }
+  });
+
+  it("reads a whole status off the receiver", async () => {
+    const { device } = fakeMouse();
+    const status = await new MchoseV3HidClient(device).readStatus();
+
+    assert.equal(status.brand, "MCHOSE");
+    // Resolved from the id inside the device-info reply, not the receiver's.
+    assert.equal(status.name, "MCHOSE A7 V3 Ultra+");
+    assert.equal(status.batteryPercent, 87);
+    assert.equal(status.batteryState, "Discharging");
+    assert.equal(status.connectionType, "Wireless");
+    assert.equal(status.dpi, 800, "stage 1 of the table");
+    assert.deepEqual(status.dpiStages, [400, 800, 1600, 3200]);
+    assert.equal(status.pollingRateHz, 8000, "wireless slot 6 is the top rate");
+    assert.equal(status.activeProfile, 2, "the wire's 0-based profile shown from one");
+    assert.equal(status.profileCount, 3);
+    assert.equal(status.debounceMs, 8);
+    assert.equal(status.sleepTimeout, 600);
+    assert.equal(status.angleTuning, -15);
+    assert.equal(status.rippleControl, true);
+    assert.equal(status.motionSync, false);
+    assert.equal(status.powerMode, "eSports");
+    assert.deepEqual(status.firmware, ["Firmware 107"]);
+  });
+
+  it("takes lift-off from the dedicated command on a five-step model", () => {
+    // 0x0009 answered 4, the top of the Ultra+'s ladder — the sensor byte's
+    // own two bits say 2, which would be wrong here.
+    const { device } = fakeMouse();
+    return new MchoseV3HidClient(device).readStatus().then((status) => {
+      assert.equal(status.liftOffDistance, "High");
+      assert.match(status.ui!.statusNote!, /1\.7 mm/, "the real height survives in the note");
+    });
+  });
+
+  it("offers no settings, and says why", async () => {
+    const { device } = fakeMouse();
+    const client = new MchoseV3HidClient(device);
+    const status = await client.readStatus();
+
+    assert.equal(status.ui!.settingsReady, false, "nothing here can be written yet");
+    assert.equal(status.ui!.valuesVerified, true, "but what is shown was read off the mouse");
+    assert.match(status.ui!.statusNote!, /not been confirmed on hardware/);
+    // The read-only promise is part of the contract, not just the prose.
+    assert.equal("setDpi" in client, false);
+    assert.equal("setPollingRate" in client, false);
+    assert.equal("setLiftOffDistance" in client, false);
+  });
+
+  it("ignores unrelated input reports while waiting for its answer", async () => {
+    const { device } = fakeMouse({ noisy: true });
+    const status = await new MchoseV3HidClient(device).readStatus();
+    assert.equal(status.name, "MCHOSE A7 V3 Ultra+");
+    assert.equal(status.dpi, 800);
+  });
+
+  it("degrades to a named, empty status when the mouse says nothing", async () => {
+    const { device, sent } = fakeMouse({
+      silent: Object.values(MCHOSE_V3_COMMAND),
+      productId: 0x4033,
+      productName: "MCHOSE A7 V3 Ultra+",
+    });
+    const status = await new MchoseV3HidClient(device).readStatus();
+
+    // One command's retries are enough to conclude nothing is listening.
+    // Spending the full budget on all six would stall the connect flow.
+    assert.deepEqual(
+      [...new Set(sent)], [MCHOSE_V3_COMMAND.readDeviceInfo],
+      "the rest of the status is abandoned after the first silent command",
+    );
+
+    // Falls back to the product string rather than throwing the connect flow.
+    assert.equal(status.name, "MCHOSE A7 V3 Ultra+");
+    assert.equal(status.batteryPercent, null);
+    assert.equal(status.dpi, 0);
+    assert.equal(status.activeProfile, null);
+    assert.equal(status.connectionType, "Wired", "its own id means the cable");
+    assert.match(status.ui!.statusNote!, /did not answer/);
+  });
+
+  it("reports an unlinked mouse instead of showing the receiver's own state", async () => {
+    const { device } = fakeMouse({ silent: [MCHOSE_V3_COMMAND.readSettings] });
+    const status = await new MchoseV3HidClient(device).readStatus();
+    assert.equal(status.name, "MCHOSE A7 V3 Ultra+", "the receiver still knows the model");
+    assert.equal(status.activeProfile, null, "but nothing behind the link answered");
+    assert.equal(status.dpi, 0);
+  });
+});

--- a/src/drivers/mchose/v3-hid.ts
+++ b/src/drivers/mchose/v3-hid.ts
@@ -1,0 +1,293 @@
+import {
+  MCHOSE_V3_COMMAND,
+  MCHOSE_V3_MODES,
+  MCHOSE_V3_LINK_PRODUCT_IDS,
+  MCHOSE_V3_REPORT_ID,
+  MCHOSE_V3_USAGE,
+  MCHOSE_V3_USAGE_PAGE,
+  mchoseV3DecodeButtons,
+  mchoseV3DecodeDeviceInfo,
+  mchoseV3DecodeDpi,
+  mchoseV3DecodeLiftOff,
+  mchoseV3DecodeSensor,
+  mchoseV3DecodeSettings,
+  mchoseV3Encode,
+  mchoseV3FindProduct,
+  mchoseV3IsProductId,
+  mchoseV3LiftOffLabels,
+  mchoseV3LiftOffStop,
+  mchoseV3Payload,
+  mchoseV3PollingRates,
+  type MchoseV3DeviceInfo,
+  type MchoseV3Product,
+  type MchoseV3Settings,
+} from "@openmouse/protocol/mchose";
+import type { MouseStatus } from "../mouse-types.ts";
+import { VENDOR_ID } from "../vendors.ts";
+
+/**
+ * MCHOSE A7 V3 and its siblings — **read-only, and untested on hardware**.
+ *
+ * This generation abandoned the A7 V2's inverted feature reports for a
+ * `0x4d`-magic output report (see `src/mchose/v3.ts`). The command set was read
+ * out of MCHOSE's own M HUB bundle; unlike the V2 driver next door, none of it
+ * has been exercised against a physical mouse.
+ *
+ * That is why there are no setters here. Every value below is a read, so the
+ * worst a wrong guess costs is a blank or nonsensical field — where a
+ * speculative write could leave a stranger's mouse in a state they cannot get
+ * out of. `settingsReady` is false for the same reason: the shell would
+ * otherwise offer controls with nothing behind them. `valuesVerified` stays
+ * true so the DPI and polling rate it does read are still worth showing.
+ *
+ * Adding writes is a small change on top of this — the encoders are already in
+ * the codec — but it should wait for someone with the hardware.
+ */
+
+const REPLY_TIMEOUT_MS = 600;
+const READ_ATTEMPTS = 3;
+
+/** The receivers serve every model in the generation. */
+const LINK_PRODUCT_IDS: readonly number[] = Object.values(MCHOSE_V3_LINK_PRODUCT_IDS);
+
+export class MchoseV3HidClient {
+  readonly device: HIDDevice;
+
+  private queue: Promise<unknown> = Promise.resolve();
+
+  /**
+   * Set once a command has exhausted its retries, and cleared at the top of
+   * every status read. A status is six commands, so without this a mouse that
+   * is off or out of range costs six full retry budgets — long enough to look
+   * like the app has hung. One silent command is enough to conclude nothing is
+   * listening; the next poll gets a clean try.
+   */
+  private unresponsive = false;
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+  }
+
+  static isSupported(device: HIDDevice): boolean {
+    const search = (collection: HIDCollectionInfo): boolean =>
+      (collection.usagePage === MCHOSE_V3_USAGE_PAGE && collection.usage === MCHOSE_V3_USAGE)
+      || collection.children.some(search);
+    return device.vendorId === VENDOR_ID.mchose
+      // An allowlist, not a usage-page match: this collection is shared with
+      // the V2 protocol, so only ids known to be V3 may be claimed here.
+      && mchoseV3IsProductId(device.productId)
+      && device.collections.some(search);
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    if (this.device.opened) await this.device.close();
+  }
+
+  /** Nothing here subscribes to unsolicited state. */
+  async startNotifications(): Promise<boolean> {
+    return false;
+  }
+
+  displayName(): string {
+    return this.device.productName?.trim() || "MCHOSE";
+  }
+
+  /** Wired when the host is talking to the mouse rather than to a receiver. */
+  private isWired(): boolean {
+    return !LINK_PRODUCT_IDS.includes(this.device.productId);
+  }
+
+  /**
+   * Send one command and wait for the reply carrying the same id.
+   *
+   * Replies arrive as input reports rather than as the answer to a read, so
+   * the listener goes on before the write and the id match is what pairs them
+   * up — the mouse also pushes movement and battery reports down this pipe.
+   */
+  private request(command: number, data: readonly number[] = []): Promise<Uint8Array | null> {
+    const run = async (): Promise<Uint8Array | null> => {
+      if (this.unresponsive) return null;
+      const body = mchoseV3Encode(command, data);
+      for (let attempt = 0; attempt < READ_ATTEMPTS; attempt += 1) {
+        const reply = await new Promise<Uint8Array | null>((resolve) => {
+          const finish = (value: Uint8Array | null): void => {
+            clearTimeout(timer);
+            this.device.removeEventListener("inputreport", listener);
+            resolve(value);
+          };
+          const listener = (event: Event): void => {
+            const report = event as HIDInputReportEvent;
+            const payload = mchoseV3Payload(new Uint8Array(report.data.buffer), command);
+            if (payload) finish(payload);
+          };
+          const timer = setTimeout(() => { finish(null); }, REPLY_TIMEOUT_MS);
+          this.device.addEventListener("inputreport", listener);
+          this.device.sendReport(MCHOSE_V3_REPORT_ID, body).catch(() => { finish(null); });
+        });
+        if (reply) return reply;
+      }
+      this.unresponsive = true;
+      return null;
+    };
+    const next = this.queue.then(run, run);
+    this.queue = next.catch(() => undefined);
+    return next;
+  }
+
+  private async readDeviceInfo(): Promise<MchoseV3DeviceInfo | null> {
+    const payload = await this.request(MCHOSE_V3_COMMAND.readDeviceInfo);
+    return payload ? mchoseV3DecodeDeviceInfo(payload) : null;
+  }
+
+  private async readSettings(): Promise<MchoseV3Settings | null> {
+    const payload = await this.request(MCHOSE_V3_COMMAND.readSettings);
+    return payload ? mchoseV3DecodeSettings(payload) : null;
+  }
+
+  private async readVersion(): Promise<string | null> {
+    const payload = await this.request(MCHOSE_V3_COMMAND.readVersion);
+    if (!payload || payload.length < 2) return null;
+    const raw = `${(payload[0] ?? 0).toString(16).padStart(2, "0")}`
+      + `${(payload[1] ?? 0).toString(16).padStart(2, "0")}`;
+    const trimmed = raw.replace(/^0+/, "");
+    return trimmed ? trimmed : null;
+  }
+
+  /**
+   * Lift-off sits in two places depending on the model: the five-step ladders
+   * do not fit the sensor byte's two bits, so those models answer `0x0009`
+   * instead.
+   */
+  private async readLiftOffIndex(
+    product: MchoseV3Product | null,
+    settings: MchoseV3Settings,
+  ): Promise<number | null> {
+    if (!product?.liftOffCommand) return mchoseV3DecodeSensor(settings.sensor).liftOffIndex;
+    const payload = await this.request(
+      MCHOSE_V3_COMMAND.readLiftOff, [settings.profileIndex],
+    );
+    return payload ? mchoseV3DecodeLiftOff(payload) : null;
+  }
+
+  getDpiOptions(): number[] {
+    return [];
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    await this.open();
+    this.unresponsive = false;
+
+    // Identity first: the host-facing product id is shared across the whole
+    // generation, so this is the only thing that says which model is on the
+    // other end, and the DPI ceiling and lift-off ladder both hang off it.
+    const info = await this.readDeviceInfo();
+    const product = mchoseV3FindProduct(info?.productId ?? null, this.device.productName);
+
+    const settings = await this.readSettings();
+    const dpiPayload = settings
+      ? await this.request(MCHOSE_V3_COMMAND.readDpi, [settings.profileIndex, 0])
+      : null;
+    const dpi = dpiPayload ? mchoseV3DecodeDpi(dpiPayload) : null;
+    const buttonPayload = settings
+      ? await this.request(MCHOSE_V3_COMMAND.readButtons, [settings.profileIndex, 0, 6])
+      : null;
+    const buttons = buttonPayload ? mchoseV3DecodeButtons(buttonPayload) : null;
+    const liftOffIndex = settings ? await this.readLiftOffIndex(product, settings) : null;
+    const version = await this.readVersion();
+
+    const sensor = settings ? mchoseV3DecodeSensor(settings.sensor) : null;
+    const rates = product ? mchoseV3PollingRates(product) : [];
+    const rateIndex = settings
+      ? (this.isWired() ? settings.wiredRateIndex : settings.wirelessRateIndex)
+      : -1;
+    const stages = dpi?.stages.slice(0, dpi.stageCount || dpi.stages.length) ?? [];
+    const liftOffHeight = product && liftOffIndex !== null
+      ? (mchoseV3LiftOffLabels(product)[liftOffIndex] ?? null)
+      : null;
+
+    const firmware: string[] = [];
+    if (version) firmware.push(`Firmware ${version}`);
+
+    return {
+      brand: "MCHOSE",
+      name: product ? `MCHOSE ${product.name}` : this.displayName(),
+      batteryPercent: info?.batteryPercent ?? null,
+      batteryState: info ? (info.chargeStatus ? "Charging" : "Discharging") : "Unknown",
+      dpi: dpi ? (dpi.stages[dpi.activeStage] ?? 0) : 0,
+      dpiStages: stages.length ? stages : undefined,
+      activeDpiStage: stages.length ? dpi!.activeStage : undefined,
+      supportsSeparateDpiAxes: dpi?.hasSeparateY || undefined,
+      pollingRateHz: rates[rateIndex] ?? 0,
+      supportedPollingRates: rates.length ? [...rates] : undefined,
+      // The wire index is 0-based; the shell counts profiles from one.
+      activeProfile: settings ? settings.profileIndex + 1 : null,
+      profileCount: info?.profileCount || undefined,
+      // Both switches read fine; neither can be written yet, so they are shown
+      // as state rather than offered as controls.
+      debounceMs: settings?.leftDebounceMs ?? null,
+      sleepTimeout: settings ? settings.sleep * 60 : null,
+      connectionType: this.isWired() ? "Wired" : "Wireless",
+      connectionDetail: info && info.connectStatus === 0
+        ? "Receiver connected, mouse not linked"
+        : undefined,
+      // The shell's field is a three-stop scale and this family's ladders run
+      // to five, so the bucket goes here and the exact height goes in the note.
+      liftOffDistance: product && liftOffIndex !== null
+        ? mchoseV3LiftOffStop(product, liftOffIndex)
+        : null,
+      motionSync: sensor?.motionSync ?? null,
+      angleSnapping: sensor?.angleSnapping ?? null,
+      rippleControl: sensor?.rippleControl ?? null,
+      angleTuning: settings?.angleTuning ?? null,
+      powerMode: sensor ? MCHOSE_V3_MODES[sensor.modeIndex] : undefined,
+      powerModes: sensor ? [...MCHOSE_V3_MODES] : undefined,
+      buttonMappings: buttons
+        ? Object.fromEntries(
+          Object.entries(buttons).map(([name, action]) => [name, describeButton(action.type)]),
+        )
+        : undefined,
+      firmware,
+      ui: {
+        family: "mchose-v3",
+        // No setters exist yet, so the settings grid would be inert.
+        settingsReady: false,
+        // …but what is shown was genuinely read off the mouse.
+        valuesVerified: true,
+        defaultDisplayName: "MCHOSE",
+        forceShowBattery: true,
+        hideSignalCard: true,
+        statusNote: settings
+          ? [
+            liftOffHeight ? `Lift-off ${liftOffHeight}.` : "",
+            "Read-only: this model's protocol is implemented from vendor software and has not been confirmed on hardware.",
+          ].filter(Boolean).join(" ")
+          : "Read-only, and this mouse did not answer. Please report the model and how it is connected.",
+      },
+    };
+  }
+}
+
+/**
+ * A human label for a button's action type. Only the type is named, not the
+ * value: the V2's value tables were confirmed key by key on hardware, and
+ * nothing here has been, so naming a specific key would be a guess presented
+ * as a fact.
+ */
+function describeButton(type: number): string {
+  switch (type) {
+    case 0x00: return "Default";
+    case 0x01: return "Mouse button";
+    case 0x02: return "Keyboard";
+    case 0x03: return "Media";
+    case 0x04: return "Macro";
+    case 0x05: return "DPI";
+    case 0x08: return "System";
+    case 0x0a: return "Profile";
+    case 0xff: return "Unassigned";
+    default: return `Type ${type}`;
+  }
+}

--- a/src/drivers/registry.test.ts
+++ b/src/drivers/registry.test.ts
@@ -8,6 +8,7 @@ import { DEVICE_DRIVERS } from "./registry.ts";
 import { SUPPORTED_HID_FILTERS, VENDOR_ID } from "./vendors.ts";
 import { LAMZU_PRODUCTS } from "@openmouse/protocol/lamzu";
 import { ORBITAL_DEVICES } from "@openmouse/protocol/orbital";
+import { MCHOSE_V3_PRODUCT_IDS } from "@openmouse/protocol/mchose";
 
 const DEVICES_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -68,6 +69,9 @@ function candidateProductIds(): number[] {
     0xffff,
     ...LAMZU_PRODUCTS.keys(),
     ...ORBITAL_DEVICES.keys(),
+    // The MCHOSE V3 driver matches on an id allowlist and shares its usage
+    // page with the V2, so the probe needs a real one to reach it at all.
+    ...MCHOSE_V3_PRODUCT_IDS,
   ]);
   for (const filter of SUPPORTED_HID_FILTERS) {
     if (filter.productId !== undefined) ids.add(filter.productId);

--- a/src/drivers/registry.ts
+++ b/src/drivers/registry.ts
@@ -49,9 +49,10 @@ import { KsnakeHidClient } from "./ksnake/hid.ts";
 import { MicrosoftHidClient } from "./microsoft/hid.ts";
 import { IncottHidClient } from "./incott/hid.ts";
 import { HyperXHidClient } from "./hyperx/hid.ts";
+import { MchoseV3HidClient } from "./mchose/v3-hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient | PulsarXs1HidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient | MicrosoftHidClient | IncottHidClient | HyperXHidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient | MicrosoftHidClient | IncottHidClient | HyperXHidClient | MchoseV3HidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -115,6 +116,9 @@ export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "Glorious", supports: (device) => GloriousClassicHidClient.isSupported(device), create: (device) => new GloriousClassicHidClient(device), score: () => 5 },
   { brand: "MCHOSE", supports: (device) => MchoseHidClient.isSupported(device), create: (device) => new MchoseHidClient(device), score: () => 7 },
   { brand: "MCHOSE", supports: (device) => MchoseDockHidClient.isSupported(device), create: (device) => new MchoseDockHidClient(device), score: () => 7 },
+  // The A7 V3 generation shares the V2 usage page but not its protocol; the
+  // two matchers are kept disjoint by product id.
+  { brand: "MCHOSE", supports: (device) => MchoseV3HidClient.isSupported(device), create: (device) => new MchoseV3HidClient(device), score: () => 7 },
   { brand: "K-snake", supports: (device) => KsnakeHidClient.isSupported(device), create: (device) => new KsnakeHidClient(device), score: () => 5 },
   { brand: "Microsoft", supports: (device) => MicrosoftHidClient.isSupported(device), create: (device) => new MicrosoftHidClient(device), score: () => 5 },
   // Shares vendor id 0x093a with Glorious (see vendors.ts), but claims only

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -535,6 +535,9 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.orbital, usagePage: 0xff0a, usage: 1 },
   // MCHOSE ships keyboards and audio devices under 0x3837 too, so this stays
   // narrowed to the mouse configuration collection rather than the whole VID.
+  // Both mouse generations answer on this collection — the A7 V2 with inverted
+  // feature reports, the A7 V3 with its own output-report protocol — so one
+  // filter offers the whole mouse line and the drivers split it by product id.
   { vendorId: VENDOR_ID.mchose, usagePage: MCHOSE_CONFIG_USAGE_PAGE, usage: MCHOSE_CONFIG_USAGE },
   // The MagDock is a separate device on its own usage page; it carries the RGB.
   { vendorId: VENDOR_ID.mchose, productId: MCHOSE_DOCK_PRODUCT_ID, usagePage: MCHOSE_DOCK_USAGE_PAGE, usage: MCHOSE_DOCK_USAGE },

--- a/src/mchose/index.ts
+++ b/src/mchose/index.ts
@@ -540,6 +540,8 @@ export function mchosePollingRates(
 
 export * from "./buttons.ts";
 export * from "./dock.ts";
+// The A7 V3 generation's protocol, which shares only a vendor id with the above.
+export * from "./v3.ts";
 
 /**
  * Profile names, read one at a time with `0x12 0x68 <index>`. The reply is the

--- a/src/mchose/v3.test.ts
+++ b/src/mchose/v3.test.ts
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MCHOSE_V3_BODY_LENGTH,
+  MCHOSE_V3_COMMAND,
+  MCHOSE_V3_MODES,
+  MCHOSE_V3_PRODUCTS,
+  mchoseV3DecodeButtons,
+  mchoseV3DecodeDeviceInfo,
+  mchoseV3DecodeDpi,
+  mchoseV3DecodeLiftOff,
+  mchoseV3DecodeSensor,
+  mchoseV3DecodeSettings,
+  mchoseV3Encode,
+  mchoseV3EncodeSettings,
+  mchoseV3FindProduct,
+  mchoseV3IsProductId,
+  mchoseV3LiftOffLabels,
+  mchoseV3LiftOffStop,
+  mchoseV3OptionToRateIndex,
+  mchoseV3Payload,
+  mchoseV3PollingRates,
+  mchoseV3RateIndexToOption,
+  type MchoseV3Settings,
+} from "./v3.ts";
+import { MCHOSE_LOD_MASK, mchoseDecodeConfig } from "./index.ts";
+
+/** Wrap a data block in the reply framing the mouse sends back. */
+function reply(command: number, data: readonly number[]): Uint8Array {
+  const body = new Uint8Array(MCHOSE_V3_BODY_LENGTH);
+  body[0] = 0x01;
+  body[1] = 0x01;
+  body[2] = data.length;
+  body[3] = command & 0xff;
+  body[4] = (command >> 8) & 0xff;
+  body.set(data, 7);
+  let sum = 0;
+  for (let index = 1; index <= 6 + data.length; index += 1) sum ^= body[index]!;
+  body[7 + data.length] = sum;
+  return body;
+}
+
+test("a request frame carries the M magic's header and a checksum", () => {
+  const body = mchoseV3Encode(MCHOSE_V3_COMMAND.readDeviceInfo);
+  // The 0x4d magic is the report id and is not part of the body.
+  assert.equal(body.length, MCHOSE_V3_BODY_LENGTH);
+  assert.equal(body[0], 0x01, "protocol version");
+  assert.equal(body[1], 0x01, "checksum flag");
+  assert.equal(body[2], 0, "no data");
+  assert.equal(body[3], 0x00, "command low byte");
+  assert.equal(body[4], 0x09, "command high byte");
+  // XOR of bytes 1..6 = 0x01 ^ 0 ^ 0x00 ^ 0x09 ^ 0 ^ 0 = 0x08.
+  assert.equal(body[7], 0x08, "checksum lands right after the empty data block");
+});
+
+test("the command id goes out little-endian", () => {
+  const body = mchoseV3Encode(MCHOSE_V3_COMMAND.writeLiftOff, [0, 3]);
+  assert.equal(body[3], 0x09);
+  assert.equal(body[4], 0x01);
+  assert.equal(body[2], 2, "data length");
+  assert.deepEqual([...body.subarray(7, 9)], [0, 3]);
+});
+
+test("data too long to leave room for the checksum is refused, not truncated", () => {
+  // 56 bytes fit; 57 would push the checksum past the end of the body.
+  assert.doesNotThrow(() => mchoseV3Encode(0x0001, new Array<number>(55).fill(1)));
+  assert.throws(() => mchoseV3Encode(0x0001, new Array<number>(57).fill(1)), RangeError);
+});
+
+test("a reply is matched on its command id and rejected on a bad checksum", () => {
+  const frame = reply(MCHOSE_V3_COMMAND.readLiftOff, [3]);
+  assert.deepEqual([...mchoseV3Payload(frame, MCHOSE_V3_COMMAND.readLiftOff)!], [3]);
+  assert.equal(
+    mchoseV3Payload(frame, MCHOSE_V3_COMMAND.readSettings), null,
+    "a frame answering another command is not this command's payload",
+  );
+
+  const corrupted = Uint8Array.from(frame);
+  corrupted[8] = (corrupted[8]! ^ 0xff) & 0xff;
+  assert.equal(mchoseV3Payload(corrupted, MCHOSE_V3_COMMAND.readLiftOff), null);
+});
+
+test("a reply that claims no checksum is still accepted on its command id", () => {
+  const frame = reply(MCHOSE_V3_COMMAND.readLiftOff, [2]);
+  frame[1] = 0x00;
+  assert.deepEqual([...mchoseV3Payload(frame, MCHOSE_V3_COMMAND.readLiftOff)!], [2]);
+});
+
+test("device info yields the mouse's own product id, not the receiver's", () => {
+  const info = mchoseV3DecodeDeviceInfo(new Uint8Array([
+    0x37, 0x38, // vendor 0x3837
+    0x33, 0x40, // product 0x4033 — an A7 V3 Ultra+ behind its receiver
+    0x03, 0x01, 0x00, 0x04, 0x20, 0x00, 0x01, 0x00, 0x57, 0x02,
+  ]))!;
+  assert.equal(info.vendorId, 0x3837);
+  assert.equal(info.productId, 0x4033);
+  assert.equal(info.profileCount, 3);
+  assert.equal(info.connectStatus, 1);
+  assert.equal(info.chargeStatus, 0);
+  assert.equal(info.batteryPercent, 87);
+  assert.equal(mchoseV3FindProduct(info.productId)!.name, "A7 V3 Ultra+");
+});
+
+test("a truncated device info is rejected rather than read as zeroes", () => {
+  assert.equal(mchoseV3DecodeDeviceInfo(new Uint8Array(13)), null);
+});
+
+test("settings unpack both links, and the angle is signed", () => {
+  const settings = mchoseV3DecodeSettings(new Uint8Array([
+    0x01, // profile 1
+    0x32, // wired: rate slot 3, stage 2
+    0x62, // wireless: rate slot 6, stage 2
+    0x0a, // ten minutes
+    0x01,
+    0x00,
+    0xf1, // −15°
+    0x08, 0x04,
+  ]))!;
+  assert.equal(settings.profileIndex, 1);
+  assert.equal(settings.dpiIndex, 2);
+  // Slot 3 and slot 6 map down past the rate the vendor UI hides.
+  assert.equal(settings.wiredRateIndex, 2);
+  assert.equal(settings.wirelessRateIndex, 5);
+  assert.equal(settings.sleep, 10);
+  assert.equal(settings.angleTuning, -15, "two's complement, not 241");
+  assert.equal(settings.leftDebounceMs, 8);
+  assert.equal(settings.rightDebounceMs, 4);
+});
+
+test("the hidden polling slot makes the index maps deliberately asymmetric", () => {
+  // Anything the UI can pick survives a round trip…
+  for (let option = 0; option < 6; option += 1) {
+    assert.equal(mchoseV3RateIndexToOption(mchoseV3OptionToRateIndex(option)), option);
+  }
+  // …but slot 1, which it never writes, still reads as something sensible.
+  assert.equal(mchoseV3RateIndexToOption(1), 1);
+  assert.equal(mchoseV3OptionToRateIndex(1), 2);
+});
+
+test("encoding settings restores the wire's rate slots", () => {
+  const settings: MchoseV3Settings = {
+    profileIndex: 1,
+    dpiIndex: 2,
+    wiredRateIndex: 2,
+    wirelessRateIndex: 5,
+    sleep: 10,
+    sleepMode: 1,
+    sensor: 0x00,
+    angleTuning: -15,
+    leftDebounceMs: 8,
+    rightDebounceMs: 4,
+  };
+  const data = mchoseV3EncodeSettings(settings);
+  assert.equal(data[1], 0x32, "wired slot 3 with stage 2");
+  assert.equal(data[2], 0x62, "wireless slot 6 with stage 2");
+  assert.equal(data[6], 0xf1, "the negative angle goes back out as two's complement");
+  assert.deepEqual(
+    mchoseV3DecodeSettings(new Uint8Array(data)), settings,
+    "a decode of the encode is the settings that went in",
+  );
+});
+
+/**
+ * The trap this generation sets: the sensor byte carries the same fields as the
+ * A7 V2's but lift-off and the power mode have swapped ends of it. Reading a V3
+ * byte with the V2 masks turns a lift-off level into a power mode and back.
+ */
+test("the sensor byte is not laid out like the A7 V2's", () => {
+  // Lift-off step 2, ripple on, mode 1.
+  const sensor = 0x45;
+  const decoded = mchoseV3DecodeSensor(sensor);
+  assert.equal(decoded.liftOffIndex, 2);
+  assert.equal(decoded.rippleControl, true);
+  assert.equal(decoded.angleSnapping, false);
+  assert.equal(decoded.motionSync, false);
+  assert.equal(decoded.glassMode, false);
+  assert.equal(MCHOSE_V3_MODES[decoded.modeIndex], "eSports");
+
+  // The V2 codec reads the very same byte as lift-off 1 — which is the whole
+  // reason the two drivers must never claim each other's devices.
+  assert.equal(sensor & MCHOSE_LOD_MASK, 1);
+});
+
+test("glass mode sits on the top bit the A7 V2 leaves alone", () => {
+  assert.equal(mchoseV3DecodeSensor(0x80).glassMode, true);
+  assert.equal(mchoseV3DecodeSensor(0x80).liftOffIndex, 0);
+  assert.equal(mchoseV3DecodeSensor(0x7f).glassMode, false);
+});
+
+test("the DPI table reads six little-endian stages", () => {
+  const dpi = mchoseV3DecodeDpi(new Uint8Array([
+    0x00, 0x00, 0x04, 0x01, 0x01,
+    0x90, 0x01, // 400
+    0x20, 0x03, // 800
+    0x40, 0x06, // 1600
+    0x80, 0x0c, // 3200
+    0x00, 0x19, // 6400
+    0x50, 0xc3, // 50000
+  ]))!;
+  assert.equal(dpi.stageCount, 4);
+  assert.equal(dpi.activeStage, 1);
+  assert.equal(dpi.hasSeparateY, true);
+  assert.deepEqual(dpi.stages, [400, 800, 1600, 3200, 6400, 50000]);
+  assert.equal(dpi.stages[dpi.activeStage], 800);
+});
+
+test("a DPI reply missing stages is rejected", () => {
+  assert.equal(mchoseV3DecodeDpi(new Uint8Array(16)), null);
+});
+
+test("lift-off comes back as a bare index", () => {
+  assert.equal(mchoseV3DecodeLiftOff(new Uint8Array([4])), 4);
+  assert.equal(mchoseV3DecodeLiftOff(new Uint8Array()), null);
+});
+
+test("the button table is walked by type, since entries vary in width", () => {
+  // Left is type 0x01 (three value bytes); the rest are the two-byte default.
+  const buttons = mchoseV3DecodeButtons(new Uint8Array([
+    0x01, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x02,
+    0x00, 0x00, 0x04,
+    0x02, 0x00, 0x42,
+    0x02, 0x00, 0x43,
+    0x05, 0x00, 0x01,
+  ]))!;
+  assert.equal(buttons.Left!.type, 0x01);
+  assert.deepEqual(buttons.Left!.value, [0x01, 0x00, 0x00]);
+  assert.equal(buttons.Right!.type, 0x00);
+  assert.equal(buttons.DPI!.type, 0x05);
+  assert.equal(Object.keys(buttons).length, 6);
+});
+
+test("a button table that would run past the payload is rejected", () => {
+  // Announces a wide type with nothing behind it.
+  assert.equal(mchoseV3DecodeButtons(new Uint8Array([0x23, 0x00])), null);
+  assert.equal(mchoseV3DecodeButtons(new Uint8Array()), null);
+});
+
+test("models resolve by id, and the longest name wins on a string match", () => {
+  assert.equal(mchoseV3FindProduct(0x4033)!.name, "A7 V3 Ultra+");
+  assert.equal(mchoseV3FindProduct(0x4030)!.dpiMax, 26000);
+  assert.equal(
+    mchoseV3FindProduct(null, "MCHOSE A7 V3 Pro+")!.name, "A7 V3 Pro+",
+    "\"A7 V3 Pro+\" must not be swallowed by \"A7 V3 Pro\"",
+  );
+  assert.equal(mchoseV3FindProduct(null, "MCHOSE A7 V2 Ultra+"), null, "a V2 is not a V3");
+  assert.equal(mchoseV3FindProduct(0x4021), null);
+});
+
+test("the V3 id set covers the mice and their shared receivers, and no V2", () => {
+  assert.ok(mchoseV3IsProductId(0x4033), "A7 V3 Ultra+ over its cable");
+  assert.ok(mchoseV3IsProductId(0x1014), "the shared receiver");
+  assert.ok(mchoseV3IsProductId(0x1018));
+  assert.ok(!mchoseV3IsProductId(0x4021), "A7 V2 Ultra+");
+  assert.ok(!mchoseV3IsProductId(0x100b), "the V2 receiver");
+  assert.ok(!mchoseV3IsProductId(0x1012), "the MagDock");
+});
+
+test("the five-step ladder keeps its millimetres and still fits the three-stop field", () => {
+  const ultra = mchoseV3FindProduct(0x4033)!;
+  assert.deepEqual(
+    mchoseV3LiftOffLabels(ultra),
+    ["0.7 mm", "0.9 mm", "1.2 mm", "1.4 mm", "1.7 mm"],
+  );
+  assert.equal(mchoseV3LiftOffStop(ultra, 0), "Low");
+  assert.equal(mchoseV3LiftOffStop(ultra, 2), "Medium");
+  assert.equal(mchoseV3LiftOffStop(ultra, 4), "High");
+  assert.equal(mchoseV3LiftOffStop(ultra, 5), null, "off the end of the ladder");
+
+  const base = mchoseV3FindProduct(0x4030)!;
+  assert.equal(mchoseV3LiftOffStop(base, 0), "Low");
+  assert.equal(mchoseV3LiftOffStop(base, 1), "High", "a two-step ladder has no middle");
+});
+
+test("only the five-step models moved lift-off out of the sensor byte", () => {
+  for (const product of MCHOSE_V3_PRODUCTS) {
+    assert.equal(
+      product.liftOffCommand, product.liftOffDistances.length > 4,
+      `${product.name}: a ladder longer than the sensor byte's two bits needs 0x0009`,
+    );
+  }
+});
+
+test("the 1000 Hz models get the short rate list", () => {
+  assert.deepEqual([...mchoseV3PollingRates(mchoseV3FindProduct(0x4029)!)], [125, 500, 1000]);
+  assert.deepEqual(
+    [...mchoseV3PollingRates(mchoseV3FindProduct(0x4033)!)],
+    [125, 500, 1000, 2000, 4000, 8000],
+  );
+});
+
+/**
+ * Guards the split itself: a V3 frame decoded by the V2's config decoder must
+ * not look like a plausible config. The V2 blob is read straight off a feature
+ * report, so nothing but the shape stops a misrouted frame being believed.
+ */
+test("a V3 reply does not decode as a plausible A7 V2 config", () => {
+  const frame = reply(MCHOSE_V3_COMMAND.readSettings, [
+    0x01, 0x32, 0x62, 0x0a, 0x01, 0x00, 0xf1, 0x08, 0x04,
+  ]);
+  const asV2 = mchoseDecodeConfig(frame);
+  // It decodes structurally — it is 63 bytes — but the first DPI stage is the
+  // giveaway the V2 driver's own plausibility check looks at.
+  assert.ok(
+    asV2 === null || asV2.dpiStages[0]! < 50 || asV2.dpiStages[0]! > 42000,
+    "a V3 frame must not pass as a V2 config with a believable DPI stage",
+  );
+});

--- a/src/mchose/v3.ts
+++ b/src/mchose/v3.ts
@@ -1,0 +1,545 @@
+/**
+ * MCHOSE's **second** mouse protocol — the one the A7 V3 generation speaks.
+ *
+ * Read out of the same M HUB bundle as the A7 V2 codec in `./index.ts`, which
+ * carries two complete mouse UIs side by side: an older one driving the V2
+ * models and a newer one driving everything in {@link MCHOSE_V3_PRODUCTS}.
+ * They share a vendor id and even a usage page, and share nothing else.
+ *
+ * | | A7 V2 (`./index.ts`) | A7 V3 (this file) |
+ * | --- | --- | --- |
+ * | transport | feature reports `0x11` / `0x12` | **output report `0x4d`**, replies on the input report |
+ * | encoding | every body byte inverted (XOR `0xff`) | plain bytes, XOR checksum |
+ * | commands | one byte | **two bytes, little-endian** |
+ * | settings | one 64-byte blob (`0x67`) | several focused commands |
+ *
+ * The framing is a 64-byte frame whose first byte is both the `'M'` magic and
+ * the HID report id, so the body that actually goes out over
+ * `sendReport(0x4d, body)` is the remaining 63 bytes — which is what every
+ * function here encodes and decodes:
+ *
+ * ```
+ * frame[0] = 0x4d   report id, not part of the body
+ * body[0]  = 0x01   protocol version
+ * body[1]  = flags  1 when a trailing checksum is present
+ * body[2]  = data length
+ * body[3]  = command low byte
+ * body[4]  = command high byte
+ * body[5]  = business code
+ * body[6]  = sequence
+ * body[7…] = data, then the checksum at body[7 + length]
+ * ```
+ *
+ * The checksum is an XOR of `body[1]` through `body[6 + length]`.
+ *
+ * **Nothing in this file has been exercised on hardware.** It is a reading of
+ * the vendor bundle, and the driver that uses it is read-only for that reason;
+ * see docs/mchose-protocol.md.
+ */
+
+/** Output report the whole V3 command set rides on; also the `'M'` magic. */
+export const MCHOSE_V3_REPORT_ID = 0x4d;
+
+/** Full frame including the report id. The body sent over WebHID is one less. */
+export const MCHOSE_V3_FRAME_LENGTH = 64;
+export const MCHOSE_V3_BODY_LENGTH = MCHOSE_V3_FRAME_LENGTH - 1;
+
+/**
+ * The V3 config channel sits on the **same collection as the V2's** — the
+ * vendor's own WebHID filters ask for `0xff01`/`0x0001` for both generations.
+ * Spelled out rather than imported from `./index.ts` to keep the two codecs
+ * free of a circular import; they are the same numbers because the hardware
+ * uses the same numbers, not because one derives from the other.
+ */
+export const MCHOSE_V3_USAGE_PAGE = 0xff01;
+export const MCHOSE_V3_USAGE = 0x0001;
+
+const VERSION_OFFSET = 0;
+const FLAGS_OFFSET = 1;
+const LENGTH_OFFSET = 2;
+const COMMAND_LOW_OFFSET = 3;
+const COMMAND_HIGH_OFFSET = 4;
+const BIZ_CODE_OFFSET = 5;
+const SEQUENCE_OFFSET = 6;
+const DATA_OFFSET = 7;
+
+const PROTOCOL_VERSION = 0x01;
+const FLAG_CHECKSUM = 0x01;
+
+/**
+ * Command ids, little-endian in the frame. The `0x00xx` block is settings and
+ * the `0x09xx` block is device-level; a write is its read plus `0x0100`.
+ */
+export const MCHOSE_V3_COMMAND = {
+  /** Button assignments for one profile: `[profileIndex, 0, buttonCount]`. */
+  readButtons: 0x0001,
+  /** Profile, DPI/rate indices, sleep, sensor flags, debounce: `[]`. */
+  readSettings: 0x0002,
+  /** DPI stage table for one axis: `[profileIndex, axis]`. */
+  readDpi: 0x0003,
+  /** Lift-off index, on models that keep it outside the sensor byte. */
+  readLiftOff: 0x0009,
+  /** Identity and power: vendor/product id, charge state, battery. */
+  readDeviceInfo: 0x0900,
+  /** Firmware version, returned as a hex string the vendor trims. */
+  readVersion: 0x0901,
+  /** Macro storage, read 22 bytes at a time. */
+  readMacro: 0x090c,
+
+  writeButtons: 0x0101,
+  writeSettings: 0x0102,
+  writeDpi: 0x0103,
+  /** One stage without rewriting the table: `[profile, stage, axis, dpi u16]`. */
+  writeSingleDpi: 0x0104,
+  /** Factory reset, whole device or one profile. */
+  reset: 0x0105,
+  writeLiftOff: 0x0109,
+} as const;
+
+/**
+ * Physical buttons, in the fixed order the button commands walk them. Matches
+ * the V2 vocabulary in `./buttons.ts` apart from the vendor's own spelling.
+ */
+export const MCHOSE_V3_BUTTONS = ["Left", "Right", "Middle", "Forward", "Back", "DPI"] as const;
+
+/** XOR of `body[from]` through `body[to]`, inclusive. */
+function checksum(body: Uint8Array, from: number, to: number): number {
+  let value = 0;
+  for (let index = from; index <= to; index += 1) value ^= body[index] ?? 0;
+  return value & 0xff;
+}
+
+export interface MchoseV3FrameOptions {
+  /** Defaults to 1, which appends the checksum. */
+  flags?: number;
+  bizCode?: number;
+  sequence?: number;
+}
+
+/**
+ * Build the 63-byte body for `sendReport(MCHOSE_V3_REPORT_ID, body)`.
+ *
+ * Throws rather than silently truncating: a command whose data does not fit
+ * would otherwise go out with a valid checksum over the wrong bytes.
+ */
+export function mchoseV3Encode(
+  command: number,
+  data: readonly number[] = [],
+  options: MchoseV3FrameOptions = {},
+): Uint8Array<ArrayBuffer> {
+  const flags = options.flags ?? FLAG_CHECKSUM;
+  // The checksum needs a byte of its own past the data.
+  if (DATA_OFFSET + data.length + 1 > MCHOSE_V3_BODY_LENGTH) {
+    throw new RangeError(`mchoseV3Encode: ${data.length} data bytes do not fit in a frame`);
+  }
+  const body = new Uint8Array(MCHOSE_V3_BODY_LENGTH);
+  body[VERSION_OFFSET] = PROTOCOL_VERSION;
+  body[FLAGS_OFFSET] = flags & 0xff;
+  body[LENGTH_OFFSET] = data.length & 0xff;
+  body[COMMAND_LOW_OFFSET] = command & 0xff;
+  body[COMMAND_HIGH_OFFSET] = (command >> 8) & 0xff;
+  body[BIZ_CODE_OFFSET] = (options.bizCode ?? 0) & 0xff;
+  body[SEQUENCE_OFFSET] = (options.sequence ?? 0) & 0xff;
+  for (let index = 0; index < data.length; index += 1) {
+    body[DATA_OFFSET + index] = data[index]! & 0xff;
+  }
+  if (flags === FLAG_CHECKSUM) {
+    body[DATA_OFFSET + data.length] = checksum(body, FLAGS_OFFSET, SEQUENCE_OFFSET + data.length);
+  }
+  return body;
+}
+
+/** Command id carried by a reply body, or null if it is too short to hold one. */
+export function mchoseV3ReplyCommand(body: Uint8Array): number | null {
+  if (body.length <= COMMAND_HIGH_OFFSET) return null;
+  return (body[COMMAND_LOW_OFFSET]! | (body[COMMAND_HIGH_OFFSET]! << 8)) & 0xffff;
+}
+
+/**
+ * Data slice of a reply, or null when the frame is malformed or answers a
+ * different command.
+ *
+ * The vendor's own reader trusts the command id alone and never checks the
+ * checksum. This does check it, but only when the reply claims to carry one:
+ * a reply with other flags is accepted on its command id, the way M HUB
+ * accepts it.
+ */
+export function mchoseV3Payload(body: Uint8Array, command: number): Uint8Array | null {
+  if (mchoseV3ReplyCommand(body) !== command) return null;
+  const length = body[LENGTH_OFFSET] ?? 0;
+  if (DATA_OFFSET + length > body.length) return null;
+  if ((body[FLAGS_OFFSET] ?? 0) === FLAG_CHECKSUM) {
+    const expected = checksum(body, FLAGS_OFFSET, SEQUENCE_OFFSET + length);
+    if (body[DATA_OFFSET + length] !== expected) return null;
+  }
+  return body.slice(DATA_OFFSET, DATA_OFFSET + length);
+}
+
+const u16 = (data: Uint8Array, offset: number): number =>
+  (data[offset] ?? 0) | ((data[offset + 1] ?? 0) << 8);
+
+export interface MchoseV3DeviceInfo {
+  vendorId: number;
+  /** The mouse's own product id, even when the host is talking to a receiver. */
+  productId: number;
+  /** Onboard profile count. */
+  profileCount: number;
+  macroSaveType: number;
+  shareMacroDataSize: number;
+  macroUnitSize: number;
+  /** 0 when the mouse is not on the air; the receiver still answers. */
+  connectStatus: number;
+  chargeStatus: number;
+  batteryPercent: number;
+  /** Performance mode, mirrored out of the sensor byte's low bits. */
+  gameMode: number;
+}
+
+/** `0x0900` — identity and power. This is how a model is resolved. */
+export function mchoseV3DecodeDeviceInfo(data: Uint8Array): MchoseV3DeviceInfo | null {
+  if (data.length < 14) return null;
+  return {
+    vendorId: u16(data, 0),
+    productId: u16(data, 2),
+    profileCount: data[4]!,
+    macroSaveType: data[5]!,
+    shareMacroDataSize: u16(data, 6),
+    macroUnitSize: u16(data, 8),
+    connectStatus: data[10]!,
+    chargeStatus: data[11]!,
+    batteryPercent: data[12]!,
+    gameMode: data[13]!,
+  };
+}
+
+/**
+ * The firmware's polling table has a slot M HUB never offers, so a stored rate
+ * index is not an index into the model's rate list. The vendor maps around it
+ * in both directions; these two are those maps.
+ *
+ * Device slot 1 is the hidden one — it reads back as option 1 but is never
+ * written, which is what makes the pair asymmetric.
+ */
+export function mchoseV3RateIndexToOption(deviceIndex: number): number {
+  return deviceIndex > 1 ? deviceIndex - 1 : deviceIndex;
+}
+
+export function mchoseV3OptionToRateIndex(optionIndex: number): number {
+  return optionIndex > 0 ? optionIndex + 1 : optionIndex;
+}
+
+export interface MchoseV3Settings {
+  profileIndex: number;
+  /** Active DPI stage, shared by both links. */
+  dpiIndex: number;
+  /** Option indices into the model's rate list, already mapped off the wire. */
+  wiredRateIndex: number;
+  wirelessRateIndex: number;
+  /** Auto-sleep in minutes; 0 disables it. */
+  sleep: number;
+  sleepMode: number;
+  /** Packed flags — see {@link mchoseV3DecodeSensor}. */
+  sensor: number;
+  /** Signed −30…+30 rotation, two's complement on the wire. */
+  angleTuning: number;
+  leftDebounceMs: number;
+  rightDebounceMs: number;
+}
+
+/** `0x0002` — the settings the V2 kept in its one big config blob. */
+export function mchoseV3DecodeSettings(data: Uint8Array): MchoseV3Settings | null {
+  if (data.length < 9) return null;
+  const wired = data[1]!;
+  const wireless = data[2]!;
+  return {
+    profileIndex: data[0]!,
+    dpiIndex: wired & 0x0f,
+    wiredRateIndex: mchoseV3RateIndexToOption((wired >> 4) & 0x0f),
+    wirelessRateIndex: mchoseV3RateIndexToOption((wireless >> 4) & 0x0f),
+    sleep: data[3]!,
+    sleepMode: data[4]! & 1,
+    sensor: data[5]!,
+    angleTuning: (data[6]! << 24) >> 24,
+    leftDebounceMs: data[7]!,
+    rightDebounceMs: data[8]!,
+  };
+}
+
+/**
+ * Encode the settings block back. Every field is required because the command
+ * replaces the whole block — there is no read-modify-write on the device side,
+ * so a caller must pass a freshly read {@link MchoseV3Settings} with its edits
+ * applied rather than a partial object.
+ */
+export function mchoseV3EncodeSettings(settings: MchoseV3Settings): number[] {
+  const wired = ((mchoseV3OptionToRateIndex(settings.wiredRateIndex) & 0x0f) << 4)
+    | (settings.dpiIndex & 0x0f);
+  const wireless = ((mchoseV3OptionToRateIndex(settings.wirelessRateIndex) & 0x0f) << 4)
+    | (settings.dpiIndex & 0x0f);
+  return [
+    settings.profileIndex & 0xff,
+    wired,
+    wireless,
+    settings.sleep & 0xff,
+    settings.sleepMode & 0xff,
+    settings.sensor & 0xff,
+    settings.angleTuning & 0xff,
+    settings.leftDebounceMs & 0xff,
+    settings.rightDebounceMs & 0xff,
+    // The vendor pads ten zero bytes past the block; the firmware may well
+    // read them, so they are not dropped.
+    ...new Array<number>(10).fill(0),
+  ];
+}
+
+/**
+ * Sensor byte layout — **note that it is not the V2's**. The V2 puts lift-off
+ * in bits 0-1 and the performance mode in bits 6-7; this generation swaps
+ * them, and adds a glass-surface flag on the top bit. Getting the two mixed up
+ * reads a lift-off level as a power mode.
+ */
+export const MCHOSE_V3_SENSOR_MODE_MASK = 0x03;
+export const MCHOSE_V3_SENSOR_RIPPLE = 0x04;
+export const MCHOSE_V3_SENSOR_LINEAR = 0x08;
+export const MCHOSE_V3_SENSOR_MOTION_SYNC = 0x10;
+export const MCHOSE_V3_SENSOR_LOD_MASK = 0x60;
+export const MCHOSE_V3_SENSOR_LOD_SHIFT = 5;
+export const MCHOSE_V3_SENSOR_GLASS = 0x80;
+
+export interface MchoseV3Sensor {
+  /** Index into the model's lift-off ladder, for models that keep it here. */
+  liftOffIndex: number;
+  rippleControl: boolean;
+  angleSnapping: boolean;
+  motionSync: boolean;
+  glassMode: boolean;
+  /** Index into {@link MCHOSE_V3_MODES}. */
+  modeIndex: number;
+}
+
+export function mchoseV3DecodeSensor(sensor: number): MchoseV3Sensor {
+  return {
+    liftOffIndex: (sensor & MCHOSE_V3_SENSOR_LOD_MASK) >> MCHOSE_V3_SENSOR_LOD_SHIFT,
+    rippleControl: (sensor & MCHOSE_V3_SENSOR_RIPPLE) !== 0,
+    angleSnapping: (sensor & MCHOSE_V3_SENSOR_LINEAR) !== 0,
+    motionSync: (sensor & MCHOSE_V3_SENSOR_MOTION_SYNC) !== 0,
+    glassMode: (sensor & MCHOSE_V3_SENSOR_GLASS) !== 0,
+    modeIndex: sensor & MCHOSE_V3_SENSOR_MODE_MASK,
+  };
+}
+
+/** Same three-way choice the V2 offers, in the same order. */
+export const MCHOSE_V3_MODES = ["Performance", "eSports", "Ultra"] as const;
+
+export interface MchoseV3Dpi {
+  profileIndex: number;
+  /** 0 for X, 1 for Y. */
+  axis: number;
+  /** Stages the mouse cycles through. */
+  stageCount: number;
+  activeStage: number;
+  /** Whether this model stores a separate Y-axis table at all. */
+  hasSeparateY: boolean;
+  /** Six stages, whatever `stageCount` says is live. */
+  stages: number[];
+}
+
+export const MCHOSE_V3_DPI_STAGES = 6;
+
+/** `0x0003` — one axis of the DPI table. */
+export function mchoseV3DecodeDpi(data: Uint8Array): MchoseV3Dpi | null {
+  if (data.length < 5 + MCHOSE_V3_DPI_STAGES * 2) return null;
+  const stages: number[] = [];
+  for (let stage = 0; stage < MCHOSE_V3_DPI_STAGES; stage += 1) {
+    stages.push(u16(data, 5 + stage * 2));
+  }
+  return {
+    profileIndex: data[0]!,
+    axis: data[1]!,
+    stageCount: data[2]!,
+    activeStage: data[3]!,
+    hasSeparateY: data[4]! === 1,
+    stages,
+  };
+}
+
+/** `0x0009` — lift-off on the models that moved it out of the sensor byte. */
+export function mchoseV3DecodeLiftOff(data: Uint8Array): number | null {
+  if (data.length < 1) return null;
+  return data[0]!;
+}
+
+/**
+ * Button action types. The same numbering as the V2's, except that the V3
+ * marks an unassigned button `0xff` rather than leaving it at type 0, and its
+ * value width varies with the type.
+ */
+export const MCHOSE_V3_BUTTON_UNSET = 0xff;
+
+/** Value byte counts by type; anything unlisted carries two. */
+const BUTTON_VALUE_WIDTH: Readonly<Record<number, number>> = {
+  0x01: 3,
+  0x22: 3,
+  0x23: 7,
+  0x24: 7,
+};
+
+/** Types whose value bytes are already in order rather than little-endian. */
+const BUTTON_BIG_ENDIAN_TYPES = new Set([0x13, 0x16]);
+
+export interface MchoseV3ButtonAssignment {
+  type: number;
+  /** Raw value bytes, most significant first. */
+  value: number[];
+}
+
+/**
+ * `0x0001` — the button table, which is a variable-width walk rather than a
+ * fixed record: each entry's width depends on the type byte in front of it.
+ *
+ * Returns null if the walk would run past the payload, so a short or stale
+ * reply is rejected instead of yielding half a table.
+ */
+export function mchoseV3DecodeButtons(
+  data: Uint8Array,
+): Record<string, MchoseV3ButtonAssignment> | null {
+  const result: Record<string, MchoseV3ButtonAssignment> = {};
+  let offset = 0;
+  for (const name of MCHOSE_V3_BUTTONS) {
+    if (offset >= data.length) return null;
+    const type = data[offset]!;
+    const width = BUTTON_VALUE_WIDTH[type] ?? 2;
+    if (offset + 1 + width > data.length) return null;
+    const raw = Array.from(data.slice(offset + 1, offset + 1 + width));
+    result[name] = {
+      type,
+      value: BUTTON_BIG_ENDIAN_TYPES.has(type) ? raw : raw.reverse(),
+    };
+    offset += 1 + width;
+  }
+  return result;
+}
+
+export interface MchoseV3Product {
+  name: string;
+  /** The mouse's own product id, reported by `0x0900`. */
+  productId: number;
+  dpiMax: number;
+  /** Lift-off steps in millimetres, in firmware index order. */
+  liftOffDistances: readonly number[];
+  maxPollingRate: number;
+  /**
+   * True when lift-off lives behind `0x0009` instead of the sensor byte. The
+   * five-step models need it: three bits of ladder do not fit in the sensor
+   * byte's two.
+   */
+  liftOffCommand: boolean;
+}
+
+const LOD_TWO = [1, 2] as const;
+const LOD_THREE = [0.7, 1, 2] as const;
+const LOD_FIVE = [0.7, 0.9, 1.2, 1.4, 1.7] as const;
+
+/**
+ * Every model on this protocol, from the bundle's own table. The A7 V3 family
+ * is what this was written for; the rest share the wire format and the same
+ * receivers, so leaving them out would mean resolving one of them to the wrong
+ * DPI ceiling rather than not claiming it at all.
+ */
+export const MCHOSE_V3_PRODUCTS: readonly MchoseV3Product[] = [
+  { name: "A5 V3 Pro", productId: 0x4035, dpiMax: 26000, liftOffDistances: LOD_TWO, maxPollingRate: 8000, liftOffCommand: false },
+  { name: "A5 V3 Ultra+", productId: 0x4026, dpiMax: 42000, liftOffDistances: LOD_THREE, maxPollingRate: 8000, liftOffCommand: false },
+  { name: "A5 V3 Ultra+ (3955)", productId: 0x4034, dpiMax: 50000, liftOffDistances: LOD_FIVE, maxPollingRate: 8000, liftOffCommand: true },
+  { name: "K7 V2 Pro+", productId: 0x4027, dpiMax: 42000, liftOffDistances: LOD_THREE, maxPollingRate: 8000, liftOffCommand: false },
+  { name: "K7 V2 Ultra+", productId: 0x4028, dpiMax: 50000, liftOffDistances: LOD_FIVE, maxPollingRate: 8000, liftOffCommand: true },
+  { name: "A7 V3", productId: 0x4030, dpiMax: 26000, liftOffDistances: LOD_TWO, maxPollingRate: 8000, liftOffCommand: false },
+  { name: "A7 V3 Pro", productId: 0x4031, dpiMax: 42000, liftOffDistances: LOD_THREE, maxPollingRate: 8000, liftOffCommand: false },
+  { name: "A7 V3 Pro+", productId: 0x4032, dpiMax: 42000, liftOffDistances: LOD_THREE, maxPollingRate: 8000, liftOffCommand: false },
+  { name: "A7 V3 Ultra+", productId: 0x4033, dpiMax: 50000, liftOffDistances: LOD_FIVE, maxPollingRate: 8000, liftOffCommand: true },
+  { name: "K5 Pro", productId: 0x4037, dpiMax: 26000, liftOffDistances: LOD_TWO, maxPollingRate: 8000, liftOffCommand: false },
+  { name: "K5 Ultra", productId: 0x4038, dpiMax: 50000, liftOffDistances: LOD_FIVE, maxPollingRate: 8000, liftOffCommand: true },
+  { name: "R7 Ultra", productId: 0x4036, dpiMax: 50000, liftOffDistances: LOD_FIVE, maxPollingRate: 8000, liftOffCommand: true },
+  { name: "V7", productId: 0x402a, dpiMax: 26000, liftOffDistances: LOD_TWO, maxPollingRate: 1000, liftOffCommand: false },
+  { name: "G3 V3", productId: 0x4029, dpiMax: 12000, liftOffDistances: LOD_TWO, maxPollingRate: 1000, liftOffCommand: false },
+];
+
+/**
+ * Receivers, shared across the whole generation — which is exactly why a model
+ * cannot be resolved from the host-facing product id and `0x0900` has to be
+ * asked. `receiver1k` serves the two 1000 Hz models.
+ */
+export const MCHOSE_V3_LINK_PRODUCT_IDS = {
+  receiver: 0x1014,
+  receiver8k: 0x1018,
+  receiver1k: 0x1016,
+} as const;
+
+const V3_LINK_IDS: readonly number[] = Object.values(MCHOSE_V3_LINK_PRODUCT_IDS);
+
+/**
+ * Every product id this protocol answers on: the mice over their own cable,
+ * plus the receivers. The V2 driver subtracts this set from its own match, so
+ * anything added here has to be a V3 device.
+ */
+export const MCHOSE_V3_PRODUCT_IDS: readonly number[] = [
+  ...MCHOSE_V3_PRODUCTS.map((product) => product.productId),
+  ...V3_LINK_IDS,
+];
+
+export function mchoseV3IsProductId(productId: number): boolean {
+  return MCHOSE_V3_PRODUCT_IDS.includes(productId);
+}
+
+/** Rate lists the firmware exposes, keyed by the model's maximum. */
+export const MCHOSE_V3_POLLING_RATES: Readonly<Record<number, readonly number[]>> = {
+  1000: [125, 500, 1000],
+  8000: [125, 500, 1000, 2000, 4000, 8000],
+};
+
+/**
+ * Resolve a model from the id `0x0900` reports, falling back to the product
+ * string. An unrecognised device yields null rather than a wrong DPI ceiling.
+ */
+export function mchoseV3FindProduct(
+  mouseProductId: number | null,
+  productName?: string | null,
+): MchoseV3Product | null {
+  const byId = MCHOSE_V3_PRODUCTS.find((product) => product.productId === mouseProductId);
+  if (byId) return byId;
+  const name = productName?.trim().toUpperCase() ?? "";
+  if (!name) return null;
+  // Longest name first so "A7 V3 Pro+" is not swallowed by "A7 V3 Pro".
+  return [...MCHOSE_V3_PRODUCTS]
+    .sort((a, b) => b.name.length - a.name.length)
+    .find((product) => name.includes(product.name.toUpperCase())) ?? null;
+}
+
+/** Polling rates available to a model. */
+export function mchoseV3PollingRates(product: MchoseV3Product): readonly number[] {
+  return MCHOSE_V3_POLLING_RATES[product.maxPollingRate] ?? MCHOSE_V3_POLLING_RATES[1000]!;
+}
+
+/** Lift-off labels, matching the ladder the model actually has. */
+export function mchoseV3LiftOffLabels(product: MchoseV3Product): string[] {
+  return product.liftOffDistances.map((mm) => `${mm} mm`);
+}
+
+/**
+ * Position a lift-off index on the shell's three-stop Low/Medium/High scale.
+ *
+ * The five-step models do not fit that scale, so this buckets them: the lowest
+ * step is Low, the highest is High, everything in between is Medium. The exact
+ * millimetre figure is the thing actually worth reporting and it survives in
+ * {@link mchoseV3LiftOffLabels}; this is only what the shared status field can
+ * carry.
+ */
+export function mchoseV3LiftOffStop(
+  product: MchoseV3Product,
+  index: number,
+): "Low" | "Medium" | "High" | null {
+  const steps = product.liftOffDistances.length;
+  if (index < 0 || index >= steps) return null;
+  if (index === 0) return "Low";
+  if (index === steps - 1) return "High";
+  return "Medium";
+}


### PR DESCRIPTION
Follows [#55](https://github.com/OpenMouse-Project/mouse-protocol/pull/55). MCHOSE's newer mice do not speak the A7 V2 protocol that PR added — the A7 V3 family and nine siblings use a second protocol that shares the vendor id **and the usage page** with the V2, and nothing else.

| | A7 V2 (#55) | A7 V3 (this PR) |
| --- | --- | --- |
| transport | feature reports `0x11` / `0x12` | **output report `0x4d`**, replies on the input report |
| encoding | every body byte XOR `0xff` | plain bytes, XOR checksum |
| command id | one byte | two bytes, little-endian |
| settings | one 64-byte blob (`0x67`) | several focused commands |
| collection | `0xff01` / `0x0001` | `0xff01` / `0x0001` — **the same one** |

That last row is why this is not purely additive. #55's `isSupported` matched on the usage page alone, so it would have opened an A7 V3 and talked inverted feature reports at a mouse that speaks none. The matchers are now disjoint: the V3 driver takes an id allowlist, the V2 driver subtracts it. The registry probe matrix could not reach the new driver without a real V3 id, so it seeds from the exported list.

This is also a correction. `docs/mchose-protocol.md` wrote the `0x4d` framing off as "a different product line". The A7 V2 really does reject it — that part was right — but the conclusion was wrong, and the note is fixed here.

## ⚠️ Read-only, and untested on hardware

I do not own an A7 V3. Everything here is a reading of MCHOSE's own M HUB bundle, so **no setter is exposed**, even though the encoders are in the codec:

- a wrong read costs a blank field; a speculative write could leave a stranger's mouse somewhere they cannot get it back from
- the settle timings the V2 work could only find empirically (400 ms–2 s per command, three attempts for the slowest) are simply unknown here
- `settingsReady: false` so the shell offers no inert controls, `valuesVerified: true` so what it does read is still shown, and the status line tells the user the model is unverified

The doc ends with a four-step recipe for whoever has the hardware. Happy to be told this should wait for a tester instead of landing as-is.

**Reads:** model and battery (`0x0900`), profile/rate/sleep/sensor/debounce (`0x0002`), the DPI table (`0x0003`), lift-off (`0x0009` or the sensor byte), buttons (`0x0001`), firmware (`0x0901`).

## Two traps worth naming

**The sensor byte is not laid out like the V2's.** Lift-off and the performance mode have swapped ends of it, and bit 7 is a new glass-surface flag. Read a V3 byte with V2 masks and a lift-off level comes out as a power mode — there is a test pinning exactly that confusion.

**The polling nibble is not an index into the rate list.** The firmware has a slot M HUB never offers, so the vendor maps `slot > 1 ? slot - 1 : slot` in and `option > 0 ? option + 1 : option` out. Those are deliberately not inverses, and a test says so, because it looks like a bug otherwise.

Also: a silent device is abandoned after one command's retry budget rather than six, so an unlinked mouse costs 1.8 s instead of eleven.

## Testing

New tests cover the framing and checksum, every decoder, both index maps, the sensor-byte confusion, the model table's internal consistency, and driver-level status assembly including the degraded paths. The `liftOffCommand` flag is asserted against ladder length rather than maintained by hand.

`npm run check` passes apart from two pre-existing `src/drivers/corsair/hid.test.ts` failures (`setDpi rejects values outside 100–18,000`, `setDpi fails when the read-back disagrees`) that also fail on a clean `main` — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
