### PR TITLE
feat(atk): Add VXE R1 Pro Max support

### DIFF
--- a/docs/vxe-r1-pro-max-testing.md
+++ b/docs/vxe-r1-pro-max-testing.md
@@ -1,8 +1,9 @@
 # VXE R1 Pro Max hardware notes
 
-This document records the R1 Pro Max values used by the ATK driver. Keep the
-receiver and wired transports separate: they share the R1 EEPROM command
-family, but the receiver write path has not been validated.
+This document records the R1 Pro Max values and transport behavior verified on
+real hardware for the ATK driver. The wired mouse and 1K receiver share the R1
+command family, but receiver writes remain restricted to individually captured
+and verified paths.
 
 ## Identity and transports
 
@@ -18,52 +19,71 @@ at `0x0000`.
 
 ## Verified wired behavior
 
-The wired `0xf58c` transport uses the same checksum-protected R1 EEPROM command
-framing already implemented by `AtkHidClient`. The driver enables persistent
-writes only after CID/MID resolves to `2,27` on this exact transport.
+The wired `0xf58c` transport uses the checksum-protected R1 EEPROM command
+framing already implemented by `AtkHidClient`. Persistent writes are enabled
+only after CID/MID resolves to `2,27` on this exact transport.
 
-Captured behavior used by the implementation:
+Verified behavior includes:
 
 - Polling rates: 125, 250, 500, and 1,000 Hz through the system EEPROM block.
 - PAW3395 DPI range used by the driver: up to 30,000 DPI.
 - DPI records preserve separate X and Y axis values.
-- R1 extended EEPROM areas are used for DPI stage colours, DPI lighting,
-  performance mode, and stored button/profile inspection.
-- Ultra Long Range uses the existing R1 command path rather than a guessed
-  receiver-only command.
+- DPI stage count and active-stage selection with readback and persistence.
+- Lift-off distance, debounce, Motion Sync, sleep timeout, ripple control, and
+  angle snapping.
+- Performance Mode, DPI stage colours, and DPI lighting including Off,
+  Always On/Steady, Breathing, brightness, and speed.
+- Ultra Long Range through commands `0x16`/`0x17`.
+- Profile switching through commands `0x0f`/`0x0e`.
+- Stored button assignments are inspected read-only; button-remap writes are
+  not implemented by this PR.
 
-Every persistent write path performs device readback where the existing R1
-protocol supports it. Unknown identities are rejected before R1 fallback
-encoding is used.
+## Verified receiver behavior
+
+The `0xf58a` receiver was captured and hardware-tested independently. The
+receiver uses the same logical settings, but writes are sent through dedicated
+receiver helpers rather than by relaxing the generic EEPROM-write guard.
+
+Verified receiver writes include:
+
+- Polling through a complete 10-byte system row at `0x0000`.
+- DPI writes through the containing two-stage 8-byte DPI group.
+- DPI stage count and active-stage selection through the complete 10-byte
+  system row, preserving unrelated bytes.
+- Lift-off distance at `0x000a`.
+- Debounce, Motion Sync, sleep timeout, angle snapping, and ripple control by
+  read-modify-writing the complete 10-byte advanced row at `0x00a9`.
+- Performance Mode through the captured 6-byte row at `0x00b5`.
+- DPI stage colours through the containing 8-byte colour group at `0x002c`
+  and subsequent groups as required by stage index.
+- DPI lighting mode, brightness, and speed through the captured 8-byte row at
+  `0x004c`.
+- Ultra Long Range through command `0x16` with `0x17` readback.
+- Profile switching through command `0x0f` with `0x0e` readback.
+
+Where the receiver echoes a write, the driver requires the captured echo before
+continuing. EEPROM-backed settings are read back after the write where the
+protocol provides a stable readback path. DPI stage management and profile
+selection were also verified to persist across reconnects.
 
 ## Receiver safety boundary
 
-The `0xf58a` receiver is recognized so status reads and device selection can use
-the correct R1 Pro Max identity. Persistent EEPROM writes are deliberately
-blocked on this transport until a reversible hardware test confirms the
-receiver write path.
+The generic R1 EEPROM `write()` path remains blocked for `0xf58a`. Receiver
+support is intentionally allow-listed per verified operation so a future R1
+setting cannot accidentally become writable merely because it shares an EEPROM
+address family with the wired device.
 
 In particular, do not route this receiver through the SE/SE+ `0x0070`
 live-settings selectors merely because both devices belong to the R1 family.
-That assumption would send the wrong protocol for polling, lift-off distance,
-debounce, and angle snapping.
+That would send the wrong protocol for polling, lift-off distance, debounce,
+and angle snapping.
 
-## Regression checklist
+Unknown identities are rejected before R1 fallback encoding is used.
 
-Before enabling additional receiver writes, verify all of the following on real
-hardware and restore the original value after each test:
+## Validation
 
-1. Read CID/MID and require `02 1b`.
-2. Read the complete system block and record its baseline.
-3. Change one polling rate, read it back, and restore the baseline.
-4. Change one active DPI stage, including unequal X/Y values, read it back, and
-   restore both axes.
-5. Verify lift-off distance, debounce, Motion Sync, ripple control, and angle
-   snapping one field at a time.
-6. Confirm that a receiver-side write does not alter unrelated EEPROM bytes or
-   another onboard profile.
-7. Re-read the original block(s) and compare them byte-for-byte with the
-   baseline before considering the transport writable.
+Final local validation for this hardware pass:
 
-Until that checklist is completed, `0xf58a` remains read-only for persistent
-configuration by design.
+- Targeted ATK tests: 52/52 passing.
+- `npm run build`: passing.
+- `git diff --check`: passing.

--- a/docs/vxe-r1-pro-max-testing.md
+++ b/docs/vxe-r1-pro-max-testing.md
@@ -1,0 +1,69 @@
+# VXE R1 Pro Max hardware notes
+
+This document records the R1 Pro Max values used by the ATK driver. Keep the
+receiver and wired transports separate: they share the R1 EEPROM command
+family, but the receiver write path has not been validated.
+
+## Identity and transports
+
+- Mouse identity (`GetMouseCIDMID`, command `0x10`): CID `0x02`, MID `0x1b`.
+- Sensor: PAW3395.
+- Wired configuration endpoint: VID/PID `0x3554:0xf58c`.
+- 1K receiver configuration endpoint: VID/PID `0x3554:0xf58a`.
+- Configuration collection: usage page `0xff02`, usage `0x02`.
+
+The R1 Pro Max must not use the R1 SE/SE+ selector-based live-settings row at
+`0x0070`. Captured Pro Max polling changes use the normal system EEPROM block
+at `0x0000`.
+
+## Verified wired behavior
+
+The wired `0xf58c` transport uses the same checksum-protected R1 EEPROM command
+framing already implemented by `AtkHidClient`. The driver enables persistent
+writes only after CID/MID resolves to `2,27` on this exact transport.
+
+Captured behavior used by the implementation:
+
+- Polling rates: 125, 250, 500, and 1,000 Hz through the system EEPROM block.
+- PAW3395 DPI range used by the driver: up to 30,000 DPI.
+- DPI records preserve separate X and Y axis values.
+- R1 extended EEPROM areas are used for DPI stage colours, DPI lighting,
+  performance mode, and stored button/profile inspection.
+- Ultra Long Range uses the existing R1 command path rather than a guessed
+  receiver-only command.
+
+Every persistent write path performs device readback where the existing R1
+protocol supports it. Unknown identities are rejected before R1 fallback
+encoding is used.
+
+## Receiver safety boundary
+
+The `0xf58a` receiver is recognized so status reads and device selection can use
+the correct R1 Pro Max identity. Persistent EEPROM writes are deliberately
+blocked on this transport until a reversible hardware test confirms the
+receiver write path.
+
+In particular, do not route this receiver through the SE/SE+ `0x0070`
+live-settings selectors merely because both devices belong to the R1 family.
+That assumption would send the wrong protocol for polling, lift-off distance,
+debounce, and angle snapping.
+
+## Regression checklist
+
+Before enabling additional receiver writes, verify all of the following on real
+hardware and restore the original value after each test:
+
+1. Read CID/MID and require `02 1b`.
+2. Read the complete system block and record its baseline.
+3. Change one polling rate, read it back, and restore the baseline.
+4. Change one active DPI stage, including unequal X/Y values, read it back, and
+   restore both axes.
+5. Verify lift-off distance, debounce, Motion Sync, ripple control, and angle
+   snapping one field at a time.
+6. Confirm that a receiver-side write does not alter unrelated EEPROM bytes or
+   another onboard profile.
+7. Re-read the original block(s) and compare them byte-for-byte with the
+   baseline before considering the transport writable.
+
+Until that checklist is completed, `0xf58a` remains read-only for persistent
+configuration by design.

