### PR TITLE
keychron: decode the M6's full 8k protocol

### DIFF
--- a/src/drivers/keychron/m6-hid.test.ts
+++ b/src/drivers/keychron/m6-hid.test.ts
@@ -1,129 +1,286 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "node:test";
+import { KeychronM6HidClient } from "./m6-hid.ts";
 
-Object.assign(globalThis, { window: globalThis });
+if (typeof globalThis.window === "undefined") {
+  (globalThis as { window?: unknown }).window = globalThis;
+}
 
-const { KeychronM6HidClient } = await import("./m6-hid.ts");
-const { VENDOR_ID } = await import("../vendors.ts");
+const ACK = 0xe4;
 
+/**
+ * Speaks the "8k" Keychron mouse protocol the way the M6 does: 63-byte
+ * queries on 0xb3 answered on 0xb4, 20-byte settings on 0xb5 acknowledged on
+ * 0xb6 with [0xe4, 0, command].
+ */
 class FakeM6Device {
-  readonly vendorId = VENDOR_ID.keychron;
-  readonly productId = 0xd060;
-  readonly productName = "Keychron M6";
-  readonly collections: HIDCollectionInfo[] = [{
-    usagePage: 0xffc1,
-    usage: 0x01,
-    children: [],
-    featureReports: [],
-    inputReports: [{ reportId: 0xb4, items: [{ reportCount: 63, reportSize: 8 }] }],
-    outputReports: [{ reportId: 0xb3, items: [{ reportCount: 63, reportSize: 8 }] }],
-  }] as unknown as HIDCollectionInfo[];
+  vendorId = 0x3434;
+  productId = 0xd060;
   opened = false;
   readonly sent: Array<{ reportId: number; packet: Uint8Array }> = [];
   private listeners = new Map<string, (event: unknown) => void>();
-  private activeDpiStage = 0;
-  private dpiStages = [400, 800, 1600, 3200, 5000];
-  private pollingIndex = 1;
-  private readonly pollingTable = [0, 1, 2];
-
-  addEventListener(type: string, listener: (event: unknown) => void): void {
-    this.listeners.set(type, listener);
-  }
-
-  removeEventListener(type: string, listener: (event: unknown) => void): void {
-    if (this.listeners.get(type) === listener) this.listeners.delete(type);
-  }
+  workMode = 0;
+  profile = 1;
+  profileCount = 3;
+  /** Per connection (USB, 2.4 GHz, Bluetooth): DPI stage low nibble, polling high nibble. */
+  levels = [0x10, 0x21, 0x32];
+  dpiStages = [400, 800, 1600, 3200, 5000];
+  stageCount = 3;
+  pollingTable = [0, 1, 2, 3, 4, 5];
+  lod = 1;
+  ripple = false;
+  angleSnap = false;
+  motion = true;
+  scrollReversed = false;
+  maxSpeed = false;
+  angle = 0;
+  angleSupported = true;
+  rejectNext = false;
+  debounce = 8;
+  sleep = 10;
+  battery = 0x80 | 100;
+  readonly collections = [{
+    usagePage: 0xffc1,
+    usage: 0x01,
+    outputReports: [{ reportId: 0xb3 }, { reportId: 0xb5 }],
+    inputReports: [{ reportId: 0xb4 }, { reportId: 0xb6 }],
+  }];
 
   async open(): Promise<void> { this.opened = true; }
   async close(): Promise<void> { this.opened = false; }
+  addEventListener(type: string, listener: (event: unknown) => void): void { this.listeners.set(type, listener); }
+  removeEventListener(type: string): void { this.listeners.delete(type); }
 
-  async sendReport(reportId: number, data: BufferSource): Promise<void> {
-    const packet = data instanceof ArrayBuffer
-      ? new Uint8Array(data)
-      : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-    this.sent.push({ reportId, packet: packet.slice() });
-    if (reportId === 0xb3 && packet[0] === 6) {
-      this.emit(0xb4, this.statusPacket());
+  async sendReport(reportId: number, data: ArrayBuffer): Promise<void> {
+    const packet = new Uint8Array(data);
+    this.sent.push({ reportId, packet });
+    if (reportId === 0xb3) {
+      if (packet[0] === 0x06) this.emit(0xb4, this.statusPacket());
+      if (packet[0] === 0x04) this.emit(0xb4, new Uint8Array([0x04, 6, ...Array.from("1.0.3", (c) => c.charCodeAt(0)), 0]));
       return;
     }
-    if (reportId === 0xb5 && packet[0] === 0x40) {
-      this.activeDpiStage = packet[1] ?? this.activeDpiStage;
-      this.dpiStages = this.dpiStages.map((_, index) => (packet[4 + index * 2] ?? 0) | ((packet[5 + index * 2] ?? 0) << 8));
-      this.emit(0xb6, new Uint8Array([0xe4]));
+    if (reportId !== 0xb5) return;
+    if (this.rejectNext) {
+      this.rejectNext = false;
+      this.emit(0xb6, new Uint8Array([ACK, 7, packet[0] ?? 0]));
       return;
     }
-    if (reportId === 0xb5 && packet[0] === 0x41) {
-      this.pollingIndex = packet[1] ?? this.pollingIndex;
-      this.emit(0xb6, new Uint8Array([0xe4]));
+    switch (packet[0]) {
+      case 0x02: {
+        const reply = new Uint8Array(20);
+        reply.set([0x02, 5, 0, 0x34, 0x34, 0x60, 0xd0, 0x03, 0x01, this.workMode]);
+        this.emit(0xb6, reply);
+        return;
+      }
+      case 0x40:
+        this.levels = this.levels.map((level, index) => (level & 0xf0) | (packet[1 + index] ?? 0));
+        this.stageCount = packet[14] ?? this.stageCount;
+        this.dpiStages = this.dpiStages.map((_, index) => (packet[4 + index * 2] ?? 0) | ((packet[5 + index * 2] ?? 0) << 8));
+        break;
+      case 0x41:
+        this.levels = this.levels.map((level) => (level & 0x0f) | ((packet[1] ?? 0) << 4));
+        this.pollingTable = Array.from(packet.slice(3, 3 + (packet[9] ?? 0)));
+        break;
+      case 0x42:
+        if (packet[9] === 2) {
+          this.angle = (packet[10] ?? 0) > 127 ? (packet[10] ?? 0) - 256 : (packet[10] ?? 0);
+          break;
+        }
+        if (packet[1]) this.lod = packet[1];
+        if (packet[2]) this.ripple = packet[2] === 1;
+        if (packet[3]) this.angleSnap = packet[3] === 1;
+        if (packet[4]) this.motion = packet[4] === 1;
+        if (packet[6]) this.scrollReversed = packet[6] === 2;
+        if (packet[8]) this.maxSpeed = packet[8] === 2;
+        break;
+      case 0x43:
+        this.debounce = packet[1] ?? 0;
+        break;
+      case 0x0a:
+        if (packet[1] === 1) this.sleep = packet[2] ?? 0;
+        break;
+      case 0x0e:
+        this.profile = packet[1] ?? 0;
+        break;
+      default:
+        return;
     }
+    this.emit(0xb6, new Uint8Array([ACK, 0, packet[0] ?? 0]));
   }
 
   private statusPacket(): Uint8Array {
     const packet = new Uint8Array(63);
-    packet[0] = 6;
-    packet[1] = this.activeDpiStage;
-    packet[2] = this.pollingIndex << 4;
+    packet[0] = 0x06;
+    packet[1] = this.profile;
+    packet.set(this.levels, 2);
     this.dpiStages.forEach((dpi, index) => {
       packet[5 + index * 2] = dpi & 0xff;
       packet[6 + index * 2] = (dpi >> 8) & 0xff;
     });
-    packet[19] = 0x80 | 99;
+    packet[15] = this.lod | (this.ripple ? 0x04 : 0) | (this.angleSnap ? 0x08 : 0) | (this.motion ? 0x10 : 0)
+      | (this.scrollReversed ? 0x40 : 0);
+    packet[16] = this.stageCount;
+    packet[17] = this.debounce;
+    packet[18] = this.sleep;
+    packet[19] = this.battery;
     packet.set(this.pollingTable, 43);
     packet[49] = this.pollingTable.length;
-    packet[50] = this.dpiStages.length;
+    packet[50] = this.profileCount;
+    packet[52] = this.maxSpeed ? 1 : 0;
+    packet[53] = this.angleSupported ? 0x04 : 0;
+    packet[55] = this.angle & 0xff;
     return packet;
   }
 
-  private emit(reportId: number, reply: Uint8Array): void {
-    queueMicrotask(() => this.listeners.get("inputreport")?.({
-      reportId,
-      data: new DataView(reply.buffer, reply.byteOffset, reply.byteLength),
-    }));
+  private emit(reportId: number, bytes: Uint8Array): void {
+    const data = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    queueMicrotask(() => this.listeners.get("inputreport")?.({ reportId, data }));
   }
 }
 
-function device(productId = 0xd060, usagePage = 0xffc1): HIDDevice {
-  return {
-    vendorId: VENDOR_ID.keychron,
-    productId,
-    productName: "Keychron M6",
-    collections: [{
-      usagePage,
-      usage: 0x01,
-      children: [],
-      featureReports: [],
-      inputReports: [{ reportId: 0xb4, items: [{ reportCount: 63, reportSize: 8 }] }],
-      outputReports: [{ reportId: 0xb3, items: [{ reportCount: 63, reportSize: 8 }] }],
-    }],
-  } as unknown as HIDDevice;
-}
+const client = (fake: FakeM6Device): KeychronM6HidClient => new KeychronM6HidClient(fake as unknown as HIDDevice);
+const lastSent = (fake: FakeM6Device, command: number) =>
+  [...fake.sent].reverse().find(({ reportId, packet }) => reportId === 0xb5 && packet[0] === command)?.packet;
 
 test("Keychron M6 is limited to its verified 0xffc1 control interface", () => {
-  assert.equal(KeychronM6HidClient.isSupported(device()), true);
-  assert.equal(KeychronM6HidClient.isSupported(device(0xd060, 0xff60)), false);
-  assert.equal(KeychronM6HidClient.isSupported(device(0xd029)), true);
-  assert.equal(KeychronM6HidClient.isSupported({ ...device(), productId: 0xd061 } as HIDDevice), false);
+  const fake = new FakeM6Device();
+  assert.equal(KeychronM6HidClient.isSupported(fake as unknown as HIDDevice), true);
+  const viaOnly = { ...fake, collections: [{ usagePage: 0xff60, usage: 0x61, outputReports: [{ reportId: 0 }], inputReports: [{ reportId: 0 }] }] };
+  assert.equal(KeychronM6HidClient.isSupported(viaOnly as unknown as HIDDevice), false);
 });
 
-test("reads the M6 8k-protocol status report", async () => {
-  const status = await new KeychronM6HidClient(new FakeM6Device() as unknown as HIDDevice).readStatus();
+test("reads the full M6 status report", async () => {
+  const status = await client(new FakeM6Device()).readStatus();
   assert.equal(status.name, "Keychron M6");
   assert.equal(status.dpi, 400);
-  assert.deepEqual(status.dpiStages, [400, 800, 1600, 3200, 5000]);
+  assert.deepEqual(status.dpiStages, [400, 800, 1600]);
   assert.equal(status.activeDpiStage, 0);
   assert.equal(status.pollingRateHz, 500);
-  assert.deepEqual(status.supportedPollingRates, [125, 500, 1000]);
-  assert.equal(status.batteryPercent, 99);
+  assert.deepEqual(status.supportedPollingRates, [125, 500, 1000, 2000, 4000, 8000]);
+  assert.equal(status.liftOffDistance, "Medium");
+  assert.deepEqual(status.supportedLiftOffDistances, ["Low", "Medium", "High"]);
+  assert.equal(status.motionSync, true);
+  assert.equal(status.angleSnapping, false);
+  assert.equal(status.rippleControl, false);
+  assert.equal(status.angleTuning, 0);
+  assert.equal(status.debounceMs, 8);
+  assert.equal(status.sleepTimeout, 600);
+  assert.equal(status.activeProfile, 2);
+  assert.equal(status.profileCount, 3);
+  assert.equal(status.batteryPercent, 100);
   assert.equal(status.batteryState, "Charging");
-  assert.equal(status.ui?.family, "keychron-m6");
+  assert.deepEqual(status.firmware, ["v1.0.3"]);
+  assert.equal(status.ui?.hideProcessingCard, undefined);
+  assert.equal(status.ui?.hideSleepCard, undefined);
 });
 
-test("writes M6 DPI and polling settings, then reads them back", async () => {
+test("reads the DPI and polling levels of the connection in use", async () => {
   const fake = new FakeM6Device();
-  const client = new KeychronM6HidClient(fake as unknown as HIDDevice);
-  assert.equal(await client.setDpi(1200), 1200);
-  assert.equal(await client.setActiveDpiStage(2), 2);
-  assert.equal(await client.setPollingRate(1000), 1000);
-  assert.ok(fake.sent.some(({ reportId, packet }) => reportId === 0xb5 && packet[0] === 0x40));
-  assert.ok(fake.sent.some(({ reportId, packet }) => reportId === 0xb5 && packet[0] === 0x41));
+  fake.productId = 0xd029;
+  fake.workMode = 1;
+  const status = await client(fake).readStatus();
+  // 2.4 GHz slot: stage 1 (800 DPI) and polling index 2 (1000 Hz).
+  assert.equal(status.dpi, 800);
+  assert.equal(status.pollingRateHz, 1000);
+  assert.equal(status.connectionType, "Wireless");
+});
+
+test("DPI writes follow the active stage and keep the stage count", async () => {
+  const fake = new FakeM6Device();
+  const m6 = client(fake);
+  await m6.setActiveDpiStage(1);
+  await m6.setDpi(2400);
+  const status = await m6.readStatus();
+  assert.deepEqual(status.dpiStages, [400, 2400, 1600]);
+  assert.equal(status.activeDpiStage, 1);
+  assert.equal(status.dpi, 2400);
+  assert.equal(await m6.setDpiStageValue(2, 3200), 3200);
+  assert.deepEqual((await m6.readStatus()).dpiStages, [400, 2400, 3200]);
+  assert.equal(lastSent(fake, 0x40)?.[14], 3);
+});
+
+test("rejects stages past the count the mouse reports", async () => {
+  const m6 = client(new FakeM6Device());
+  await assert.rejects(m6.setActiveDpiStage(3), /between 1 and 3/);
+  await assert.rejects(m6.setDpiStageValue(4, 800), /between 1 and 3/);
+});
+
+test("writes the polling rate as an index into the mouse's table", async () => {
+  const fake = new FakeM6Device();
+  assert.equal(await client(fake).setPollingRate(4000), 4000);
+  const packet = lastSent(fake, 0x41)!;
+  assert.deepEqual(Array.from(packet.slice(0, 10)), [0x41, 4, 4, 0, 1, 2, 3, 4, 5, 6]);
+  await assert.rejects(client(fake).setPollingRate(250), /does not support 250 Hz/);
+});
+
+test("sensor options are resent together with 1 = on and 2 = off", async () => {
+  const fake = new FakeM6Device();
+  const m6 = client(fake);
+  assert.equal(await m6.setLiftOffDistance("High"), "High");
+  assert.equal(await m6.setMotionSync(false), false);
+  assert.equal(await m6.setAngleSnapping(true), true);
+  assert.equal(await m6.setRippleControl(true), true);
+  const packet = lastSent(fake, 0x42)!;
+  assert.deepEqual(Array.from(packet.slice(0, 9)), [0x42, 2, 1, 1, 2, 0, 1, 0, 1]);
+  const status = await m6.readStatus();
+  assert.equal(status.liftOffDistance, "High");
+  assert.equal(status.motionSync, false);
+  assert.equal(status.angleSnapping, true);
+  assert.equal(status.rippleControl, true);
+  assert.equal(await m6.setLiftOffDistance("Low"), "Low");
+  assert.equal(fake.lod, 3);
+});
+
+test("angle tuning uses the dedicated 0x42 form with a signed byte", async () => {
+  const fake = new FakeM6Device();
+  const m6 = client(fake);
+  assert.equal(await m6.setAngleTuning(-15), -15);
+  const packet = lastSent(fake, 0x42)!;
+  assert.equal(packet[9], 2);
+  assert.equal(packet[10], 0xf1);
+  assert.equal((await m6.readStatus()).angleTuning, -15);
+  await assert.rejects(m6.setAngleTuning(45), /between -30 and 30/);
+});
+
+test("debounce, sleep and profile round-trip through their own commands", async () => {
+  const fake = new FakeM6Device();
+  const m6 = client(fake);
+  assert.equal(await m6.setDebounceTime(4), 4);
+  assert.deepEqual(Array.from(lastSent(fake, 0x43)!.slice(0, 2)), [0x43, 4]);
+  assert.equal(await m6.setSleepTimeout(300), 300);
+  assert.deepEqual(Array.from(lastSent(fake, 0x0a)!.slice(0, 3)), [0x0a, 1, 5]);
+  assert.equal(await m6.setProfile(3), 3);
+  assert.deepEqual(Array.from(lastSent(fake, 0x0e)!.slice(0, 2)), [0x0e, 2]);
+  const status = await m6.readStatus();
+  assert.equal(status.debounceMs, 4);
+  assert.equal(status.sleepTimeout, 300);
+  assert.equal(status.activeProfile, 3);
+  await assert.rejects(m6.setProfile(4), /between 1 and 3/);
+  await assert.rejects(m6.setDebounceTime(21), /between 0 and 20/);
+  await assert.rejects(m6.setSleepTimeout(90), /must be one of/);
+  assert.deepEqual(m6.getSleepOptions().slice(0, 3), [60, 180, 300]);
+  assert.equal(m6.getDebounceOptions().length, 21);
+});
+
+test("angle tuning is offered only when the mouse flags support for it", async () => {
+  const fake = new FakeM6Device();
+  fake.angleSupported = false;
+  const m6 = client(fake);
+  assert.equal((await m6.readStatus()).angleTuning, undefined);
+  await assert.rejects(m6.setAngleTuning(5), /does not support angle tuning/);
+  assert.equal(lastSent(fake, 0x42), undefined);
+});
+
+test("a non-zero ack code fails the write instead of a silent re-read", async () => {
+  const fake = new FakeM6Device();
+  fake.rejectNext = true;
+  await assert.rejects(client(fake).setDebounceTime(3), /rejected command 0x43 \(code 7\)/);
+});
+
+test("a mouse that hides its profiles shows no profile card", async () => {
+  const fake = new FakeM6Device();
+  fake.profileCount = 0;
+  const status = await client(fake).readStatus();
+  assert.equal(status.activeProfile, null);
+  assert.equal(status.profileCount, undefined);
 });

--- a/src/drivers/keychron/m6-hid.ts
+++ b/src/drivers/keychron/m6-hid.ts
@@ -1,11 +1,9 @@
 import type { MouseStatus } from "../mouse-types.ts";
 import {
   KEYCHRON_M6_COMMAND_REPORT_ID as COMMAND_REPORT_ID,
-  KEYCHRON_M6_COMMAND_RESPONSE_REPORT_ID as COMMAND_RESPONSE_REPORT_ID,
   KEYCHRON_M6_PRODUCT_ID as PRODUCT_ID,
   KEYCHRON_M6_RECEIVER_PRODUCT_ID as RECEIVER_PRODUCT_ID,
   KEYCHRON_M6_SETTINGS_REPORT_ID as SETTINGS_REPORT_ID,
-  KEYCHRON_M6_SETTINGS_RESPONSE_REPORT_ID as SETTINGS_RESPONSE_REPORT_ID,
   KEYCHRON_M6_STATUS_COMMAND as STATUS_COMMAND,
   KEYCHRON_M6_STATUS_PACKET_LENGTH as PACKET_LENGTH,
   KEYCHRON_M6_USAGE as USAGE,
@@ -14,37 +12,98 @@ import {
 } from "@openmouse/protocol/keychron";
 
 const QUERY_TIMEOUT_MS = 1200;
+const SETTINGS_PACKET_LENGTH = 20;
 const DPI_STAGE_COUNT = 5;
 const DPI_MIN = 100;
 const DPI_MAX = 26_000;
 const DPI_STEP = 50;
-const POLLING_RATES = [125, 500, 1000] as const;
+/** Polling table entries index this scale (Keychron Launcher POLLING_RATE_VALUE_SCALE). */
+const POLLING_RATES = [125, 500, 1000, 2000, 4000, 8000] as const;
+const ACK = 0xe4;
+/** Firmware LOD codes on the PAW3950: 1 = 1 mm, 2 = 2 mm, 3 = 0.7 mm. */
+const LOD_BY_LEVEL = { Low: 3, Medium: 1, High: 2 } as const;
+const SLEEP_MINUTES = [1, 3, 5, 10, 15, 30, 60, 120, 240] as const;
+const DEBOUNCE_MAX_MS = 20;
+const ANGLE_LIMIT = 30;
+const PROFILE_MAX = 5;
+
+/** Commands on the 63-byte 0xb3 report (answers arrive on 0xb4). */
+const CMD = { firmware: 0x04, status: 0x06 } as const;
+/** Commands on the 20-byte 0xb5 report (answers arrive on 0xb6). */
+const SET = {
+  version: 0x02,
+  sleep: 0x0a,
+  profile: 0x0e,
+  dpi: 0x40,
+  polling: 0x41,
+  sensor: 0x42,
+  debounce: 0x43,
+} as const;
+
+type LiftOff = NonNullable<MouseStatus["liftOffDistance"]>;
 
 type M6Settings = {
+  profile: number;
+  profileCount: number;
   activeDpiStage: number;
+  /** All five hardware slots; only the first `stageCount` are in use. */
   dpiStages: number[];
+  stageCount: number;
   pollingTable: number[];
   pollingIndex: number;
+  lod: number;
+  lodLevel: number;
+  rippleControl: boolean;
+  angleSnapping: boolean;
+  motionSync: boolean;
+  scrollReversed: boolean;
+  maxSpeed: boolean;
+  angle: number;
+  angleSupported: boolean;
+  debounceMs: number;
+  sleepMinutes: number;
   batteryPercent: number;
   charging: boolean;
 };
 
+type M6Identity = { firmware: string | null; workMode: number };
+
 /**
- * Keychron M6 wired client. The 0xffc1 collection uses 63-byte reports,
- * unlike the VIA raw-HID protocol used by the Nape Pro.
+ * Keychron M6 client for the 0xffc1 vendor collection, the "8k" variant of
+ * Keychron Launcher's mouse protocol (63-byte 0xb3/0xb4 reads, 20-byte
+ * 0xb5/0xb6 writes). Not the VIA raw-HID protocol the Nape Pro speaks.
+ *
+ * Status report (0x06) layout, decoded from Keychron Launcher and confirmed
+ * on an M6 (firmware 1.0.3, USB) for every field the driver reads:
+ *   [1]      active onboard profile, zero-based; [50] profile count
+ *   [2..4]   per connection (USB, 2.4 GHz, Bluetooth): DPI stage in the low
+ *            nibble, polling index in the high nibble
+ *   [5..14]  five DPI slots, little-endian 16-bit
+ *   [15]     bits 0-1 lift-off code, bit 2 ripple control, bit 3 angle
+ *            snapping, bit 4 motion sync, bit 6 reversed scroll
+ *   [16]     DPI stages in use (1-5); unused tail slots keep stale values
+ *   [17]     debounce in ms; [18] sleep timeout in minutes
+ *   [19]     battery percent, bit 7 = charging
+ *   [43..48] polling table as indexes into POLLING_RATES; [49] its length
+ *   [52]     bit 0 max-speed mode; [53] bit 2 = angle tuning supported
+ *   [55]     sensor angle as a signed byte; [61] lift-off fine level
+ * Settings writes are acknowledged with [0xe4, code, command]; code 0 is
+ * success and 7 means the command is not supported on this connection.
+ * The 0x40 write packet is the DPI part of this layout shifted one byte down
+ * (stage at [1..3], slots at [4..13], stage count at [14]).
  */
 export class KeychronM6HidClient {
   readonly device: HIDDevice;
   private openedListener = false;
+  private identity: M6Identity | null = null;
   private responseWaiter: {
-    reportId: number;
     match: (bytes: Uint8Array) => boolean;
     resolve: (bytes: Uint8Array) => void;
     reject: (reason: Error) => void;
   } | null = null;
 
   private readonly onInputReport = (event: HIDInputReportEvent): void => {
-    if (event.reportId !== this.responseWaiter?.reportId) return;
+    if (!this.responseWaiter) return;
     const bytes = new Uint8Array(event.data.buffer.slice(
       event.data.byteOffset,
       event.data.byteOffset + event.data.byteLength,
@@ -66,7 +125,7 @@ export class KeychronM6HidClient {
         collection.usagePage === USAGE_PAGE
         && collection.usage === USAGE
         && collection.outputReports.some((report) => report.reportId === COMMAND_REPORT_ID)
-        && collection.inputReports.some((report) => report.reportId === COMMAND_RESPONSE_REPORT_ID));
+        && collection.inputReports.some((report) => report.reportId === COMMAND_REPORT_ID + 1));
   }
 
   async open(): Promise<void> {
@@ -91,17 +150,28 @@ export class KeychronM6HidClient {
     return Array.from({ length: (DPI_MAX - DPI_MIN) / DPI_STEP + 1 }, (_, index) => DPI_MIN + index * DPI_STEP);
   }
 
+  getSleepOptions(): number[] {
+    return SLEEP_MINUTES.map((minutes) => minutes * 60);
+  }
+
+  getDebounceOptions(): number[] {
+    return Array.from({ length: DEBOUNCE_MAX_MS + 1 }, (_, ms) => ms);
+  }
+
   readonly canDisableSleep = false;
 
   async readStatus(): Promise<MouseStatus> {
     await this.open();
-    const settings = this.parseStatus(await this.queryStatus());
-    const activeDpiStage = Math.min(settings.activeDpiStage, settings.dpiStages.length - 1);
-    const dpi = settings.dpiStages[activeDpiStage] ?? settings.dpiStages[0] ?? 800;
+    const identity = await this.readIdentity();
+    const settings = this.parseStatus(await this.queryStatus(), identity.workMode);
+    const dpi = settings.dpiStages[settings.activeDpiStage] ?? settings.dpiStages[0] ?? 800;
     const pollingRateHz = POLLING_RATES[settings.pollingTable[settings.pollingIndex] ?? 2] ?? 1000;
     const supportedPollingRates = settings.pollingTable
       .map((value) => POLLING_RATES[value])
-      .filter((value) => value !== undefined) as number[];
+      .filter((value): value is (typeof POLLING_RATES)[number] => value !== undefined)
+      .sort((a, b) => a - b);
+    const liftOffDistance = (Object.keys(LOD_BY_LEVEL) as LiftOff[])
+      .find((level) => LOD_BY_LEVEL[level] === settings.lod) ?? null;
 
     return {
       brand: "Keychron",
@@ -110,9 +180,8 @@ export class KeychronM6HidClient {
         family: "keychron-m6",
         defaultDisplayName: "Keychron M6",
         hideUnsupportedPollingRates: true,
-        hideProcessingCard: true,
-        hideSleepCard: true,
         forceShowBattery: true,
+        statusNote: "Lift-off: Low is 0.7 mm, Medium is 1 mm, High is 2 mm.",
         dpiStageEditor: {
           maxStages: DPI_STAGE_COUNT,
           countEditable: false,
@@ -124,86 +193,220 @@ export class KeychronM6HidClient {
       batteryPercent: settings.batteryPercent <= 100 ? settings.batteryPercent : null,
       batteryState: settings.charging ? "Charging" : "Discharging",
       dpi,
-      dpiStages: settings.dpiStages,
-      activeDpiStage,
+      dpiStages: settings.dpiStages.slice(0, settings.stageCount),
+      activeDpiStage: settings.activeDpiStage,
       pollingRateHz,
       supportedPollingRates: supportedPollingRates.length ? supportedPollingRates : [pollingRateHz],
-      activeProfile: null,
+      activeProfile: settings.profileCount > 1 ? settings.profile + 1 : null,
+      profileCount: settings.profileCount > 1 ? settings.profileCount : undefined,
       connectionType: this.device.productId === RECEIVER_PRODUCT_ID ? "Wireless" : "Wired",
       connectionDetail: this.device.productId === RECEIVER_PRODUCT_ID
         ? "2.4 GHz (Keychron Link-KM)"
         : "Wired USB",
-      liftOffDistance: null,
-      supportedLiftOffDistances: [],
-      firmware: ["Firmware version not yet decoded"],
+      liftOffDistance,
+      supportedLiftOffDistances: Object.keys(LOD_BY_LEVEL) as LiftOff[],
+      motionSync: settings.motionSync,
+      angleSnapping: settings.angleSnapping,
+      rippleControl: settings.rippleControl,
+      angleTuning: settings.angleSupported ? settings.angle : undefined,
+      debounceMs: settings.debounceMs,
+      sleepTimeout: settings.sleepMinutes > 0 && settings.sleepMinutes < 0xff ? settings.sleepMinutes * 60 : null,
+      firmware: [identity.firmware ?? "Firmware unavailable"],
     };
   }
 
   async setDpi(dpi: number): Promise<number> {
-    if (!Number.isInteger(dpi) || dpi < DPI_MIN || dpi > DPI_MAX || dpi % DPI_STEP !== 0) {
-      throw new Error(`Keychron M6 DPI must be a multiple of ${DPI_STEP} between ${DPI_MIN} and ${DPI_MAX}.`);
-    }
-    await this.open();
-    const settings = this.parseStatus(await this.queryStatus());
-    const active = Math.min(settings.activeDpiStage, DPI_STAGE_COUNT - 1);
-    settings.dpiStages[active] = dpi;
+    this.requireDpi(dpi);
+    const settings = await this.readSettings();
+    settings.dpiStages[settings.activeDpiStage] = dpi;
     await this.writeSettings(this.dpiSettingsPacket(settings));
-    const confirmed = this.parseStatus(await this.queryStatus()).dpiStages[active];
+    const confirmed = (await this.readSettings()).dpiStages[settings.activeDpiStage];
     if (confirmed !== dpi) throw new Error(`The Keychron M6 kept ${confirmed} DPI instead of ${dpi} DPI.`);
     return confirmed;
   }
 
-  async setActiveDpiStage(stage: number): Promise<number> {
-    if (!Number.isInteger(stage) || stage < 0 || stage >= DPI_STAGE_COUNT) {
-      throw new Error(`DPI stage must be between 1 and ${DPI_STAGE_COUNT}.`);
+  async setDpiStageValue(stage: number, dpi: number): Promise<number> {
+    this.requireDpi(dpi);
+    const settings = await this.readSettings();
+    this.requireStage(stage, settings.stageCount);
+    settings.dpiStages[stage] = dpi;
+    await this.writeSettings(this.dpiSettingsPacket(settings));
+    const confirmed = (await this.readSettings()).dpiStages[stage];
+    if (confirmed !== dpi) {
+      throw new Error(`The Keychron M6 kept ${confirmed} DPI on stage ${stage + 1} instead of ${dpi} DPI.`);
     }
-    await this.open();
-    const settings = this.parseStatus(await this.queryStatus());
+    return confirmed;
+  }
+
+  async setActiveDpiStage(stage: number): Promise<number> {
+    const settings = await this.readSettings();
+    this.requireStage(stage, settings.stageCount);
     settings.activeDpiStage = stage;
     await this.writeSettings(this.dpiSettingsPacket(settings));
-    const confirmed = this.parseStatus(await this.queryStatus()).activeDpiStage;
+    const confirmed = (await this.readSettings()).activeDpiStage;
     if (confirmed !== stage) throw new Error(`The Keychron M6 kept DPI stage ${confirmed + 1}.`);
     return confirmed;
   }
 
   async setPollingRate(rateHz: number): Promise<number> {
-    await this.open();
-    const settings = this.parseStatus(await this.queryStatus());
-    const supported = settings.pollingTable
-      .map((value) => POLLING_RATES[value])
-      .filter((value) => value !== undefined) as number[];
-    if (!supported.includes(rateHz)) throw new Error(`The Keychron M6 does not support ${rateHz} Hz on this connection.`);
+    const settings = await this.readSettings();
     const pollingIndex = settings.pollingTable.findIndex((value) => POLLING_RATES[value] === rateHz);
-    if (pollingIndex < 0) throw new Error(`The Keychron M6 has no polling-rate entry for ${rateHz} Hz.`);
+    if (pollingIndex < 0) throw new Error(`The Keychron M6 does not support ${rateHz} Hz on this connection.`);
     settings.pollingIndex = pollingIndex;
     await this.writeSettings(this.pollingSettingsPacket(settings));
-    const confirmed = this.parseStatus(await this.queryStatus());
+    const confirmed = await this.readSettings();
     const actual = POLLING_RATES[confirmed.pollingTable[confirmed.pollingIndex] ?? 2] ?? 1000;
     if (actual !== rateHz) throw new Error(`The Keychron M6 kept ${actual} Hz instead of ${rateHz} Hz.`);
     return actual;
   }
 
-  async setLiftOffDistance(_lod: NonNullable<MouseStatus["liftOffDistance"]>): Promise<never> {
-    throw new Error("Lift-off distance writes are not yet validated for the Keychron M6.");
+  async setLiftOffDistance(lod: LiftOff): Promise<LiftOff> {
+    const code = LOD_BY_LEVEL[lod];
+    if (code === undefined) throw new Error(`The Keychron M6 has no ${lod} lift-off distance.`);
+    const confirmed = await this.writeSensor({ lod: code });
+    if (confirmed.lod !== code) throw new Error(`The Keychron M6 kept lift-off code ${confirmed.lod}.`);
+    return lod;
   }
 
-  async setMotionSync(_enabled: boolean): Promise<never> {
-    throw new Error("Motion Sync writes are not yet validated for the Keychron M6.");
+  async setMotionSync(enabled: boolean): Promise<boolean> {
+    return this.writeSensorFlag("motionSync", enabled);
   }
 
-  async setAngleSnapping(_enabled: boolean): Promise<never> {
-    throw new Error("Angle-snapping writes are not yet validated for the Keychron M6.");
+  async setAngleSnapping(enabled: boolean): Promise<boolean> {
+    return this.writeSensorFlag("angleSnapping", enabled);
   }
 
-  async setRippleControl(_enabled: boolean): Promise<never> {
-    throw new Error("Ripple-control writes are not yet validated for the Keychron M6.");
+  async setRippleControl(enabled: boolean): Promise<boolean> {
+    return this.writeSensorFlag("rippleControl", enabled);
   }
 
-  async setDebounceTime(_debounceMs: number): Promise<never> {
-    throw new Error("Debounce writes are not yet validated for the Keychron M6.");
+  async setAngleTuning(degrees: number): Promise<number> {
+    if (!Number.isInteger(degrees) || Math.abs(degrees) > ANGLE_LIMIT) {
+      throw new Error(`Keychron M6 angle tuning must be a whole number between -${ANGLE_LIMIT} and ${ANGLE_LIMIT} degrees.`);
+    }
+    if (!(await this.readSettings()).angleSupported) {
+      throw new Error("This Keychron M6 firmware does not support angle tuning.");
+    }
+    const packet = new Uint8Array(SETTINGS_PACKET_LENGTH);
+    packet[0] = SET.sensor;
+    packet[9] = 2;
+    packet[10] = degrees & 0xff;
+    await this.writeSettings(packet);
+    const confirmed = (await this.readSettings()).angle;
+    if (confirmed !== degrees) throw new Error(`The Keychron M6 kept a ${confirmed}° sensor angle instead of ${degrees}°.`);
+    return confirmed;
   }
 
-  private parseStatus(bytes: Uint8Array): M6Settings {
+  async setDebounceTime(debounceMs: number): Promise<number> {
+    if (!Number.isInteger(debounceMs) || debounceMs < 0 || debounceMs > DEBOUNCE_MAX_MS) {
+      throw new Error(`Keychron M6 debounce must be between 0 and ${DEBOUNCE_MAX_MS} ms.`);
+    }
+    await this.open();
+    const packet = new Uint8Array(SETTINGS_PACKET_LENGTH);
+    packet[0] = SET.debounce;
+    packet[1] = debounceMs;
+    await this.writeSettings(packet);
+    const confirmed = (await this.readSettings()).debounceMs;
+    if (confirmed !== debounceMs) throw new Error(`The Keychron M6 kept ${confirmed} ms debounce instead of ${debounceMs} ms.`);
+    return confirmed;
+  }
+
+  async setSleepTimeout(seconds: number): Promise<number> {
+    const minutes = Math.round(seconds / 60);
+    if (!SLEEP_MINUTES.includes(minutes as (typeof SLEEP_MINUTES)[number])) {
+      throw new Error(`Keychron M6 sleep timeout must be one of ${SLEEP_MINUTES.join(", ")} minutes.`);
+    }
+    await this.open();
+    const packet = new Uint8Array(SETTINGS_PACKET_LENGTH);
+    packet[0] = SET.sleep;
+    packet[1] = 1;
+    packet[2] = minutes;
+    await this.writeSettings(packet);
+    const confirmed = (await this.readSettings()).sleepMinutes;
+    if (confirmed !== minutes) throw new Error(`The Keychron M6 kept a ${confirmed} minute sleep timeout instead of ${minutes}.`);
+    return confirmed * 60;
+  }
+
+  /** Switch the onboard profile (1-based, as the panel numbers them). */
+  async setProfile(profile: number): Promise<number> {
+    const settings = await this.readSettings();
+    if (!Number.isInteger(profile) || profile < 1 || profile > Math.min(settings.profileCount, PROFILE_MAX)) {
+      throw new Error(`Keychron M6 profile must be between 1 and ${settings.profileCount}.`);
+    }
+    const packet = new Uint8Array(SETTINGS_PACKET_LENGTH);
+    packet[0] = SET.profile;
+    packet[1] = profile - 1;
+    await this.writeSettings(packet);
+    const confirmed = (await this.readSettings()).profile + 1;
+    if (confirmed !== profile) throw new Error(`The Keychron M6 kept profile ${confirmed}.`);
+    return confirmed;
+  }
+
+  private async writeSensorFlag(
+    flag: "motionSync" | "angleSnapping" | "rippleControl",
+    enabled: boolean,
+  ): Promise<boolean> {
+    const confirmed = await this.writeSensor({ [flag]: enabled });
+    if (confirmed[flag] !== enabled) throw new Error(`The Keychron M6 kept ${flag} ${confirmed[flag] ? "on" : "off"}.`);
+    return confirmed[flag];
+  }
+
+  /**
+   * The 0x42 packet carries every sensor option at once; each toggle byte is
+   * 1 = on, 2 = off, 0 = leave alone, so resend the current state with the
+   * requested change applied.
+   */
+  private async writeSensor(change: Partial<M6Settings>): Promise<M6Settings> {
+    const settings = { ...(await this.readSettings()), ...change };
+    const packet = new Uint8Array(SETTINGS_PACKET_LENGTH);
+    packet[0] = SET.sensor;
+    packet[1] = settings.lod;
+    packet[2] = settings.rippleControl ? 1 : 2;
+    packet[3] = settings.angleSnapping ? 1 : 2;
+    packet[4] = settings.motionSync ? 1 : 2;
+    packet[6] = settings.scrollReversed ? 2 : 1;
+    packet[8] = settings.maxSpeed ? 2 : 1;
+    packet[11] = settings.lodLevel;
+    await this.writeSettings(packet);
+    return await this.readSettings();
+  }
+
+  private requireDpi(dpi: number): void {
+    if (!Number.isInteger(dpi) || dpi < DPI_MIN || dpi > DPI_MAX || dpi % DPI_STEP !== 0) {
+      throw new Error(`Keychron M6 DPI must be a multiple of ${DPI_STEP} between ${DPI_MIN} and ${DPI_MAX}.`);
+    }
+  }
+
+  private requireStage(stage: number, stageCount: number): void {
+    if (!Number.isInteger(stage) || stage < 0 || stage >= stageCount) {
+      throw new Error(`DPI stage must be between 1 and ${stageCount}.`);
+    }
+  }
+
+  private async readSettings(): Promise<M6Settings> {
+    await this.open();
+    const identity = await this.readIdentity();
+    return this.parseStatus(await this.queryStatus(), identity.workMode);
+  }
+
+  /**
+   * Firmware string (0x04 on 0xb3) and connection mode (0x02 on 0xb5) never
+   * change while connected, so they are read once. Either failing leaves the
+   * mouse usable: the mode falls back to what the product ID implies.
+   */
+  private async readIdentity(): Promise<M6Identity> {
+    if (this.identity) return this.identity;
+    const fallbackMode = this.device.productId === RECEIVER_PRODUCT_ID ? 1 : 0;
+    const version = await this.querySettings(SET.version, [fallbackMode]).catch(() => null);
+    const workMode = version ? (version[9] ?? fallbackMode) & 0x07 : fallbackMode;
+    const firmware = await this.query(COMMAND_REPORT_ID, PACKET_LENGTH, [CMD.firmware, workMode], (bytes) => bytes[0] === CMD.firmware)
+      .then((bytes) => decodeFirmwareString(bytes) ?? (version ? decodeFirmwareNibbles(version) : null))
+      .catch(() => (version ? decodeFirmwareNibbles(version) : null));
+    this.identity = { firmware, workMode };
+    return this.identity;
+  }
+
+  private parseStatus(bytes: Uint8Array, workMode: number): M6Settings {
     if (bytes.length < 51 || bytes[0] !== STATUS_COMMAND) {
       throw new Error("The Keychron M6 returned an invalid status report.");
     }
@@ -212,19 +415,37 @@ export class KeychronM6HidClient {
       return (bytes[offset] ?? 0) | ((bytes[offset + 1] ?? 0) << 8);
     });
     const pollingCount = Math.min(bytes[49] || 6, 6);
+    const stageCount = Math.min(bytes[16] || DPI_STAGE_COUNT, DPI_STAGE_COUNT);
+    const levels = bytes[2 + Math.min(workMode, 2)] ?? 0;
+    const flags = bytes[15] ?? 0;
+    const angle = bytes[55] ?? 0;
     return {
-      activeDpiStage: bytes[1] ?? 0,
+      profile: bytes[1] ?? 0,
+      profileCount: Math.min(bytes[50] ?? 0, PROFILE_MAX),
+      activeDpiStage: Math.min(levels & 0x0f, stageCount - 1),
       dpiStages,
+      stageCount,
       pollingTable: Array.from(bytes.slice(43, 43 + pollingCount)),
-      pollingIndex: ((bytes[2] ?? 0) >> 4) & 0x0f,
+      pollingIndex: (levels >> 4) & 0x0f,
+      lod: flags & 0x03,
+      lodLevel: bytes[61] ?? 0,
+      rippleControl: (flags & 0x04) !== 0,
+      angleSnapping: (flags & 0x08) !== 0,
+      motionSync: (flags & 0x10) !== 0,
+      scrollReversed: (flags & 0x40) !== 0,
+      maxSpeed: ((bytes[52] ?? 0) & 0x01) !== 0,
+      angle: angle > 127 ? angle - 256 : angle,
+      angleSupported: ((bytes[53] ?? 0) & 0x04) !== 0,
+      debounceMs: bytes[17] ?? 0,
+      sleepMinutes: bytes[18] ?? 0,
       batteryPercent: (bytes[19] ?? 0) & 0x7f,
       charging: ((bytes[19] ?? 0) & 0x80) !== 0,
     };
   }
 
   private dpiSettingsPacket(settings: M6Settings): Uint8Array {
-    const packet = new Uint8Array(20);
-    packet[0] = 0x40;
+    const packet = new Uint8Array(SETTINGS_PACKET_LENGTH);
+    packet[0] = SET.dpi;
     packet[1] = settings.activeDpiStage;
     packet[2] = settings.activeDpiStage;
     packet[3] = settings.activeDpiStage;
@@ -232,13 +453,13 @@ export class KeychronM6HidClient {
       packet[4 + index * 2] = dpi & 0xff;
       packet[5 + index * 2] = (dpi >> 8) & 0xff;
     });
-    packet[14] = DPI_STAGE_COUNT;
+    packet[14] = settings.stageCount;
     return packet;
   }
 
   private pollingSettingsPacket(settings: M6Settings): Uint8Array {
-    const packet = new Uint8Array(20);
-    packet[0] = 0x41;
+    const packet = new Uint8Array(SETTINGS_PACKET_LENGTH);
+    packet[0] = SET.polling;
     packet[1] = settings.pollingIndex;
     packet[2] = settings.pollingIndex;
     packet[9] = settings.pollingTable.length;
@@ -247,27 +468,35 @@ export class KeychronM6HidClient {
   }
 
   private async queryStatus(): Promise<Uint8Array> {
-    const packet = new Uint8Array(PACKET_LENGTH);
-    packet[0] = STATUS_COMMAND;
-    return await this.query(COMMAND_REPORT_ID, COMMAND_RESPONSE_REPORT_ID, (bytes) => bytes[0] === STATUS_COMMAND, packet);
+    return await this.query(COMMAND_REPORT_ID, PACKET_LENGTH, [STATUS_COMMAND], (bytes) => bytes[0] === STATUS_COMMAND);
+  }
+
+  private async querySettings(command: number, args: number[]): Promise<Uint8Array> {
+    return await this.query(SETTINGS_REPORT_ID, SETTINGS_PACKET_LENGTH, [command, ...args], (bytes) => bytes[0] === command);
   }
 
   private async writeSettings(packet: Uint8Array): Promise<void> {
-    await this.query(
+    const command = packet[0] ?? 0;
+    const reply = await this.query(
       SETTINGS_REPORT_ID,
-      SETTINGS_RESPONSE_REPORT_ID,
-      (bytes) => bytes[0] === packet[0] || bytes[0] === 0xe4,
-      packet,
+      SETTINGS_PACKET_LENGTH,
+      Array.from(packet),
+      (bytes) => bytes[0] === command || (bytes[0] === ACK && bytes[2] === command),
     );
+    if (reply[0] === ACK && reply[1] !== 0) {
+      throw new Error(`The Keychron M6 rejected command 0x${command.toString(16)} (code ${reply[1]}).`);
+    }
   }
 
   private async query(
     reportId: number,
-    responseReportId: number,
+    length: number,
+    payload: number[],
     match: (bytes: Uint8Array) => boolean,
-    packet: Uint8Array,
   ): Promise<Uint8Array> {
     if (this.responseWaiter) throw new Error("Another Keychron M6 request is already in progress.");
+    const packet = new Uint8Array(length);
+    packet.set(payload.slice(0, length));
     let timeout = 0;
     let rejectResponse: ((reason: Error) => void) | null = null;
     const response = new Promise<Uint8Array>((resolve, reject) => {
@@ -277,7 +506,6 @@ export class KeychronM6HidClient {
         reject(new Error(`The Keychron M6 did not answer command 0x${packet[0]?.toString(16)}.`));
       }, QUERY_TIMEOUT_MS);
       this.responseWaiter = {
-        reportId: responseReportId,
         match,
         resolve: (bytes) => {
           window.clearTimeout(timeout);
@@ -291,7 +519,7 @@ export class KeychronM6HidClient {
     });
     void response.catch(() => undefined);
     try {
-      await this.device.sendReport(reportId, new Uint8Array(packet).buffer);
+      await this.device.sendReport(reportId, packet.buffer);
     } catch (error) {
       this.responseWaiter = null;
       const detail = error instanceof Error ? error.message : String(error);
@@ -301,4 +529,22 @@ export class KeychronM6HidClient {
     }
     return await response;
   }
+}
+
+/** 0x04 answer: [1] is the length of the ASCII version that starts at [2]. */
+function decodeFirmwareString(bytes: Uint8Array): string | null {
+  const length = Math.min(bytes[1] ?? 0, bytes.length - 2);
+  const text = Array.from(bytes.slice(2, 2 + length))
+    .filter((byte) => byte >= 0x20 && byte < 0x7f)
+    .map((byte) => String.fromCharCode(byte))
+    .join("")
+    .trim();
+  if (!text) return null;
+  return text.startsWith("v") ? text : `v${text}`;
+}
+
+/** 0x02 answer: major at [8], minor and patch in the nibbles of [7]. */
+function decodeFirmwareNibbles(bytes: Uint8Array): string | null {
+  if (bytes.length < 9) return null;
+  return `v${bytes[8]}.${(bytes[7] ?? 0) >> 4}.${(bytes[7] ?? 0) & 0x0f}`;
 }


### PR DESCRIPTION
## Summary

The Keychron M6 driver only read the DPI slots, polling table and battery byte of its 0x06 status report, so the control panel showed the mouse with no sensor, debounce, sleep or profile controls and a "firmware not yet decoded" placeholder. The M6 speaks Keychron Launcher's "8k" mouse protocol on its 0xffc1 collection (63-byte 0xb3/0xb4 queries, 20-byte 0xb5/0xb6 settings). This decodes the rest of it.

New in the driver:

- lift-off distance (0x42; PAW3950 codes 3/1/2 = 0.7 mm / 1 mm / 2 mm, mapped to Low/Medium/High)
- motion sync, angle snapping, ripple control (0x42; toggle bytes are 1 = on, 2 = off, 0 = leave alone, so the whole block is resent)
- angle tuning (0x42 with byte 9 = 2, signed angle in byte 10), only offered when status byte 53 bit 2 says the firmware supports it
- debounce 0-20 ms (0x43), sleep timeout in minutes (0x0a), onboard profile switching (0x0e) with the count from byte 50
- firmware string via 0x04 on 0xb3 (falls back to the 0x02 version nibbles), read once per connection
- DPI and polling levels of the connection in use: bytes 2-4 hold one nibble pair each for USB, 2.4 GHz and Bluetooth
- polling scale extended to 8000 Hz (`[125, 500, 1000, 2000, 4000, 8000]`, the Launcher's `POLLING_RATE_VALUE_SCALE`)
- settings acks are `[0xe4, code, command]`; a non-zero code (7 = unsupported) fails the write with that code

Every setter still re-reads the status report and throws if the mouse kept its old value.

## Hardware verification

Keychron M6, firmware 1.0.3, wired USB (PID 0xd060), driven over WebHID from Chrome:

- status packet decoded field by field against the layout in the file header (profile, per-connection nibbles, stages, byte 15 flags, debounce, sleep, battery, polling table, profile count)
- round trips with restore for angle snapping, lift-off codes 1, 2 and 3, debounce, sleep (byte 18 is minutes), polling level and profile switching (five profiles, each with its own DPI and polling table)
- this unit reports no angle-tuning support and acks the angle write without effect, hence the flag gate
- XY DPI (0x49), separate polling (0x4b) and receiver query (0x03) answer `0xe4 07`, so they stay out

Not included: button remapping (0x61/0x62/0x52). The commands are decoded, but the M6's button indices need confirming with physical presses first.

## Source

Protocol decoded from the Keychron Launcher web bundle (launcher.keychron.com), which also embeds tool descriptors spelling out the LOD codes, debounce range and sleep range.

## Tests

12 M6 tests against a fake device speaking the full protocol; `npm test` (1090) and `npm run build` pass.