--- a/src/drivers/atk/hid.test.ts
+++ b/src/drivers/atk/hid.test.ts
@@ -308,7 +308,7 @@ test("R1 inspection rejects unsuccessful and corrupt command replies", async () 
   const otherR1 = device(0xf58f, "VXE R1");
   Object.assign(otherR1, { vendorId: 0x3554 });
   (otherR1 as unknown as FakeAtkDevice).replies = [reply(0x10, 0, [2, 12])];
-  await assert.rejects(new AtkHidClient(otherR1).setR1ActiveProfile(2), /verified wired transport/);
+  await assert.rejects(new AtkHidClient(otherR1).setR1ActiveProfile(2), /not available on this connection/);
   assert.equal((otherR1 as unknown as FakeAtkDevice).sent.some(({ data }) => data[0] === 0x0f), false);
 
   const corruptColor = device(0xf58f, "VXE R1SE+");

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -1,4 +1,4 @@
-﻿import {
+import {
   WE_CMD_READ_EEPROM,
   WE_CMD_WRITE_EEPROM,
   WE_REPORT_ID,
@@ -41,7 +41,7 @@ import {
 import { type AtkProduct, ATK_COMPX_PRODUCT_IDS, ATK_PRODUCTS } from "./products.ts";
 
 // ATK mice (A9 family and siblings) use the same OEM framing as the Endgame
-// Gear WE series â€” 16-byte EEPROM commands on report 0x08 â€” but carry them on
+// Gear WE series — 16-byte EEPROM commands on report 0x08 — but carry them on
 // output/input reports rather than feature reports.
 const BATTERY_COMMAND = 0x04;
 const VERSION_COMMAND = 0x12;
@@ -617,10 +617,10 @@ export class AtkHidClient {
       throw new Error("The DPI lighting setting is invalid.");
     }
 
-    // Captured R1 Pro Max rows use literal 00 00 for fields that are inactive:
+    // R1 Pro Max uses its own DPI-lighting row encoding:
     // Off       = 00 00 | 00 00 | speed | 00 55
     // Always On = 01 54 | brightness | speed | 01 54
-    // Breathing = 02 53 | 00 00 | speed | 01 54
+    // Breathing = 02 53 | preserve brightness | speed | 01 54
     const block = Array.from(await this.read(REGISTER.dpiLighting, R1_DPI_LIGHTING_LENGTH));
     const proMax = this.isR1ProMax();
 
@@ -1124,7 +1124,7 @@ export class AtkHidClient {
         };
         const timer = setTimeout(() => {
           finish();
-          reject(new Error("The mouse did not answer â€” it may be asleep or out of range."));
+          reject(new Error("The mouse did not answer — it may be asleep or out of range."));
         }, REPLY_TIMEOUT_MS);
         const listener = (event: HIDInputReportEvent) => {
           if (event.reportId !== WE_REPORT_ID) return;

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -61,6 +61,8 @@ const MAX_IDENTIFY_ATTEMPTS = 3;
 // (Beken MCU). It shares the A9 EEPROM map for DPI/advanced/lod, but the poll
 // rate lives in the live-settings row; see the codec for the full story.
 const VXE_R1_RECEIVER_PID = 0x1085;
+const VXE_R1_PRO_MAX_RECEIVER_PID = 0xf58a;
+const VXE_R1_PRO_MAX_MOUSE_PID = 0xf58c;
 const VXE_R1_COMPX_RECEIVER_PID = 0xf58e;
 const VXE_R1_COMPX_MOUSE_PID = 0xf58f;
 const R1_SETTINGS_LENGTH = 4;
@@ -189,11 +191,13 @@ export class AtkHidClient {
    */
   isWireless(): boolean {
     return this.device.productId === VXE_R1_RECEIVER_PID
-      || (this.device.vendorId === VENDOR_ID.vgn && this.device.productId === VXE_R1_COMPX_RECEIVER_PID)
+      || (this.device.vendorId === VENDOR_ID.vgn
+        && (this.device.productId === VXE_R1_PRO_MAX_RECEIVER_PID
+          || this.device.productId === VXE_R1_COMPX_RECEIVER_PID))
       || /receiver|dongle/i.test(this.device.productName || "");
   }
 
-  /** VXE R1 SE/SE+ on its stock 1K receiver (Beken MCU, per OpenVXE). */
+  /** VXE R1-family devices using the shared EEPROM command framing. */
   isR1(): boolean {
     return this.product?.family === "r1"
       || this.usesSharedR1Transport();
@@ -277,6 +281,7 @@ export class AtkHidClient {
       : null;
     const angleTuning = angle ? weUnpackScalarPair(angle[0], angle[1]) : null;
     const angleSnapping = angle ? weUnpackScalarPair(angle[2], angle[3]) : null;
+    const sensorProfile = this.product ? ATK_SENSORS[this.product.sensor] : null;
     return this.lastStatus = {
       brand: this.deviceBrand(),
       name: this.displayName(),
@@ -287,8 +292,8 @@ export class AtkHidClient {
         dpiStageEditor: this.usesVerifiedR1WiredTransport() ? {
           maxStages: R1_MAX_DPI_STAGES,
           countEditable: false,
-          minDpi: ATK_SENSORS.PAW3395SE.minDpi,
-          maxDpi: ATK_SENSORS.PAW3395SE.maxDpi,
+          minDpi: sensorProfile?.minDpi ?? DPI_MIN,
+          maxDpi: sensorProfile?.maxDpi ?? DPI_MAX,
           stepDpi: 50,
         } : undefined,
         dpiLighting: r1Extras ? {
@@ -305,7 +310,7 @@ export class AtkHidClient {
       dpiStages: dpiStages.map(({ x }) => x),
       dpiStageColors: r1Extras?.dpiStageColors,
       activeDpiStage,
-      supportsSeparateDpiAxes: false,
+      supportsSeparateDpiAxes: this.isR1ProMax(),
       pollingRateHz: await this.readPollingRate(system),
       supportedPollingRates: this.getSupportedPollingRates(),
       activeProfile: stored?.activeProfile ?? null,
@@ -465,7 +470,7 @@ export class AtkHidClient {
   async setActiveDpiStage(index: number): Promise<number> {
     await this.identify();
     if (this.isR1() && !this.usesVerifiedR1WiredTransport()) {
-      throw new Error("R1 DPI stage selection is available only over the verified R1 SE+ wired transport.");
+      throw new Error("R1 DPI stage selection is available only over a verified wired transport.");
     }
     const system = await this.read(REGISTER.system, SYSTEM_LENGTH);
     const count = this.stageCount(system);
@@ -484,7 +489,7 @@ export class AtkHidClient {
   async setDpiStageValue(index: number, dpi: number): Promise<number> {
     await this.identify();
     if (this.isR1() && !this.usesVerifiedR1WiredTransport()) {
-      throw new Error("R1 DPI stage editing is available only over the verified R1 SE+ wired transport.");
+      throw new Error("R1 DPI stage editing is available only over a verified wired transport.");
     }
     const system = await this.read(REGISTER.system, SYSTEM_LENGTH);
     const count = this.stageCount(system);
@@ -935,18 +940,25 @@ export class AtkHidClient {
 
   private usesSharedR1Transport(): boolean {
     return this.device.productId === VXE_R1_RECEIVER_PID
-      || (this.device.vendorId === VENDOR_ID.vgn
-        && (this.device.productId === VXE_R1_COMPX_RECEIVER_PID || this.device.productId === VXE_R1_COMPX_MOUSE_PID))
-      || /\bvxe\s+r1(?:\s*se\+?)?\b/i.test(this.device.productName || "");
+      || (this.device.vendorId === VENDOR_ID.vgn && ATK_COMPX_PRODUCT_IDS.includes(this.device.productId))
+      || /\bvxe\s+r1(?:\s*(?:se\+?|pro\s+max))?\b/i.test(this.device.productName || "");
   }
 
+  /** Only the SE/SE+ receiver family uses the selector-based 0x0070 live row. */
   private usesR1LiveSettings(): boolean {
-    return this.isR1() && this.isWireless();
+    return this.isR1()
+      && (this.device.productId === VXE_R1_RECEIVER_PID
+        || (this.device.vendorId === VENDOR_ID.vgn && this.device.productId === VXE_R1_COMPX_RECEIVER_PID));
+  }
+
+  private isR1ProMax(): boolean {
+    return this.product === ATK_PRODUCTS["2,27"];
   }
 
   private usesVerifiedR1WiredTransport(): boolean {
-    return this.device.vendorId === VENDOR_ID.vgn && this.device.productId === VXE_R1_COMPX_MOUSE_PID
-      && this.product === ATK_PRODUCTS["2,32"] && !this.isWireless();
+    if (this.device.vendorId !== VENDOR_ID.vgn || this.isWireless()) return false;
+    return (this.device.productId === VXE_R1_COMPX_MOUSE_PID && this.product === ATK_PRODUCTS["2,32"])
+      || (this.device.productId === VXE_R1_PRO_MAX_MOUSE_PID && this.isR1ProMax());
   }
 
   /**
@@ -999,7 +1011,7 @@ export class AtkHidClient {
 
   private async write(address: number, data: readonly number[]): Promise<void> {
     if (this.isR1() && !this.usesR1LiveSettings() && !this.usesVerifiedR1WiredTransport()) {
-      throw new Error("Persistent R1 EEPROM writes are available only over the verified R1 SE+ wired transport.");
+      throw new Error("Persistent R1 EEPROM writes are available only over a verified wired transport.");
     }
     const payload = weBuildCmdPayload(
       WE_CMD_WRITE_EEPROM,

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -711,18 +711,76 @@ export class AtkHidClient {
 
   async setMotionSync(enabled: boolean): Promise<boolean> {
     await this.identify();
+
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      const confirmed = await this.writeR1ProMaxReceiverAdvanced(
+        2,
+        enabled ? 1 : 0,
+      ) === 1;
+
+      if (confirmed !== enabled) {
+        throw new Error(
+          `The mouse left Motion Sync ${confirmed ? "on" : "off"}.`,
+        );
+      }
+
+      this.patch({ motionSync: confirmed });
+      return confirmed;
+    }
+
     return await this.setAdvancedFlag(2, enabled, "motionSync", "Motion Sync");
   }
 
   async setRippleControl(enabled: boolean): Promise<boolean> {
     await this.identify();
+
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      const confirmed = await this.writeR1ProMaxReceiverAdvanced(
+        8,
+        enabled ? 1 : 0,
+      ) === 1;
+
+      if (confirmed !== enabled) {
+        throw new Error(
+          `The mouse left ripple control ${confirmed ? "on" : "off"}.`,
+        );
+      }
+
+      this.patch({ rippleControl: confirmed });
+      return confirmed;
+    }
+
     return await this.setAdvancedFlag(8, enabled, "rippleControl", "ripple control");
   }
 
   async setAngleSnapping(enabled: boolean): Promise<boolean> {
     if (!this.usesR1LiveSettings()) await this.identify();
     if (this.usesR1LiveSettings()) return await this.setR1AngleSnapping(enabled);
-    if (this.isR1()) return await this.setAdvancedFlag(6, enabled, "angleSnapping", "straight-line correction");
+
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      const confirmed = await this.writeR1ProMaxReceiverAdvanced(
+        6,
+        enabled ? 1 : 0,
+      ) === 1;
+
+      if (confirmed !== enabled) {
+        throw new Error(
+          `The mouse left angle snapping ${confirmed ? "on" : "off"}.`,
+        );
+      }
+
+      this.patch({ angleSnapping: confirmed });
+      return confirmed;
+    }
+
+    if (this.isR1()) {
+      return await this.setAdvancedFlag(
+        6,
+        enabled,
+        "angleSnapping",
+        "straight-line correction",
+      );
+    }
     const group = await this.read(REGISTER.angle, ANGLE_LENGTH);
     await this.write(REGISTER.angle, [group[0], enabled ? 1 : 0].flatMap((value) => wePackScalarPair(value)));
     const confirmed = (await this.read(REGISTER.angle, ANGLE_LENGTH))[2] === 1;
@@ -738,7 +796,10 @@ export class AtkHidClient {
     if (!Number.isInteger(milliseconds) || !options.includes(milliseconds)) {
       throw new Error(`This mouse does not support ${milliseconds} ms debounce.`);
     }
-    const confirmed = await this.writeAdvanced(0, milliseconds);
+    const confirmed = this.usesVerifiedR1ProMaxReceiverTransport()
+      ? await this.writeR1ProMaxReceiverAdvanced(0, milliseconds)
+      : await this.writeAdvanced(0, milliseconds);
+
     if (confirmed !== milliseconds) {
       throw new Error(`The mouse kept ${confirmed} ms of debounce instead of ${milliseconds} ms.`);
     }
@@ -756,7 +817,11 @@ export class AtkHidClient {
       throw new Error(`This mouse does not support a ${seconds} second sleep timeout.`);
     }
     const units = Math.round(seconds / SLEEP_STEP_SECONDS);
-    const confirmed = await this.writeAdvanced(4, units) * SLEEP_STEP_SECONDS;
+    const confirmedUnits = this.usesVerifiedR1ProMaxReceiverTransport()
+      ? await this.writeR1ProMaxReceiverAdvanced(4, units)
+      : await this.writeAdvanced(4, units);
+    const confirmed = confirmedUnits * SLEEP_STEP_SECONDS;
+
     if (confirmed !== units * SLEEP_STEP_SECONDS) {
       throw new Error(`The mouse kept a ${confirmed} second sleep timeout instead of ${seconds} seconds.`);
     }
@@ -1140,6 +1205,49 @@ export class AtkHidClient {
       await this.device.sendReport(WE_REPORT_ID, new Uint8Array(payload).buffer);
       await delay(WRITE_SETTLE_MS);
     });
+  }
+
+  /**
+   * F58A advanced settings are written as the complete 10-byte EEPROM row.
+   * Callers remain individually gated until each field is hardware-verified.
+   */
+  private async writeR1ProMaxReceiverAdvanced(
+    offset: number,
+    value: number,
+  ): Promise<number> {
+    await this.identify();
+
+    if (!this.usesVerifiedR1ProMaxReceiverTransport()) {
+      throw new Error("R1 Pro Max receiver advanced writes are not available on this connection.");
+    }
+
+    const address = REGISTER.advanced;
+    const block = Array.from(await this.read(address, ADVANCED_LENGTH));
+    block.splice(offset, 2, ...wePackScalarPair(value));
+
+    const payload = weBuildCmdPayload(
+      WE_CMD_WRITE_EEPROM,
+      [
+        0,
+        (address >> 8) & 0xff,
+        address & 0xff,
+        block.length,
+        ...block,
+      ],
+    );
+
+    await this.exchange(
+      payload,
+      (frame) => frame[0] === WE_CMD_WRITE_EEPROM
+        && frame[1] === 0
+        && frame[2] === ((address >> 8) & 0xff)
+        && frame[3] === (address & 0xff)
+        && frame[4] === block.length
+        && this.hasValidChecksum(frame)
+        && block.every((byte, index) => frame[DATA_OFFSET + index] === byte),
+    );
+
+    return (await this.read(address, ADVANCED_LENGTH))[offset]!;
   }
 
   /**

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -85,6 +85,7 @@ const REGISTER = {
 } as const;
 
 const SYSTEM_LENGTH = 6;
+const R1_SYSTEM_ROW_LENGTH = 10;
 const ADVANCED_LENGTH = 10;
 const ANGLE_LENGTH = 4;
 const DPI_STAGE_LENGTH = 4;
@@ -436,7 +437,16 @@ export class AtkHidClient {
     if (this.usesR1LiveSettings()) return await this.setR1PollingRate(pollingRateHz);
     const encoded = POLLING_RATES.find(([, hertz]) => hertz === pollingRateHz);
     if (!encoded) throw new Error(`This mouse does not support ${pollingRateHz} Hz.`);
-    await this.write(REGISTER.system, wePackScalarPair(encoded[0]));
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      // ATK Hub writes the complete 10-byte system row through the F58A
+      // receiver. Preserve stage count, active stage, and the unknown tail.
+      const system = Array.from(await this.read(REGISTER.system, R1_SYSTEM_ROW_LENGTH));
+      system.splice(0, 2, ...wePackScalarPair(encoded[0]));
+      await this.writeR1ProMaxReceiverSystem(system);
+    } else {
+      await this.write(REGISTER.system, wePackScalarPair(encoded[0]));
+    }
+
     if (this.isR1()) await delay(R1_LIVE_WRITE_SETTLE_MS);
     const confirmed = this.decodePollingRate((await this.read(REGISTER.system, SYSTEM_LENGTH))[0]);
     if (confirmed !== pollingRateHz) {
@@ -1044,6 +1054,12 @@ export class AtkHidClient {
     return this.product === ATK_PRODUCTS["2,27"];
   }
 
+  private usesVerifiedR1ProMaxReceiverTransport(): boolean {
+    return this.device.vendorId === VENDOR_ID.vgn
+      && this.device.productId === VXE_R1_PRO_MAX_RECEIVER_PID
+      && this.isR1ProMax();
+  }
+
   private usesVerifiedR1WiredTransport(): boolean {
     if (this.device.vendorId !== VENDOR_ID.vgn || this.isWireless()) return false;
     return (this.device.productId === VXE_R1_COMPX_MOUSE_PID && this.product === ATK_PRODUCTS["2,32"])
@@ -1112,6 +1128,39 @@ export class AtkHidClient {
       await this.device.sendReport(WE_REPORT_ID, new Uint8Array(payload).buffer);
       await delay(WRITE_SETTLE_MS);
     });
+  }
+
+  /**
+   * The verified F58A polling path writes the complete system row and echoes
+   * the committed row back on report 0x08. No other receiver EEPROM writes
+   * are enabled through this helper.
+   */
+  private async writeR1ProMaxReceiverSystem(data: readonly number[]): Promise<void> {
+    await this.identify();
+    if (!this.usesVerifiedR1ProMaxReceiverTransport()) {
+      throw new Error("R1 Pro Max receiver system writes are not available on this connection.");
+    }
+    if (data.length !== R1_SYSTEM_ROW_LENGTH) {
+      throw new Error(
+        `R1 Pro Max receiver system writes must preserve the complete ${R1_SYSTEM_ROW_LENGTH}-byte row.`,
+      );
+    }
+
+    const payload = weBuildCmdPayload(
+      WE_CMD_WRITE_EEPROM,
+      [0, 0x00, 0x00, data.length, ...data],
+    );
+
+    await this.exchange(
+      payload,
+      (frame) => frame[0] === WE_CMD_WRITE_EEPROM
+        && frame[1] === 0
+        && frame[2] === 0
+        && frame[3] === 0
+        && frame[4] === data.length
+        && this.hasValidChecksum(frame)
+        && data.every((byte, index) => frame[DATA_OFFSET + index] === byte),
+    );
   }
 
   private async send(frame: Uint8Array): Promise<void> {

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -468,7 +468,12 @@ export class AtkHidClient {
     const index = this.stageIndex(await this.read(REGISTER.system, SYSTEM_LENGTH));
     const stage = sensor ? atkPackDpiStageForSensor(sensor, dpi, dpiY) : atkPackDpiStage(dpi, dpiY);
     if (!stage) throw new Error(`${dpi.toLocaleString()} DPI is not representable by this sensor.`);
-    await this.write(this.dpiAddress(index), stage);
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      await this.writeR1ProMaxReceiverDpiStage(index, stage);
+    } else {
+      await this.write(this.dpiAddress(index), stage);
+    }
+
     const confirmed = await this.readDpiStage(index);
     if (confirmed.x !== dpi || confirmed.y !== dpiY) {
       throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);
@@ -1128,6 +1133,57 @@ export class AtkHidClient {
       await this.device.sendReport(WE_REPORT_ID, new Uint8Array(payload).buffer);
       await delay(WRITE_SETTLE_MS);
     });
+  }
+
+  /**
+   * ATK Hub writes F58A DPI records as an 8-byte pair of adjacent stages.
+   * Preserve the neighbouring stage and require the receiver to echo the
+   * complete group before the normal DPI readback confirms the active stage.
+   */
+  private async writeR1ProMaxReceiverDpiStage(
+    index: number,
+    stage: readonly number[],
+  ): Promise<void> {
+    await this.identify();
+    if (!this.usesVerifiedR1ProMaxReceiverTransport()) {
+      throw new Error("R1 Pro Max receiver DPI writes are not available on this connection.");
+    }
+    if (stage.length !== DPI_STAGE_LENGTH) {
+      throw new Error("R1 Pro Max receiver DPI records must contain four bytes.");
+    }
+
+    const groupLength = DPI_STAGE_LENGTH * 2;
+    const groupIndex = Math.floor(index / 2);
+    const address = REGISTER.dpiBase + groupIndex * groupLength;
+    const group = Array.from(await this.read(address, groupLength));
+
+    group.splice(
+      (index % 2) * DPI_STAGE_LENGTH,
+      DPI_STAGE_LENGTH,
+      ...stage,
+    );
+
+    const payload = weBuildCmdPayload(
+      WE_CMD_WRITE_EEPROM,
+      [
+        0,
+        (address >> 8) & 0xff,
+        address & 0xff,
+        group.length,
+        ...group,
+      ],
+    );
+
+    await this.exchange(
+      payload,
+      (frame) => frame[0] === WE_CMD_WRITE_EEPROM
+        && frame[1] === 0
+        && frame[2] === ((address >> 8) & 0xff)
+        && frame[3] === (address & 0xff)
+        && frame[4] === group.length
+        && this.hasValidChecksum(frame)
+        && group.every((byte, offset) => frame[DATA_OFFSET + offset] === byte),
+    );
   }
 
   /**

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -582,7 +582,10 @@ export class AtkHidClient {
 
   async setDpiStageColor(index: number, color: string): Promise<string> {
     await this.identify();
-    if (!this.usesVerifiedR1WiredTransport()) {
+    if (
+      !this.usesVerifiedR1WiredTransport()
+      && !this.usesVerifiedR1ProMaxReceiverTransport()
+    ) {
       throw new Error("DPI stage colors are not available on this connection.");
     }
     const rgb = parseHexColor(color);
@@ -593,7 +596,13 @@ export class AtkHidClient {
     const groupAddress = REGISTER.dpiColorBase + Math.floor(index / 2) * R1_DPI_COLOR_GROUP_LENGTH;
     const group = Array.from(await this.read(groupAddress, R1_DPI_COLOR_GROUP_LENGTH));
     group.splice((index % 2) * 4, 4, ...packRgb(rgb));
-    await this.write(groupAddress, group);
+
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      await this.writeR1ProMaxReceiverDpiColorGroup(groupAddress, group);
+    } else {
+      await this.write(groupAddress, group);
+    }
+
     const confirmedGroup = await this.read(groupAddress, R1_DPI_COLOR_GROUP_LENGTH);
     const confirmed = unpackRgb(confirmedGroup.subarray((index % 2) * 4, (index % 2 + 1) * 4));
     if (confirmed !== color.toLowerCase()) throw new Error(`The mouse kept ${confirmed ?? "an invalid colour"} instead of ${color}.`);
@@ -627,7 +636,12 @@ export class AtkHidClient {
 
   async setDpiLighting(mode: number, brightness: number, speed: number): Promise<void> {
     await this.identify();
-    if (!this.usesVerifiedR1WiredTransport()) throw new Error("DPI lighting is not available on this connection.");
+    if (
+      !this.usesVerifiedR1WiredTransport()
+      && !this.usesVerifiedR1ProMaxReceiverTransport()
+    ) {
+      throw new Error("DPI lighting is not available on this connection.");
+    }
     if (![0, 1, 2].includes(mode) || ![0, 1, 2].includes(brightness) || ![0, 1, 2].includes(speed)) {
       throw new Error("The DPI lighting setting is invalid.");
     }
@@ -653,7 +667,11 @@ export class AtkHidClient {
     block.splice(2, 2, ...expectedBrightness);
     block.splice(4, 2, ...wePackScalarPair(R1_DPI_SPEED[speed]!));
     block.splice(6, 2, ...wePackScalarPair(mode === 0 ? 0 : 1));
-    await this.write(REGISTER.dpiLighting, block);
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      await this.writeR1ProMaxReceiverDpiLighting(block);
+    } else {
+      await this.write(REGISTER.dpiLighting, block);
+    }
 
     const raw = await this.read(REGISTER.dpiLighting, R1_DPI_LIGHTING_LENGTH);
     const expectedSpeed = wePackScalarPair(R1_DPI_SPEED[speed]!);
@@ -847,6 +865,83 @@ export class AtkHidClient {
     group.splice(offset, 2, ...wePackScalarPair(value));
     await this.write(REGISTER.advanced, group);
     return (await this.read(REGISTER.advanced, ADVANCED_LENGTH))[offset];
+  }
+
+  /**
+   * F58A DPI stage colours are stored as two 4-byte colour records per
+   * 8-byte EEPROM group, matching the captured receiver write/echo path.
+   */
+  private async writeR1ProMaxReceiverDpiColorGroup(
+    address: number,
+    block: readonly number[],
+  ): Promise<void> {
+    await this.identify();
+
+    if (!this.usesVerifiedR1ProMaxReceiverTransport()) {
+      throw new Error("DPI stage colors are not available on this connection.");
+    }
+
+    if (block.length !== R1_DPI_COLOR_GROUP_LENGTH) {
+      throw new Error("The DPI stage colour block has an invalid length.");
+    }
+
+    const payload = weBuildCmdPayload(
+      WE_CMD_WRITE_EEPROM,
+      [
+        0,
+        (address >> 8) & 0xff,
+        address & 0xff,
+        block.length,
+        ...block,
+      ],
+    );
+
+    await this.exchange(
+      payload,
+      (frame) => frame[0] === WE_CMD_WRITE_EEPROM
+        && frame[1] === 0
+        && frame[2] === ((address >> 8) & 0xff)
+        && frame[3] === (address & 0xff)
+        && frame[4] === block.length
+        && this.hasValidChecksum(frame)
+        && block.every((byte, index) => frame[DATA_OFFSET + index] === byte),
+    );
+  }
+
+  /**
+   * F58A DPI lighting uses the same complete 8-byte 0x004c row as wired.
+   */
+  private async writeR1ProMaxReceiverDpiLighting(
+    block: readonly number[],
+  ): Promise<void> {
+    await this.identify();
+
+    if (!this.usesVerifiedR1ProMaxReceiverTransport()) {
+      throw new Error("DPI lighting is not available on this connection.");
+    }
+
+    const address = REGISTER.dpiLighting;
+    const payload = weBuildCmdPayload(
+      WE_CMD_WRITE_EEPROM,
+      [
+        0,
+        (address >> 8) & 0xff,
+        address & 0xff,
+        block.length,
+        ...block,
+      ],
+    );
+
+    await this.exchange(
+      payload,
+      (frame) => frame[0] === WE_CMD_WRITE_EEPROM
+        && frame[1] === 0
+        && frame[2] === ((address >> 8) & 0xff)
+        && frame[3] === (address & 0xff)
+        && frame[4] === block.length
+        && this.hasValidChecksum(frame)
+        && block.every((byte, index) => frame[DATA_OFFSET + index] === byte),
+    );
   }
 
   private async readR1Extras(stageCount: number): Promise<{

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -691,11 +691,36 @@ export class AtkHidClient {
 
   async setLongRangeMode(enabled: boolean): Promise<boolean> {
     await this.identify();
-    if (!this.usesVerifiedR1WiredTransport()) throw new Error("Long-range mode is not available on this connection.");
-    await this.send(weBuildCmdPayload(SET_LONG_RANGE_COMMAND, [0, 0, 0, 10, enabled ? 1 : 0]));
+
+    const receiver = this.usesVerifiedR1ProMaxReceiverTransport();
+    if (!this.usesVerifiedR1WiredTransport() && !receiver) {
+      throw new Error("Long-range mode is not available on this connection.");
+    }
+
+    const frame = weBuildCmdPayload(
+      SET_LONG_RANGE_COMMAND,
+      [0, 0, 0, 10, enabled ? 1 : 0],
+    );
+
+    if (receiver) {
+      await this.exchange(
+        frame,
+        (reply) => reply.length === frame.length
+          && reply.every((byte, index) => byte === frame[index]),
+      );
+    } else {
+      await this.send(frame);
+    }
+
     await delay(WRITE_SETTLE_MS);
+
     const confirmed = await this.readLongRangeMode();
-    if (confirmed !== enabled) throw new Error(`The mouse left long-range mode ${confirmed ? "on" : "off"}.`);
+    if (confirmed !== enabled) {
+      throw new Error(
+        `The mouse left long-range mode ${confirmed ? "on" : "off"}.`,
+      );
+    }
+
     this.patch({ longRangeMode: confirmed });
     return confirmed;
   }

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -676,8 +676,15 @@ export class AtkHidClient {
     if (this.usesR1LiveSettings()) return await this.setR1LiftOffDistance(value);
     const encoded = (this.isR1() ? R1_LIFT_OFF_CODES : LIFT_OFF_CODES).find(([, name]) => name === value);
     if (!encoded) throw new Error(`This mouse does not support a ${value.toLowerCase()} lift-off distance.`);
-    await this.write(REGISTER.liftOffDistance, wePackScalarPair(encoded[0]));
-    const confirmed = this.decodeLiftOffDistance((await this.read(REGISTER.liftOffDistance, 2))[0]);
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      await this.writeR1ProMaxReceiverLiftOffDistance(encoded[0]);
+    } else {
+      await this.write(REGISTER.liftOffDistance, wePackScalarPair(encoded[0]));
+    }
+
+    const confirmed = this.decodeLiftOffDistance(
+      (await this.read(REGISTER.liftOffDistance, 2))[0],
+    );
     if (confirmed !== value) {
       throw new Error(`The mouse kept a ${String(confirmed).toLowerCase()} lift-off distance instead of ${value.toLowerCase()}.`);
     }
@@ -1133,6 +1140,41 @@ export class AtkHidClient {
       await this.device.sendReport(WE_REPORT_ID, new Uint8Array(payload).buffer);
       await delay(WRITE_SETTLE_MS);
     });
+  }
+
+  /**
+   * The F58A vendor path writes LOD as one checksum-protected scalar pair at
+   * EEPROM 0x000a and echoes the committed pair back on report 0x08.
+   */
+  private async writeR1ProMaxReceiverLiftOffDistance(code: number): Promise<void> {
+    await this.identify();
+    if (!this.usesVerifiedR1ProMaxReceiverTransport()) {
+      throw new Error("R1 Pro Max receiver lift-off writes are not available on this connection.");
+    }
+
+    const data = wePackScalarPair(code);
+    const address = REGISTER.liftOffDistance;
+    const payload = weBuildCmdPayload(
+      WE_CMD_WRITE_EEPROM,
+      [
+        0,
+        (address >> 8) & 0xff,
+        address & 0xff,
+        data.length,
+        ...data,
+      ],
+    );
+
+    await this.exchange(
+      payload,
+      (frame) => frame[0] === WE_CMD_WRITE_EEPROM
+        && frame[1] === 0
+        && frame[2] === ((address >> 8) & 0xff)
+        && frame[3] === (address & 0xff)
+        && frame[4] === data.length
+        && this.hasValidChecksum(frame)
+        && data.every((byte, index) => frame[DATA_OFFSET + index] === byte),
+    );
   }
 
   /**

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -276,7 +276,7 @@ export class AtkHidClient {
     const r1Extras = this.usesR1ProMaxUiTransport()
       ? await this.readR1Extras(stageCount)
       : null;
-    const stored = this.usesVerifiedR1WiredTransport()
+    const stored = this.usesR1ProMaxUiTransport()
       ? await this.readR1StoredConfiguration().catch(() => null)
       : null;
     const receiver = this.usesR1LiveSettings()
@@ -348,8 +348,8 @@ export class AtkHidClient {
     buttons: NonNullable<MouseStatus["atkButtonMappings"]>;
   }> {
     await this.identify();
-    if (!this.usesVerifiedR1WiredTransport()) {
-      throw new Error("Stored R1 configuration inspection is available only over the verified wired transport.");
+    if (!this.usesR1ProMaxUiTransport()) {
+      throw new Error("Stored R1 configuration inspection is not available on this connection.");
     }
     const activeProfile = await this.readR1CurrentProfile();
 
@@ -378,19 +378,38 @@ export class AtkHidClient {
     return { activeProfile: activeProfile + 1, buttons };
   }
 
-  /** Select one of the four verified wired R1 banks and require readback. */
+  /** Select one of the four verified R1 banks and require readback. */
   async setR1ActiveProfile(profile: number): Promise<number> {
     await this.identify();
-    if (!this.usesVerifiedR1WiredTransport()) {
-      throw new Error("R1 profile switching is available only over the verified wired transport.");
+
+    const receiver = this.usesVerifiedR1ProMaxReceiverTransport();
+    if (!this.usesVerifiedR1WiredTransport() && !receiver) {
+      throw new Error("R1 profile switching is not available on this connection.");
     }
+
     if (!Number.isInteger(profile) || profile < 1 || profile > ATK_R1_PROFILE_COUNT) {
       throw new Error(`R1 profile must be between 1 and ${ATK_R1_PROFILE_COUNT}.`);
     }
-    await this.send(atkBuildSetCurrentProfile(profile - 1));
+
+    const frame = atkBuildSetCurrentProfile(profile - 1);
+
+    if (receiver) {
+      await this.exchange(
+        frame,
+        (reply) => reply.length === frame.length
+          && reply.every((byte, index) => byte === frame[index]),
+      );
+    } else {
+      await this.send(frame);
+    }
+
     await delay(R1_PROFILE_SWITCH_SETTLE_MS);
+
     const confirmed = (await this.readR1CurrentProfile()) + 1;
-    if (confirmed !== profile) throw new Error(`The mouse kept profile ${confirmed} instead of ${profile}.`);
+    if (confirmed !== profile) {
+      throw new Error(`The mouse kept profile ${confirmed} instead of ${profile}.`);
+    }
+
     this.lastStatus = null;
     return confirmed;
   }

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -273,7 +273,9 @@ export class AtkHidClient {
     const liftOffDistance = await this.read(REGISTER.liftOffDistance, 2);
     const advanced = await this.read(REGISTER.advanced, ADVANCED_LENGTH);
     const angle = await this.read(REGISTER.angle, ANGLE_LENGTH).catch(() => null);
-    const r1Extras = this.usesVerifiedR1WiredTransport() ? await this.readR1Extras(stageCount) : null;
+    const r1Extras = this.usesR1ProMaxUiTransport()
+      ? await this.readR1Extras(stageCount)
+      : null;
     const stored = this.usesVerifiedR1WiredTransport()
       ? await this.readR1StoredConfiguration().catch(() => null)
       : null;
@@ -290,7 +292,7 @@ export class AtkHidClient {
         family: "atk",
         hideUnsupportedPollingRates: true,
         forceShowBattery: battery !== null,
-        dpiStageEditor: this.usesVerifiedR1WiredTransport() ? {
+        dpiStageEditor: this.usesR1ProMaxUiTransport() ? {
           maxStages: R1_MAX_DPI_STAGES,
           countEditable: true,
           minDpi: sensorProfile?.minDpi ?? DPI_MIN,
@@ -614,9 +616,16 @@ export class AtkHidClient {
   }
 
   async setPerformanceMode(enabled: boolean): Promise<boolean> {
-    const confirmed = await this.writeR1PerformanceBlock((block) => {
+    await this.identify();
+
+    const change = (block: number[]): void => {
       block.splice(4, 2, ...wePackScalarPair(enabled ? 1 : 0));
-    });
+    };
+
+    const confirmed = this.usesVerifiedR1ProMaxReceiverTransport()
+      ? await this.writeR1ProMaxReceiverPerformanceBlock(change)
+      : await this.writeR1PerformanceBlock(change);
+
     const value = weUnpackScalarPair(confirmed[4]!, confirmed[5]!) === 1;
     if (value !== enabled) throw new Error(`The mouse left performance mode ${value ? "on" : "off"}.`);
     this.patch({ performanceMode: value });
@@ -1030,6 +1039,50 @@ export class AtkHidClient {
     return reply[DATA_OFFSET] === 1;
   }
 
+  /**
+   * F58A Performance Mode uses the same 6-byte 0x00b5 row as wired, but
+   * receiver writes are enabled only after their write/echo path was captured.
+   */
+  private async writeR1ProMaxReceiverPerformanceBlock(
+    change: (block: number[]) => void,
+  ): Promise<Uint8Array> {
+    await this.identify();
+
+    if (!this.usesVerifiedR1ProMaxReceiverTransport()) {
+      throw new Error("Performance mode is not available on this connection.");
+    }
+
+    const address = REGISTER.sensorPerformance;
+    const block = Array.from(
+      await this.read(address, R1_SENSOR_PERFORMANCE_LENGTH),
+    );
+    change(block);
+
+    const payload = weBuildCmdPayload(
+      WE_CMD_WRITE_EEPROM,
+      [
+        0,
+        (address >> 8) & 0xff,
+        address & 0xff,
+        block.length,
+        ...block,
+      ],
+    );
+
+    await this.exchange(
+      payload,
+      (frame) => frame[0] === WE_CMD_WRITE_EEPROM
+        && frame[1] === 0
+        && frame[2] === ((address >> 8) & 0xff)
+        && frame[3] === (address & 0xff)
+        && frame[4] === block.length
+        && this.hasValidChecksum(frame)
+        && block.every((byte, index) => frame[DATA_OFFSET + index] === byte),
+    );
+
+    return await this.read(address, R1_SENSOR_PERFORMANCE_LENGTH);
+  }
+
   private async writeR1PerformanceBlock(change: (block: number[]) => void): Promise<Uint8Array> {
     await this.identify();
     if (!this.usesVerifiedR1WiredTransport()) {
@@ -1230,6 +1283,15 @@ export class AtkHidClient {
     return this.device.vendorId === VENDOR_ID.vgn
       && this.device.productId === VXE_R1_PRO_MAX_RECEIVER_PID
       && this.isR1ProMax();
+  }
+
+  /**
+   * Wired F58C and receiver F58A expose the same R1 Pro Max settings surface.
+   * This predicate is for reads/UI only; write paths remain individually gated.
+   */
+  private usesR1ProMaxUiTransport(): boolean {
+    return this.usesVerifiedR1WiredTransport()
+      || this.usesVerifiedR1ProMaxReceiverTransport();
   }
 
   private usesVerifiedR1WiredTransport(): boolean {

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -819,16 +819,24 @@ export class AtkHidClient {
     const speedIndex = R1_DPI_SPEED.indexOf(speed as typeof R1_DPI_SPEED[number]);
 
     if (brightnessIndex < 0 || speedIndex < 0 || (enabled !== 0 && enabled !== 1)) return null;
-    if (enabled === 0) {
-      if (effect !== 0 && effect !== 1) return null;
+
+    // R1 Pro Max may report the trailing flag as 0 after reconnect even when
+    // the stored effect is Breathing. Treat the effect field as authoritative.
+    // Keep effect=1 + enabled=0 as the legacy Off encoding used by other R1s.
+    if (effect === 0) {
       return { dpiLedMode: 0, dpiLedBrightness: brightnessIndex, dpiLedSpeed: speedIndex };
     }
-    if (effect !== 1 && effect !== 2) return null;
-    return {
-      dpiLedMode: effect === 2 ? 2 : 1,
-      dpiLedBrightness: brightnessIndex,
-      dpiLedSpeed: speedIndex,
-    };
+    if (effect === 2) {
+      return { dpiLedMode: 2, dpiLedBrightness: brightnessIndex, dpiLedSpeed: speedIndex };
+    }
+    if (effect === 1) {
+      return {
+        dpiLedMode: enabled === 0 ? 0 : 1,
+        dpiLedBrightness: brightnessIndex,
+        dpiLedSpeed: speedIndex,
+      };
+    }
+    return null;
   }
 
   private async readLongRangeMode(): Promise<boolean> {

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -1,4 +1,4 @@
-import {
+﻿import {
   WE_CMD_READ_EEPROM,
   WE_CMD_WRITE_EEPROM,
   WE_REPORT_ID,
@@ -41,7 +41,7 @@ import {
 import { type AtkProduct, ATK_COMPX_PRODUCT_IDS, ATK_PRODUCTS } from "./products.ts";
 
 // ATK mice (A9 family and siblings) use the same OEM framing as the Endgame
-// Gear WE series — 16-byte EEPROM commands on report 0x08 — but carry them on
+// Gear WE series â€” 16-byte EEPROM commands on report 0x08 â€” but carry them on
 // output/input reports rather than feature reports.
 const BATTERY_COMMAND = 0x04;
 const VERSION_COMMAND = 0x12;
@@ -291,7 +291,7 @@ export class AtkHidClient {
         forceShowBattery: battery !== null,
         dpiStageEditor: this.usesVerifiedR1WiredTransport() ? {
           maxStages: R1_MAX_DPI_STAGES,
-          countEditable: false,
+          countEditable: true,
           minDpi: sensorProfile?.minDpi ?? DPI_MIN,
           maxDpi: sensorProfile?.maxDpi ?? DPI_MAX,
           stepDpi: 50,
@@ -467,6 +467,52 @@ export class AtkHidClient {
     return confirmed.x;
   }
 
+  async setDpiStageCount(count: number): Promise<number> {
+    await this.identify();
+    if (!this.usesVerifiedR1WiredTransport()) {
+      throw new Error("R1 DPI stage count editing is available only over a verified wired transport.");
+    }
+    if (!Number.isInteger(count) || count < 1 || count > R1_MAX_DPI_STAGES) {
+      throw new Error(`DPI stage count must be between 1 and ${R1_MAX_DPI_STAGES}.`);
+    }
+
+    // The vendor writes the complete 10-byte system row when changing the
+    // stage count. Preserve the unknown tail and clamp the active stage in the
+    // same transaction so the row can never temporarily point past the end.
+    const system = Array.from(await this.read(REGISTER.system, 10));
+    const previousActive = Math.min(system[4]!, Math.max(system[2]!, 1) - 1);
+    const active = Math.min(previousActive, count - 1);
+    system.splice(2, 2, ...wePackScalarPair(count));
+    system.splice(4, 2, ...wePackScalarPair(active));
+    await this.write(REGISTER.system, system);
+
+    const confirmedSystem = await this.read(REGISTER.system, 10);
+    const confirmedCount = this.stageCount(confirmedSystem);
+    const confirmedActive = this.stageIndex(confirmedSystem);
+    if (confirmedCount !== count || confirmedActive !== active) {
+      throw new Error(
+        `The mouse kept ${confirmedCount} DPI stages with stage ${confirmedActive + 1} active instead of ${count}.`,
+      );
+    }
+
+    const stages: number[] = [];
+    let activeStage: { x: number; y: number } | null = null;
+    for (let index = 0; index < confirmedCount; index += 1) {
+      const stage = await this.readDpiStage(index);
+      stages.push(stage.x);
+      if (index === confirmedActive) activeStage = stage;
+    }
+    if (!activeStage) throw new Error("The active DPI stage could not be read back.");
+
+    this.patch({
+      dpiStages: stages,
+      activeDpiStage: confirmedActive,
+      dpi: activeStage.x,
+      dpiY: activeStage.y,
+    });
+    return confirmedCount;
+  }
+
   async setActiveDpiStage(index: number): Promise<number> {
     await this.identify();
     if (this.isR1() && !this.usesVerifiedR1WiredTransport()) {
@@ -570,17 +616,42 @@ export class AtkHidClient {
     if (![0, 1, 2].includes(mode) || ![0, 1, 2].includes(brightness) || ![0, 1, 2].includes(speed)) {
       throw new Error("The DPI lighting setting is invalid.");
     }
+
+    // Captured R1 Pro Max rows use literal 00 00 for fields that are inactive:
+    // Off       = 00 00 | 00 00 | speed | 00 55
+    // Always On = 01 54 | brightness | speed | 01 54
+    // Breathing = 02 53 | 00 00 | speed | 01 54
     const block = Array.from(await this.read(REGISTER.dpiLighting, R1_DPI_LIGHTING_LENGTH));
-    const effect = mode === 2 ? 2 : 1;
-    block.splice(0, 2, ...wePackScalarPair(effect));
-    block.splice(2, 2, ...wePackScalarPair(R1_DPI_BRIGHTNESS[brightness]!));
+    const proMax = this.isR1ProMax();
+
+    const expectedEffect = proMax && mode === 0
+      ? [0, 0]
+      : wePackScalarPair(mode === 2 ? 2 : 1);
+
+    const expectedBrightness = proMax && mode === 2
+      ? [block[2]!, block[3]!]
+      : mode === 0
+        ? [0, 0]
+        : wePackScalarPair(R1_DPI_BRIGHTNESS[brightness]!);
+
+    block.splice(0, 2, ...expectedEffect);
+    block.splice(2, 2, ...expectedBrightness);
     block.splice(4, 2, ...wePackScalarPair(R1_DPI_SPEED[speed]!));
     block.splice(6, 2, ...wePackScalarPair(mode === 0 ? 0 : 1));
     await this.write(REGISTER.dpiLighting, block);
-    const confirmed = this.decodeR1DpiLighting(await this.read(REGISTER.dpiLighting, R1_DPI_LIGHTING_LENGTH));
-    if (!confirmed || confirmed.dpiLedMode !== mode
-      || confirmed.dpiLedBrightness !== brightness || confirmed.dpiLedSpeed !== speed) {
+
+    const raw = await this.read(REGISTER.dpiLighting, R1_DPI_LIGHTING_LENGTH);
+    const expectedSpeed = wePackScalarPair(R1_DPI_SPEED[speed]!);
+    const expectedEnabled = wePackScalarPair(mode === 0 ? 0 : 1);
+    const expected = [...expectedEffect, ...expectedBrightness, ...expectedSpeed, ...expectedEnabled];
+    if (!expected.every((byte, index) => raw[index] === byte)) {
       throw new Error("The mouse did not retain its DPI lighting settings.");
+    }
+
+    const confirmed = this.decodeR1DpiLighting(raw);
+    if (!confirmed || confirmed.dpiLedMode !== mode || confirmed.dpiLedSpeed !== speed
+      || (mode === 1 && confirmed.dpiLedBrightness !== brightness)) {
+      throw new Error("The mouse returned an invalid DPI lighting state.");
     }
     this.patch(confirmed);
   }
@@ -735,16 +806,26 @@ export class AtkHidClient {
     dpiLedSpeed: number;
   } | null {
     if (block.length < R1_DPI_LIGHTING_LENGTH) return null;
-    const effect = weUnpackScalarPair(block[0]!, block[1]!);
-    const brightness = weUnpackScalarPair(block[2]!, block[3]!);
+
+    const effectIsZero = block[0] === 0 && block[1] === 0;
+    const brightnessIsZero = block[2] === 0 && block[3] === 0;
+    const effect = effectIsZero ? 0 : weUnpackScalarPair(block[0]!, block[1]!);
+    const brightness = brightnessIsZero ? null : weUnpackScalarPair(block[2]!, block[3]!);
     const speed = weUnpackScalarPair(block[4]!, block[5]!);
     const enabled = weUnpackScalarPair(block[6]!, block[7]!);
-    const brightnessIndex = R1_DPI_BRIGHTNESS.indexOf(brightness as typeof R1_DPI_BRIGHTNESS[number]);
+    const brightnessIndex = brightness === null
+      ? 1 // inactive brightness is not persisted; vendor UI defaults it to Medium
+      : R1_DPI_BRIGHTNESS.indexOf(brightness as typeof R1_DPI_BRIGHTNESS[number]);
     const speedIndex = R1_DPI_SPEED.indexOf(speed as typeof R1_DPI_SPEED[number]);
-    if ((effect !== 1 && effect !== 2) || brightnessIndex < 0 || speedIndex < 0
-      || (enabled !== 0 && enabled !== 1)) return null;
+
+    if (brightnessIndex < 0 || speedIndex < 0 || (enabled !== 0 && enabled !== 1)) return null;
+    if (enabled === 0) {
+      if (effect !== 0 && effect !== 1) return null;
+      return { dpiLedMode: 0, dpiLedBrightness: brightnessIndex, dpiLedSpeed: speedIndex };
+    }
+    if (effect !== 1 && effect !== 2) return null;
     return {
-      dpiLedMode: enabled === 0 ? 0 : effect === 2 ? 2 : 1,
+      dpiLedMode: effect === 2 ? 2 : 1,
       dpiLedBrightness: brightnessIndex,
       dpiLedSpeed: speedIndex,
     };
@@ -1043,7 +1124,7 @@ export class AtkHidClient {
         };
         const timer = setTimeout(() => {
           finish();
-          reject(new Error("The mouse did not answer — it may be asleep or out of range."));
+          reject(new Error("The mouse did not answer â€” it may be asleep or out of range."));
         }, REPLY_TIMEOUT_MS);
         const listener = (event: HIDInputReportEvent) => {
           if (event.reportId !== WE_REPORT_ID) return;

--- a/src/drivers/atk/hid.ts
+++ b/src/drivers/atk/hid.ts
@@ -486,8 +486,11 @@ export class AtkHidClient {
 
   async setDpiStageCount(count: number): Promise<number> {
     await this.identify();
-    if (!this.usesVerifiedR1WiredTransport()) {
-      throw new Error("R1 DPI stage count editing is available only over a verified wired transport.");
+    if (
+      !this.usesVerifiedR1WiredTransport()
+      && !this.usesVerifiedR1ProMaxReceiverTransport()
+    ) {
+      throw new Error("R1 DPI stage count editing is not available on this connection.");
     }
     if (!Number.isInteger(count) || count < 1 || count > R1_MAX_DPI_STAGES) {
       throw new Error(`DPI stage count must be between 1 and ${R1_MAX_DPI_STAGES}.`);
@@ -501,7 +504,12 @@ export class AtkHidClient {
     const active = Math.min(previousActive, count - 1);
     system.splice(2, 2, ...wePackScalarPair(count));
     system.splice(4, 2, ...wePackScalarPair(active));
-    await this.write(REGISTER.system, system);
+
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      await this.writeR1ProMaxReceiverSystem(system);
+    } else {
+      await this.write(REGISTER.system, system);
+    }
 
     const confirmedSystem = await this.read(REGISTER.system, 10);
     const confirmedCount = this.stageCount(confirmedSystem);
@@ -532,27 +540,71 @@ export class AtkHidClient {
 
   async setActiveDpiStage(index: number): Promise<number> {
     await this.identify();
-    if (this.isR1() && !this.usesVerifiedR1WiredTransport()) {
-      throw new Error("R1 DPI stage selection is available only over a verified wired transport.");
+
+    if (
+      this.isR1()
+      && !this.usesVerifiedR1WiredTransport()
+      && !this.usesVerifiedR1ProMaxReceiverTransport()
+    ) {
+      throw new Error("R1 DPI stage selection is not available on this connection.");
     }
-    const system = await this.read(REGISTER.system, SYSTEM_LENGTH);
+
+    const receiver = this.usesVerifiedR1ProMaxReceiverTransport();
+    const system = await this.read(
+      REGISTER.system,
+      receiver ? R1_SYSTEM_ROW_LENGTH : SYSTEM_LENGTH,
+    );
     const count = this.stageCount(system);
+
     if (!Number.isInteger(index) || index < 0 || index >= count) {
       throw new Error(`DPI stage must be between 1 and ${count}.`);
     }
-    await this.write(REGISTER.system + 4, wePackScalarPair(index));
-    const pair = await this.read(REGISTER.system + 4, 2);
-    const confirmed = weUnpackScalarPair(pair[0]!, pair[1]!);
-    if (confirmed !== index) throw new Error(`The mouse kept DPI stage ${(confirmed ?? 0) + 1} instead of ${index + 1}.`);
+
+    let confirmed: number | null;
+
+    if (receiver) {
+      const row = Array.from(system);
+      row.splice(4, 2, ...wePackScalarPair(index));
+
+      await this.writeR1ProMaxReceiverSystem(row);
+
+      const confirmedSystem = await this.read(
+        REGISTER.system,
+        R1_SYSTEM_ROW_LENGTH,
+      );
+      confirmed = weUnpackScalarPair(
+        confirmedSystem[4]!,
+        confirmedSystem[5]!,
+      );
+    } else {
+      await this.write(REGISTER.system + 4, wePackScalarPair(index));
+      const pair = await this.read(REGISTER.system + 4, 2);
+      confirmed = weUnpackScalarPair(pair[0]!, pair[1]!);
+    }
+
+    if (confirmed !== index) {
+      throw new Error(
+        `The mouse kept DPI stage ${(confirmed ?? 0) + 1} instead of ${index + 1}.`,
+      );
+    }
+
     const stage = await this.readDpiStage(index);
-    this.patch({ activeDpiStage: confirmed, dpi: stage.x, dpiY: stage.y });
+    this.patch({
+      activeDpiStage: confirmed,
+      dpi: stage.x,
+      dpiY: stage.y,
+    });
     return confirmed;
   }
 
   async setDpiStageValue(index: number, dpi: number): Promise<number> {
     await this.identify();
-    if (this.isR1() && !this.usesVerifiedR1WiredTransport()) {
-      throw new Error("R1 DPI stage editing is available only over a verified wired transport.");
+    if (
+      this.isR1()
+      && !this.usesVerifiedR1WiredTransport()
+      && !this.usesVerifiedR1ProMaxReceiverTransport()
+    ) {
+      throw new Error("R1 DPI stage editing is not available on this connection.");
     }
     const system = await this.read(REGISTER.system, SYSTEM_LENGTH);
     const count = this.stageCount(system);
@@ -566,7 +618,12 @@ export class AtkHidClient {
     }
     const packed = sensor ? atkPackDpiStageForSensor(sensor, dpi, dpi) : atkPackDpiStage(dpi, dpi);
     if (!packed) throw new Error(`${dpi.toLocaleString()} DPI is not representable by this sensor.`);
-    await this.write(this.dpiAddress(index), packed);
+    if (this.usesVerifiedR1ProMaxReceiverTransport()) {
+      await this.writeR1ProMaxReceiverDpiStage(index, packed);
+    } else {
+      await this.write(this.dpiAddress(index), packed);
+    }
+
     const confirmed = await this.readDpiStage(index);
     if (confirmed.x !== dpi || confirmed.y !== dpi) {
       throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()}.`);

--- a/src/drivers/atk/products.ts
+++ b/src/drivers/atk/products.ts
@@ -15,8 +15,9 @@ export const ATK_PRODUCTS: Record<string, AtkProduct> = {
   "1,52": { brand: "ATK", model: "A9 Mini +", sensor: "PAW3955Master", verified: true },
   "2,11": { brand: "VXE", model: "R1", sensor: "PAW3395", family: "r1", verified: false },
   "2,12": { brand: "VXE", model: "R1", sensor: "PAW3395", family: "r1", verified: true },
+  "2,27": { brand: "VXE", model: "R1 Pro Max", sensor: "PAW3395", family: "r1", verified: true },
   "2,32": { brand: "VXE", model: "R1 SE+", sensor: "PAW3395SE", family: "r1", verified: true },
 };
 
-/** Known VXE R1 SE+ transports under COMPX's shared vendor id. */
-export const ATK_COMPX_PRODUCT_IDS: readonly number[] = [0xf58e, 0xf58f];
+/** Known VXE R1-family transports under COMPX's shared vendor id. */
+export const ATK_COMPX_PRODUCT_IDS: readonly number[] = [0xf58a, 0xf58c, 0xf58e, 0xf58f];

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -158,3 +158,43 @@ test("R1 Pro Max receiver stays read-only for persistent EEPROM until its write 
   );
   assert.equal(writes(fake).length, 0);
 });
+
+
+test("R1 Pro Max wired transport edits DPI stage count and clamps the active stage", async () => {
+  const fake = device(0xf58c, "VXE R1 Pro Max");
+  const stage = atkPackDpiStageForSensor("PAW3395", 1600, 1600)!;
+  (fake as unknown as FakeR1ProMaxDevice).replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, [0x02, 0x53, 0x03, 0x52, 0x02, 0x53, 0x00, 0x55, 0x00, 0x55]),
+    reply(0x08, 0x0000, [0x02, 0x53, 0x02, 0x53, 0x01, 0x54, 0x00, 0x55, 0x00, 0x55]),
+    reply(0x08, 0x000c, stage),
+    reply(0x08, 0x0010, stage),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setDpiStageCount(2), 2);
+
+  const write = writes(fake).find((frame) => frame[2] === 0x00 && frame[3] === 0x00 && frame[4] === 0x0a);
+  assert.ok(write);
+  assert.deepEqual([...write!.subarray(5, 11)], [0x02, 0x53, 0x02, 0x53, 0x01, 0x54]);
+});
+
+test("R1 Pro Max DPI lighting writes the vendor-captured rows", async () => {
+  for (const sample of [
+    { mode: 0, brightness: 1, speed: 1, expected: [0x00, 0x00, 0x00, 0x00, 0x03, 0x52, 0x00, 0x55] },
+    { mode: 1, brightness: 1, speed: 1, expected: [0x01, 0x54, 0x80, 0xd5, 0x03, 0x52, 0x01, 0x54] },
+    { mode: 2, brightness: 1, speed: 1, expected: [0x02, 0x53, 0x80, 0xd5, 0x03, 0x52, 0x01, 0x54] },
+  ]) {
+    const fake = device(0xf58c, "VXE R1 Pro Max");
+    (fake as unknown as FakeR1ProMaxDevice).replies = [
+      reply(0x10, 0, [0x02, 0x1b]),
+      reply(0x08, 0x004c, [0x01, 0x54, 0x80, 0xd5, 0x03, 0x52, 0x01, 0x54]),
+      reply(0x08, 0x004c, sample.expected),
+    ];
+
+    await new AtkHidClient(fake).setDpiLighting(sample.mode, sample.brightness, sample.speed);
+    const write = writes(fake).find((frame) => frame[2] === 0x00 && frame[3] === 0x4c);
+    assert.ok(write);
+    assert.deepEqual([...write!.subarray(5, 13)], sample.expected);
+  }
+});

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -22,6 +22,7 @@ class FakeR1ProMaxDevice {
 
   readonly sent: Sent[] = [];
   replies: number[][] = [];
+  writeReplies: number[][] = [];
   private listeners = new Set<(event: HIDInputReportEvent) => void>();
 
   constructor(productId: number, productName: string) {
@@ -58,8 +59,9 @@ class FakeR1ProMaxDevice {
   async sendReport(reportId: number, data: ArrayBuffer): Promise<void> {
     const frame = new Uint8Array(data);
     this.sent.push({ reportId, data: frame });
-    if (frame[0] === 0x07) return;
-    const reply = this.replies.shift();
+    const reply = frame[0] === 0x07
+      ? this.writeReplies.shift()
+      : this.replies.shift();
     if (!reply) return;
     const payload = new Uint8Array(reply);
     queueMicrotask(() => {
@@ -148,12 +150,51 @@ test("R1 Pro Max wired transport accepts PAW3395 30K DPI with independent X/Y va
   assert.deepEqual([...write!.subarray(5, 9)], packed);
 });
 
-test("R1 Pro Max receiver stays read-only for persistent EEPROM until its write path is verified", async () => {
+test("R1 Pro Max receiver writes polling with the vendor-captured full system row", async () => {
   const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
-  (fake as unknown as FakeR1ProMaxDevice).replies = [reply(0x10, 0, [0x02, 0x1b])];
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+  const before = [
+    0x01, 0x54,
+    0x01, 0x54,
+    0x00, 0x55,
+    0x00, 0x00, 0x00, 0x55,
+  ];
+  const after = [
+    0x02, 0x53,
+    0x01, 0x54,
+    0x00, 0x55,
+    0x00, 0x00, 0x00, 0x55,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, before),
+    reply(0x08, 0x0000, after),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x0000, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setPollingRate(500), 500);
+
+  const write = writes(fake)[0];
+  assert.ok(write);
+  assert.equal(write![2], 0x00);
+  assert.equal(write![3], 0x00);
+  assert.equal(write![4], 0x0a);
+  assert.deepEqual([...write!.subarray(5, 15)], after);
+  assert.equal(writes(fake).some((frame) => frame[3] === 0x70), false);
+});
+
+test("R1 Pro Max receiver keeps unverified persistent writes blocked", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  (fake as unknown as FakeR1ProMaxDevice).replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+  ];
 
   await assert.rejects(
-    new AtkHidClient(fake).setPollingRate(500),
+    new AtkHidClient(fake).setDpiStageValue(0, 800),
     /verified wired transport/,
   );
   assert.equal(writes(fake).length, 0);

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -150,6 +150,41 @@ test("R1 Pro Max wired transport accepts PAW3395 30K DPI with independent X/Y va
   assert.deepEqual([...write!.subarray(5, 9)], packed);
 });
 
+test("R1 Pro Max receiver writes active DPI as the vendor-captured two-stage group", async () => {
+  const target = atkPackDpiStageForSensor("PAW3395", 3200, 3200)!;
+  const previous = atkPackDpiStageForSensor("PAW3395", 4000, 4000)!;
+  const neighbour = atkPackDpiStageForSensor("PAW3395", 3200, 3200)!;
+
+  assert.deepEqual(target, [0x3f, 0x3f, 0x00, 0xd7]);
+  assert.deepEqual(previous, [0x4f, 0x4f, 0x00, 0xb7]);
+
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+  const beforeGroup = [...previous, ...neighbour];
+  const afterGroup = [...target, ...neighbour];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, SYSTEM_1000_HZ_ONE_STAGE),
+    reply(0x08, 0x000c, beforeGroup),
+    reply(0x08, 0x000c, target),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x000c, afterGroup),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setDpi(3200), 3200);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0x0c,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x08);
+  assert.deepEqual([...write!.subarray(5, 13)], afterGroup);
+});
+
 test("R1 Pro Max receiver writes polling with the vendor-captured full system row", async () => {
   const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
   const hardware = fake as unknown as FakeR1ProMaxDevice;

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -346,6 +346,33 @@ test("R1 Pro Max receiver writes DPI lighting mode through the captured 0x004c r
   assert.deepEqual([...write!.subarray(5, 13)], breathing);
 });
 
+test("R1 Pro Max receiver writes Long Range through the captured 0x16 command", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const enabled = [
+    0x01,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x16, 0, enabled),
+    reply(0x17, 0, [0x01]),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setLongRangeMode(true), true);
+
+  const sent = hardware.sent.find(
+    ({ reportId, data }) => reportId === 8 && data[0] === 0x16,
+  );
+
+  assert.ok(sent);
+  assert.deepEqual([...sent!.data], reply(0x16, 0, enabled));
+});
+
 test("R1 Pro Max receiver writes Performance Mode through the captured 0x00b5 row", async () => {
   const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
   const hardware = fake as unknown as FakeR1ProMaxDevice;

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -150,6 +150,30 @@ test("R1 Pro Max wired transport accepts PAW3395 30K DPI with independent X/Y va
   assert.deepEqual([...write!.subarray(5, 9)], packed);
 });
 
+test("R1 Pro Max receiver writes lift-off distance through the captured EEPROM pair", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x000a, [0x02, 0x53]),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x000a, [0x02, 0x53]),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setLiftOffDistance("High"), "High");
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0x0a,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x02);
+  assert.deepEqual([...write!.subarray(5, 7)], [0x02, 0x53]);
+});
+
 test("R1 Pro Max receiver writes active DPI as the vendor-captured two-stage group", async () => {
   const target = atkPackDpiStageForSensor("PAW3395", 3200, 3200)!;
   const previous = atkPackDpiStageForSensor("PAW3395", 4000, 4000)!;

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -705,6 +705,27 @@ test("R1 Pro Max receiver writes polling with the vendor-captured full system ro
   assert.equal(writes(fake).some((frame) => frame[3] === 0x70), false);
 });
 
+test("R1 Pro Max receiver switches profiles through the captured 0x0f command", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x0f, 0, [0x01]),
+    reply(0x0e, 0, [0x01]),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setR1ActiveProfile(2), 2);
+
+  const sent = hardware.sent.find(
+    ({ reportId, data }) => reportId === 8 && data[0] === 0x0f,
+  );
+
+  assert.ok(sent);
+  assert.deepEqual([...sent!.data], reply(0x0f, 0, [0x01]));
+});
+
 test("R1 Pro Max wired transport edits DPI stage count and clamps the active stage", async () => {
   const fake = device(0xf58c, "VXE R1 Pro Max");
   const stage = atkPackDpiStageForSensor("PAW3395", 1600, 1600)!;

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -150,6 +150,129 @@ test("R1 Pro Max wired transport accepts PAW3395 30K DPI with independent X/Y va
   assert.deepEqual([...write!.subarray(5, 9)], packed);
 });
 
+test("R1 Pro Max receiver writes a non-active DPI stage through the captured two-stage group", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const before = [
+    0x4f, 0x4f, 0x00, 0xb7,
+    0x3f, 0x3f, 0x00, 0xd7,
+  ];
+  const after = [
+    0x4f, 0x4f, 0x00, 0xb7,
+    0x1f, 0x1f, 0x00, 0x17,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, [
+      0x01, 0x54,
+      0x02, 0x53,
+      0x00, 0x55,
+    ]),
+    reply(0x08, 0x000c, before),
+    reply(0x08, 0x0010, [
+      0x1f, 0x1f, 0x00, 0x17,
+    ]),
+  ];
+
+  hardware.writeReplies = [
+    reply(0x07, 0x000c, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setDpiStageValue(1, 1600), 1600);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0x0c,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x08);
+  assert.deepEqual([...write!.subarray(5, 13)], after);
+});
+
+test("R1 Pro Max receiver selects the active DPI stage through the captured full system row", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const stage1 = [
+    0x01, 0x54,
+    0x02, 0x53,
+    0x00, 0x55,
+    0x00, 0x00, 0x00, 0x55,
+  ];
+
+  const stage2 = [
+    0x01, 0x54,
+    0x02, 0x53,
+    0x01, 0x54,
+    0x00, 0x00, 0x00, 0x55,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, stage1),
+    reply(0x08, 0x0000, stage2),
+    reply(0x08, 0x0010, [0x3f, 0x3f, 0x00, 0xd7]),
+  ];
+
+  hardware.writeReplies = [
+    reply(0x07, 0x0000, stage2),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setActiveDpiStage(1), 1);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0x00,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x0a);
+  assert.deepEqual([...write!.subarray(5, 15)], stage2);
+});
+
+test("R1 Pro Max receiver writes DPI stage count through the captured full system row", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const oneStage = [
+    0x01, 0x54,
+    0x01, 0x54,
+    0x00, 0x55,
+    0x00, 0x00, 0x00, 0x55,
+  ];
+  const twoStages = [
+    0x01, 0x54,
+    0x02, 0x53,
+    0x00, 0x55,
+    0x00, 0x00, 0x00, 0x55,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, oneStage),
+    reply(0x08, 0x0000, twoStages),
+    reply(0x08, 0x000c, [0x4f, 0x4f, 0x00, 0xb7]),
+    reply(0x08, 0x0010, [0x3f, 0x3f, 0x00, 0xd7]),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x0000, twoStages),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setDpiStageCount(2), 2);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0x00,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x0a);
+  assert.deepEqual([...write!.subarray(5, 15)], twoStages);
+});
+
 test("R1 Pro Max receiver writes DPI stage colour through the captured two-stage group", async () => {
   const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
   const hardware = fake as unknown as FakeR1ProMaxDevice;
@@ -554,20 +677,6 @@ test("R1 Pro Max receiver writes polling with the vendor-captured full system ro
   assert.deepEqual([...write!.subarray(5, 15)], after);
   assert.equal(writes(fake).some((frame) => frame[3] === 0x70), false);
 });
-
-test("R1 Pro Max receiver keeps unverified persistent writes blocked", async () => {
-  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
-  (fake as unknown as FakeR1ProMaxDevice).replies = [
-    reply(0x10, 0, [0x02, 0x1b]),
-  ];
-
-  await assert.rejects(
-    new AtkHidClient(fake).setDpiStageValue(0, 800),
-    /verified wired transport/,
-  );
-  assert.equal(writes(fake).length, 0);
-});
-
 
 test("R1 Pro Max wired transport edits DPI stage count and clamps the active stage", async () => {
   const fake = device(0xf58c, "VXE R1 Pro Max");

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { atkPackDpiStageForSensor } from "@openmouse/protocol/atk";
+import { AtkHidClient } from "./hid.ts";
+
+type Sent = { reportId: number; data: Uint8Array };
+
+class FakeR1ProMaxDevice {
+  vendorId = 0x3554;
+  productId: number;
+  productName: string;
+  opened = false;
+  collections = [{
+    usagePage: 0xff02,
+    usage: 0x0002,
+    children: [],
+    featureReports: [],
+    inputReports: [],
+    outputReports: [],
+  }];
+
+  readonly sent: Sent[] = [];
+  replies: number[][] = [];
+  private listeners = new Set<(event: HIDInputReportEvent) => void>();
+
+  constructor(productId: number, productName: string) {
+    this.productId = productId;
+    this.productName = productName;
+  }
+
+  async open(): Promise<void> {
+    this.opened = true;
+  }
+
+  async close(): Promise<void> {
+    this.opened = false;
+  }
+
+  async forget(): Promise<void> {}
+
+  addEventListener(
+    type: string,
+    listener: (event: HIDInputReportEvent) => void,
+    _options?: boolean | AddEventListenerOptions,
+  ): void {
+    if (type === "inputreport") this.listeners.add(listener);
+  }
+
+  removeEventListener(
+    type: string,
+    listener: (event: HIDInputReportEvent) => void,
+    _options?: boolean | EventListenerOptions,
+  ): void {
+    if (type === "inputreport") this.listeners.delete(listener);
+  }
+
+  async sendReport(reportId: number, data: ArrayBuffer): Promise<void> {
+    const frame = new Uint8Array(data);
+    this.sent.push({ reportId, data: frame });
+    if (frame[0] === 0x07) return;
+    const reply = this.replies.shift();
+    if (!reply) return;
+    const payload = new Uint8Array(reply);
+    queueMicrotask(() => {
+      for (const listener of this.listeners) {
+        listener({ reportId, data: new DataView(payload.buffer) } as HIDInputReportEvent);
+      }
+    });
+  }
+
+  async sendFeatureReport(): Promise<void> {
+    throw new Error("not used");
+  }
+
+  async receiveFeatureReport(): Promise<DataView> {
+    throw new Error("not used");
+  }
+}
+
+function device(productId: number, productName: string): HIDDevice {
+  return new FakeR1ProMaxDevice(productId, productName) as unknown as HIDDevice;
+}
+
+function reply(command: number, address: number, data: number[]): number[] {
+  const frame = [command, 0x00, (address >> 8) & 0xff, address & 0xff, data.length, ...data];
+  while (frame.length < 16) frame.push(0x00);
+  frame[15] = (0x55 - 0x08 - frame.slice(0, 15).reduce((total, byte) => total + byte, 0)) & 0xff;
+  return frame;
+}
+
+function writes(fake: HIDDevice): Uint8Array[] {
+  return (fake as unknown as FakeR1ProMaxDevice).sent
+    .filter(({ reportId, data }) => reportId === 8 && data[0] === 0x07)
+    .map(({ data }) => data);
+}
+
+const SYSTEM_1000_HZ_ONE_STAGE = [0x01, 0x54, 0x01, 0x54, 0x00, 0x55];
+
+test("R1 Pro Max COMPX transports are recognized without using the SE+ live-rate table", () => {
+  const receiver = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const wired = device(0xf58c, "VXE R1 Pro Max");
+
+  assert.equal(AtkHidClient.isSupported(receiver), true);
+  assert.equal(AtkHidClient.isSupported(wired), true);
+  assert.equal(new AtkHidClient(receiver).isWireless(), true);
+  assert.equal(new AtkHidClient(wired).isWireless(), false);
+  assert.deepEqual(new AtkHidClient(receiver).getSupportedPollingRates(), [125, 250, 500, 1000]);
+  assert.deepEqual(new AtkHidClient(wired).getSupportedPollingRates(), [125, 250, 500, 1000]);
+});
+
+test("R1 Pro Max wired transport writes polling through the system EEPROM", async () => {
+  const fake = device(0xf58c, "VXE R1 Pro Max");
+  (fake as unknown as FakeR1ProMaxDevice).replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, [0x08, 0x4d, 0x01, 0x54, 0x00, 0x55]),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setPollingRate(125), 125);
+
+  const write = writes(fake)[0];
+  assert.ok(write);
+  assert.equal(write![2], 0x00);
+  assert.equal(write![3], 0x00);
+  assert.equal(write![4], 0x02);
+  assert.deepEqual([...write!.subarray(5, 7)], [0x08, 0x4d]);
+  assert.equal(writes(fake).some((frame) => frame[3] === 0x70), false);
+});
+
+test("R1 Pro Max wired transport accepts PAW3395 30K DPI with independent X/Y values", async () => {
+  const packed = atkPackDpiStageForSensor("PAW3395", 30000, 100);
+  assert.ok(packed);
+
+  const fake = device(0xf58c, "VXE R1 Pro Max");
+  (fake as unknown as FakeR1ProMaxDevice).replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, SYSTEM_1000_HZ_ONE_STAGE),
+    reply(0x08, 0x000c, packed!),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setDpi(30000, 100), 30000);
+  assert.equal(client.maxDpi(), 30000);
+
+  const write = writes(fake).find((frame) => frame[2] === 0x00 && frame[3] === 0x0c);
+  assert.ok(write);
+  assert.deepEqual([...write!.subarray(5, 9)], packed);
+});
+
+test("R1 Pro Max receiver stays read-only for persistent EEPROM until its write path is verified", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  (fake as unknown as FakeR1ProMaxDevice).replies = [reply(0x10, 0, [0x02, 0x1b])];
+
+  await assert.rejects(
+    new AtkHidClient(fake).setPollingRate(500),
+    /verified wired transport/,
+  );
+  assert.equal(writes(fake).length, 0);
+});

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -198,3 +198,27 @@ test("R1 Pro Max DPI lighting writes the vendor-captured rows", async () => {
     assert.deepEqual([...write!.subarray(5, 13)], sample.expected);
   }
 });
+
+test("R1 Pro Max accepts firmware-normalized Breathing state after reconnect", () => {
+  const fake = device(0xf58c, "VXE R1 Pro Max");
+  const client = new AtkHidClient(fake);
+
+  const decoded = (client as unknown as {
+    decodeR1DpiLighting(block: Uint8Array): {
+      dpiLedMode: number;
+      dpiLedBrightness: number;
+      dpiLedSpeed: number;
+    } | null;
+  }).decodeR1DpiLighting(Uint8Array.from([
+    0x02, 0x53,
+    0x80, 0xd5,
+    0x01, 0x54,
+    0x00, 0x55,
+  ]));
+
+  assert.deepEqual(decoded, {
+    dpiLedMode: 2,
+    dpiLedBrightness: 1,
+    dpiLedSpeed: 0,
+  });
+});

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -150,6 +150,79 @@ test("R1 Pro Max wired transport accepts PAW3395 30K DPI with independent X/Y va
   assert.deepEqual([...write!.subarray(5, 9)], packed);
 });
 
+test("R1 Pro Max receiver writes DPI stage colour through the captured two-stage group", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const before = [
+    0xff, 0x00, 0x00, 0x56,
+    0xff, 0x00, 0xff, 0x57,
+  ];
+  const after = [
+    0x00, 0xff, 0x00, 0x56,
+    0xff, 0x00, 0xff, 0x57,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x0000, SYSTEM_1000_HZ_ONE_STAGE),
+    reply(0x08, 0x002c, before),
+    reply(0x08, 0x002c, after),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x002c, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setDpiStageColor(0, "#00ff00"), "#00ff00");
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0x2c,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x08);
+  assert.deepEqual([...write!.subarray(5, 13)], after);
+});
+
+test("R1 Pro Max receiver writes DPI lighting mode through the captured 0x004c row", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const steady = [
+    0x01, 0x54,
+    0x80, 0xd5,
+    0x01, 0x54,
+    0x01, 0x54,
+  ];
+  const breathing = [
+    0x02, 0x53,
+    0x80, 0xd5,
+    0x01, 0x54,
+    0x01, 0x54,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x004c, steady),
+    reply(0x08, 0x004c, breathing),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x004c, breathing),
+  ];
+
+  const client = new AtkHidClient(fake);
+  await client.setDpiLighting(2, 1, 0);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0x4c,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x08);
+  assert.deepEqual([...write!.subarray(5, 13)], breathing);
+});
+
 test("R1 Pro Max receiver writes sleep timeout through the captured advanced block", async () => {
   const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
   const hardware = fake as unknown as FakeR1ProMaxDevice;

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -223,6 +223,42 @@ test("R1 Pro Max receiver writes DPI lighting mode through the captured 0x004c r
   assert.deepEqual([...write!.subarray(5, 13)], breathing);
 });
 
+test("R1 Pro Max receiver writes Performance Mode through the captured 0x00b5 row", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const before = [
+    0x01, 0x54,
+    0x12, 0x43,
+    0x01, 0x54,
+  ];
+  const after = [
+    0x01, 0x54,
+    0x12, 0x43,
+    0x00, 0x55,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x00b5, before),
+    reply(0x08, 0x00b5, after),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x00b5, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setPerformanceMode(false), false);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0xb5,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x06);
+  assert.deepEqual([...write!.subarray(5, 11)], after);
+});
+
 test("R1 Pro Max receiver writes sleep timeout through the captured advanced block", async () => {
   const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
   const hardware = fake as unknown as FakeR1ProMaxDevice;

--- a/src/drivers/atk/r1-pro-max-hid.test.ts
+++ b/src/drivers/atk/r1-pro-max-hid.test.ts
@@ -150,6 +150,206 @@ test("R1 Pro Max wired transport accepts PAW3395 30K DPI with independent X/Y va
   assert.deepEqual([...write!.subarray(5, 9)], packed);
 });
 
+test("R1 Pro Max receiver writes sleep timeout through the captured advanced block", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const before = [
+    0x04, 0x51,
+    0x00, 0x55,
+    0x06, 0x4f,
+    0x00, 0x55,
+    0x01, 0x54,
+  ];
+  const after = [
+    0x04, 0x51,
+    0x00, 0x55,
+    0x0c, 0x49,
+    0x00, 0x55,
+    0x01, 0x54,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x00a9, before),
+    reply(0x08, 0x00a9, after),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x00a9, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setSleepTimeout(120), 120);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0xa9,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x0a);
+  assert.deepEqual([...write!.subarray(5, 15)], after);
+});
+
+test("R1 Pro Max receiver writes angle snapping through the captured advanced block", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const before = [
+    0x04, 0x51,
+    0x00, 0x55,
+    0x06, 0x4f,
+    0x01, 0x54,
+    0x01, 0x54,
+  ];
+  const after = [
+    0x04, 0x51,
+    0x00, 0x55,
+    0x06, 0x4f,
+    0x00, 0x55,
+    0x01, 0x54,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x00a9, before),
+    reply(0x08, 0x00a9, after),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x00a9, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setAngleSnapping(false), false);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0xa9,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x0a);
+  assert.deepEqual([...write!.subarray(5, 15)], after);
+});
+
+test("R1 Pro Max receiver writes ripple control through the captured advanced block", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const before = [
+    0x04, 0x51,
+    0x01, 0x54,
+    0x06, 0x4f,
+    0x01, 0x54,
+    0x01, 0x54,
+  ];
+  const after = [
+    0x04, 0x51,
+    0x01, 0x54,
+    0x06, 0x4f,
+    0x01, 0x54,
+    0x00, 0x55,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x00a9, before),
+    reply(0x08, 0x00a9, after),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x00a9, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setRippleControl(false), false);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0xa9,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x0a);
+  assert.deepEqual([...write!.subarray(5, 15)], after);
+});
+
+test("R1 Pro Max receiver writes Motion Sync through the captured advanced block", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const before = [
+    0x04, 0x51,
+    0x01, 0x54,
+    0x06, 0x4f,
+    0x01, 0x54,
+    0x01, 0x54,
+  ];
+  const after = [
+    0x04, 0x51,
+    0x00, 0x55,
+    0x06, 0x4f,
+    0x01, 0x54,
+    0x01, 0x54,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x00a9, before),
+    reply(0x08, 0x00a9, after),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x00a9, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setMotionSync(false), false);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0xa9,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x0a);
+  assert.deepEqual([...write!.subarray(5, 15)], after);
+});
+
+test("R1 Pro Max receiver writes debounce through the captured advanced block", async () => {
+  const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
+  const hardware = fake as unknown as FakeR1ProMaxDevice;
+
+  const before = [
+    0x04, 0x51,
+    0x01, 0x54,
+    0x06, 0x4f,
+    0x01, 0x54,
+    0x01, 0x54,
+  ];
+  const after = [
+    0x08, 0x4d,
+    0x01, 0x54,
+    0x06, 0x4f,
+    0x01, 0x54,
+    0x01, 0x54,
+  ];
+
+  hardware.replies = [
+    reply(0x10, 0, [0x02, 0x1b]),
+    reply(0x08, 0x00a9, before),
+    reply(0x08, 0x00a9, after),
+  ];
+  hardware.writeReplies = [
+    reply(0x07, 0x00a9, after),
+  ];
+
+  const client = new AtkHidClient(fake);
+  assert.equal(await client.setDebounceTime(8), 8);
+
+  const write = writes(fake).find(
+    (frame) => frame[2] === 0x00 && frame[3] === 0xa9,
+  );
+
+  assert.ok(write);
+  assert.equal(write![4], 0x0a);
+  assert.deepEqual([...write!.subarray(5, 15)], after);
+});
+
 test("R1 Pro Max receiver writes lift-off distance through the captured EEPROM pair", async () => {
   const fake = device(0xf58a, "VXE R1 Pro Max Receiver");
   const hardware = fake as unknown as FakeR1ProMaxDevice;


### PR DESCRIPTION
Adds VXE R1 Pro Max support for the COMPX 0x3554:F58A receiver and 0x3554:F58C wired transports (CID/MID 2/27), including PAW3395 30,000 DPI limits, independent X/Y DPI, DPI stages and lighting, advanced/performance settings, Long Range, profiles, and stored button-mapping reads

Both transports were verified on a physical R1 Pro Max using captured command/response behavior and write-readback testing; the verified details are documented in `docs/vxe-r1-pro-max-testing.md`. Receiver writes remain limited to individually verified paths, generic receiver EEPROM writes stay blocked, and button remapping remains read-only. The firmware revision was not recorded during this hardware pass. Targeted ATK tests pass 52/52, along with the TypeScript build and `git diff --check`. Matching app integration: OpenMouse-Project/openmouse#237