### PR TITLE
feat(dareu): add A950 PRO Mg support (resolves #78)

### DIFF
--- a/docs/dareu-a950-pro-mg.md
+++ b/docs/dareu-a950-pro-mg.md
@@ -1,0 +1,32 @@
+# Dareu A950 PRO Mg Jm protocol
+
+This driver covers the Dareu A950 PRO Mg (`TM271F`) and its `TM265Dongle`
+2.4 GHz receiver. It does not claim other Jm-family mice.
+
+## Evidence and hardware verification
+
+Dareu's All in One WebHID panel identifies mouse PID `0x1117` and receiver
+PID `0x1114`. The connected retail receiver reported VID `0x260D`, a service
+collection `0xFF05:0`, and a `0xFF02:2` command collection with 16-byte
+input/output report ID `8`.
+
+The receiver path (`260D:1114`) was exercised on hardware for status reads and
+read-back-verified DPI, polling, DPI-indicator, and sleep writes. The wired
+PID is recognized only when it exposes that same measured command shape; it
+has not yet been hardware-verified.
+
+## Packet and memory format
+
+Jm commands are 16-byte bodies sent with report ID `8`. The final byte is the
+vendor checksum over the body plus report ID. Command `8` reads at most ten
+memory bytes; command `7` writes at most ten bytes and is acknowledged before
+the next write. Read replies must echo the requested address and length.
+
+The vendor panel's documented configuration records are used for polling,
+legacy DPI stages, button assignments, DPI-indicator state, and mouse/DPI LED
+sleep values. Every supported write reads the record first, writes only its
+owned bytes, then reads the value back. Unknown or macro button records remain
+read-only.
+
+Firmware, reset, calibration, pairing, and macro-write commands are not sent.
+Do not add vendor binaries, extracted resources, or firmware to this repository.

--- a/package.json
+++ b/package.json
@@ -125,6 +125,10 @@
       "types": "./dist/corsair/index.d.ts",
       "import": "./dist/corsair/index.js"
     },
+    "./dareu": {
+      "types": "./dist/dareu/index.d.ts",
+      "import": "./dist/dareu/index.js"
+    },
     "./drivers": {
       "types": "./dist/drivers/index.d.ts",
       "import": "./dist/drivers/index.js"

--- a/src/dareu/index.test.ts
+++ b/src/dareu/index.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DAREU_DIRECT_PRODUCT_ID,
+  DAREU_MAX_BUFFER_CHUNK,
+  DAREU_RECEIVER_PRODUCT_ID,
+  DAREU_REPORT_SIZE,
+  dareuCheckActiveRequest,
+  dareuChecksum,
+  dareuDecodeButtonAssignment,
+  dareuDecodeBattery,
+  dareuDecodeDpiLedState,
+  dareuDecodeFirmwareVersion,
+  dareuDecodeActiveProfile,
+  dareuDecodeReadBufferReply,
+  dareuDpiFromId,
+  dareuDpiId,
+  dareuEncodeButtonAssignment,
+  dareuEncodeDpiLedBrightness,
+  dareuGetBatteryRequest,
+  dareuGetActiveProfileRequest,
+  dareuGetMouseFirmwareRequest,
+  dareuGetReceiverFirmwareRequest,
+  dareuIsValidDpi,
+  dareuIsValidDpiLedSetting,
+  dareuIsValidSleepTimeout,
+  dareuMatchesReply,
+  dareuPollingRateHz,
+  dareuPollingRateId,
+  dareuReadBufferRequests,
+  dareuSetActiveProfileRequest,
+  dareuWithMemoryChecksum,
+  dareuWriteBufferRequests,
+} from "./index.js";
+
+test("Dareu catalog keeps direct mouse and receiver distinct", () => {
+  assert.equal(DAREU_DIRECT_PRODUCT_ID, 0x1117);
+  assert.equal(DAREU_RECEIVER_PRODUCT_ID, 0x1114);
+});
+
+test("Dareu Jm frames include report ID 8 in their checksum", () => {
+  const active = dareuCheckActiveRequest();
+  const battery = dareuGetBatteryRequest();
+  assert.equal(active.length, DAREU_REPORT_SIZE);
+  assert.deepEqual([active[0], active[15]], [3, 74]);
+  assert.deepEqual([battery[0], battery[15]], [4, 73]);
+  assert.equal(dareuChecksum(new Uint8Array([1, 0])), 84);
+  assert.deepEqual([...dareuWithMemoryChecksum(new Uint8Array([100]))], [100, 241]);
+  assert.throws(() => dareuChecksum(new Uint8Array()), RangeError);
+});
+
+test("Dareu buffer reads are ten-byte bounded and decode only matching replies", () => {
+  const requests = dareuReadBufferRequests(0x0fff, 25);
+  assert.equal(requests.length, 3);
+  assert.deepEqual(
+    requests.map((request) => [request[0], request[2], request[3], request[4]]),
+    [[8, 0x0f, 0xff, 10], [8, 0x10, 0x09, 10], [8, 0x10, 0x13, 5]],
+  );
+
+  const reply = new Uint8Array(DAREU_REPORT_SIZE);
+  reply[0] = 8;
+  reply.set(requests[2]!.slice(1, 5), 1);
+  reply.set([1, 2, 3, 4, 5], 5);
+  assert.deepEqual([...dareuDecodeReadBufferReply(requests[2], reply) ?? []], [1, 2, 3, 4, 5]);
+  reply[3] = 0x14;
+  assert.equal(dareuDecodeReadBufferReply(requests[2], reply), null);
+  reply[0] = 10;
+  assert.equal(dareuDecodeReadBufferReply(requests[2], reply), null);
+  assert.equal(dareuDecodeReadBufferReply(requests[2], new Uint8Array(15)), null);
+  assert.throws(() => dareuReadBufferRequests(0x10000, 1), RangeError);
+  assert.throws(() => dareuReadBufferRequests(0xffff, 2), RangeError);
+});
+
+test("Dareu buffer writes preserve byte order and do not mutate the source", () => {
+  const data = Uint8Array.from({ length: DAREU_MAX_BUFFER_CHUNK + 2 }, (_, index) => index + 1);
+  const writes = dareuWriteBufferRequests(96, data);
+  assert.equal(writes.length, 2);
+  assert.deepEqual([...writes[0].slice(0, 15)], [7, 0, 0, 96, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  assert.deepEqual([...writes[1].slice(0, 7)], [7, 0, 0, 106, 2, 11, 12]);
+  assert.deepEqual([...data], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  assert.throws(() => dareuWriteBufferRequests(0, new Uint8Array()), RangeError);
+});
+
+test("Dareu reply and value validation reject malformed and unsupported values", () => {
+  const request = dareuGetBatteryRequest();
+  const reply = new Uint8Array(DAREU_REPORT_SIZE);
+  reply[0] = 4;
+  reply[5] = 87;
+  reply[6] = 1;
+  assert.equal(dareuMatchesReply(request, reply), true);
+  assert.deepEqual(dareuDecodeBattery(reply), { percent: 87, status: 1 });
+  reply[5] = 101;
+  assert.equal(dareuDecodeBattery(reply), null);
+  reply[0] = 10;
+  assert.equal(dareuMatchesReply(request, reply), false);
+
+  for (const dpi of [100, 400, 1600, 26000]) assert.equal(dareuIsValidDpi(dpi), true);
+  for (const dpi of [99, 125, 26050, 1600.5, Number.NaN]) assert.equal(dareuIsValidDpi(dpi), false);
+  assert.equal(dareuPollingRateId(4000, "wired"), null);
+  assert.equal(dareuPollingRateId(4000, "receiver"), 32);
+  assert.equal(dareuPollingRateHz(32, "wired"), null);
+  assert.equal(dareuPollingRateHz(32, "receiver"), 4000);
+  assert.equal(dareuIsValidDpiLedSetting(2, 10, 5), true);
+  assert.equal(dareuIsValidDpiLedSetting(3, 10, 5), false);
+  assert.equal(dareuIsValidSleepTimeout(1800), true);
+  assert.equal(dareuIsValidSleepTimeout(120), false);
+});
+
+test("Dareu profiles, firmware, and legacy DPI ids follow the JmMouse codec", () => {
+  const profileRead = dareuGetActiveProfileRequest();
+  const profileWrite = dareuSetActiveProfileRequest(3);
+  assert.deepEqual([profileRead[0], profileWrite[0], profileWrite[4], profileWrite[5]], [14, 15, 0x81, 2]);
+  assert.throws(() => dareuSetActiveProfileRequest(5), RangeError);
+
+  const profileReply = new Uint8Array(DAREU_REPORT_SIZE);
+  profileReply[0] = 14;
+  profileReply[5] = 2;
+  assert.equal(dareuDecodeActiveProfile(profileReply), 3);
+
+  const firmware = new Uint8Array(DAREU_REPORT_SIZE);
+  firmware[0] = 18;
+  firmware[5] = 1;
+  firmware[6] = 2;
+  assert.equal(dareuGetMouseFirmwareRequest()[0], 18);
+  assert.equal(dareuGetReceiverFirmwareRequest()[0], 29);
+  assert.equal(dareuDecodeFirmwareVersion(firmware, 18), 0x0102);
+  assert.equal(dareuDecodeFirmwareVersion(firmware, 29), null);
+
+  for (const dpi of [100, 12_800, 25_600, 26_000]) {
+    const id = dareuDpiId(dpi);
+    assert.notEqual(id, null);
+    assert.equal(dareuDpiFromId(id!), dpi);
+  }
+  assert.equal(dareuDpiFromId(0x4500), null);
+});
+
+test("Dareu button and DPI-indicator codecs retain only verified values", () => {
+  const back = dareuEncodeButtonAssignment("Back");
+  assert.deepEqual([...back ?? []], [1, 8, 0, 76]);
+  assert.equal(dareuDecodeButtonAssignment(back ?? new Uint8Array()), "Back");
+  assert.deepEqual([...dareuEncodeButtonAssignment("DPI Cycle") ?? []], [2, 1, 0, 82]);
+  assert.equal(dareuDecodeButtonAssignment(dareuEncodeButtonAssignment("DPI Up")!), "DPI Up");
+  assert.equal(dareuEncodeButtonAssignment("Macro 1"), null);
+  assert.equal(dareuDecodeButtonAssignment(new Uint8Array([8, 0, 251, 0])), null);
+
+  const led = new Uint8Array([
+    2, dareuChecksum(new Uint8Array([2, 0])),
+    127, dareuChecksum(new Uint8Array([127, 0])),
+    3, dareuChecksum(new Uint8Array([3, 0])),
+    1, dareuChecksum(new Uint8Array([1, 0])),
+  ]);
+  assert.deepEqual(dareuDecodeDpiLedState(led), { mode: 2, brightness: 5, speed: 3 });
+  assert.deepEqual([...dareuEncodeDpiLedBrightness(5) ?? []], [127, 214]);
+  assert.equal(dareuEncodeDpiLedBrightness(11), null);
+});

--- a/src/dareu/index.test.ts
+++ b/src/dareu/index.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   DAREU_DIRECT_PRODUCT_ID,
   DAREU_MAX_BUFFER_CHUNK,
+  DAREU_PRODUCTS,
   DAREU_RECEIVER_PRODUCT_ID,
   DAREU_REPORT_SIZE,
   dareuCheckActiveRequest,
@@ -37,6 +38,8 @@ import {
 test("Dareu catalog keeps direct mouse and receiver distinct", () => {
   assert.equal(DAREU_DIRECT_PRODUCT_ID, 0x1117);
   assert.equal(DAREU_RECEIVER_PRODUCT_ID, 0x1114);
+  assert.equal(DAREU_PRODUCTS.get(DAREU_RECEIVER_PRODUCT_ID)?.verified, true);
+  assert.equal(DAREU_PRODUCTS.get(DAREU_DIRECT_PRODUCT_ID)?.verified, false);
 });
 
 test("Dareu Jm frames include report ID 8 in their checksum", () => {

--- a/src/dareu/index.ts
+++ b/src/dareu/index.ts
@@ -23,11 +23,13 @@ export interface DareuProduct {
   model: string;
   name: string;
   transport: "wired" | "receiver";
+  /** True only for a transport exercised against the retail A950 PRO Mg. */
+  verified: boolean;
 }
 
 export const DAREU_PRODUCTS: ReadonlyMap<number, DareuProduct> = new Map([
-  [DAREU_DIRECT_PRODUCT_ID, { model: "TM271F", name: "A950 PRO Mg", transport: "wired" }],
-  [DAREU_RECEIVER_PRODUCT_ID, { model: "TM265Dongle", name: "2.4G Receiver", transport: "receiver" }],
+  [DAREU_DIRECT_PRODUCT_ID, { model: "TM271F", name: "A950 PRO Mg", transport: "wired", verified: false }],
+  [DAREU_RECEIVER_PRODUCT_ID, { model: "TM265Dongle", name: "2.4G Receiver", transport: "receiver", verified: true }],
 ]);
 
 export const DAREU_REPORT_ID = 0x08;

--- a/src/dareu/index.ts
+++ b/src/dareu/index.ts
@@ -1,0 +1,386 @@
+/**
+ * Dareu A950 PRO Mg (TM271F) Jm-family configuration codec.
+ *
+ * Framing is derived from Dareu's Jm WebHID panel (`jmdevice.v_1.3.24.js`).
+ * The vendor id, command collection, and report-8 size below were measured
+ * from the TM265 receiver; clients must still require that exact shape.
+ */
+
+export const DAREU_DIRECT_PRODUCT_ID = 0x1117;
+export const DAREU_RECEIVER_PRODUCT_ID = 0x1114;
+export const DAREU_PRODUCT_IDS = [DAREU_DIRECT_PRODUCT_ID, DAREU_RECEIVER_PRODUCT_ID] as const;
+
+/** Captured from the connected TM265 receiver's USB and HID descriptors. */
+export const DAREU_VENDOR_ID = 0x260d;
+/** Receiver service collection that must accompany the report-8 interface. */
+export const DAREU_RECEIVER_USAGE_PAGE = 0xff05;
+export const DAREU_RECEIVER_USAGE = 0x00;
+/** Jm command collection: report ID 8 has 16-byte input/output bodies. */
+export const DAREU_COMMAND_USAGE_PAGE = 0xff02;
+export const DAREU_COMMAND_USAGE = 0x02;
+
+export interface DareuProduct {
+  model: string;
+  name: string;
+  transport: "wired" | "receiver";
+}
+
+export const DAREU_PRODUCTS: ReadonlyMap<number, DareuProduct> = new Map([
+  [DAREU_DIRECT_PRODUCT_ID, { model: "TM271F", name: "A950 PRO Mg", transport: "wired" }],
+  [DAREU_RECEIVER_PRODUCT_ID, { model: "TM265Dongle", name: "2.4G Receiver", transport: "receiver" }],
+]);
+
+export const DAREU_REPORT_ID = 0x08;
+export const DAREU_REPORT_SIZE = 16;
+export const DAREU_MAX_BUFFER_CHUNK = 10;
+export const DAREU_MAX_BUFFER_ADDRESS = 0xffff;
+
+export const DAREU_DPI_MIN = 100;
+export const DAREU_DPI_MAX = 26000;
+export const DAREU_DPI_STEP = 50;
+export const DAREU_DEFAULT_DPI_STAGES = [400, 800, 1600, 3200, 6400] as const;
+export const DAREU_DEFAULT_ACTIVE_DPI_STAGE = 2;
+export const DAREU_BUTTON_IDS = [1, 2, 3, 4, 5, 6] as const;
+/** JmMouse reports four numbered, onboard configuration banks. */
+export const DAREU_PROFILE_COUNT = 4;
+
+export const DAREU_WIRED_POLLING_RATES = [125, 250, 500, 1000] as const;
+export const DAREU_WIRELESS_POLLING_RATES = [125, 250, 500, 1000, 2000, 4000] as const;
+/** Dareu's supplied energy page exposes these mouse and DPI-LED sleep values. */
+export const DAREU_SLEEP_TIMEOUT_SECONDS = [60, 180, 300, 600, 1200, 1800, 2400, 0] as const;
+
+const POLLING_RATE_IDS = new Map<number, number>([
+  [125, 8],
+  [250, 4],
+  [500, 2],
+  [1000, 1],
+  [2000, 16],
+  [4000, 32],
+]);
+
+const COMMAND = {
+  CHECK_ACTIVE: 3,
+  GET_BATTERY: 4,
+  WRITE_BUFFER: 7,
+  READ_BUFFER: 8,
+  GET_ACTIVE_PROFILE: 14,
+  SET_ACTIVE_PROFILE: 15,
+  GET_MOUSE_FIRMWARE: 18,
+  GET_RECEIVER_FIRMWARE: 29,
+} as const;
+
+/** DPI indicator controls offered by the A950 vendor page. */
+export const DAREU_DPI_LED_EFFECTS = [0, 1, 2] as const;
+export const DAREU_DPI_LED_BRIGHTNESS_RANGE = [1, 10] as const;
+export const DAREU_DPI_LED_SPEED_RANGE = [1, 5] as const;
+
+export const DAREU_MEMORY_ADDRESS = {
+  pollingRate: 0,
+  dpiHeader: 2,
+  dpiLegacyStages: 12,
+  buttonAssignments: 96,
+  dpiLed: 76,
+  dpiLedEnabled: 82,
+  dpiLedSleep: 173,
+  sleepEnabled: 181,
+  sleepTimeout: 183,
+  dpiExtendedStages: 6912,
+} as const;
+
+export const DAREU_BUTTONS = [
+  { id: 1, name: "Left" },
+  { id: 2, name: "Right" },
+  { id: 3, name: "Middle" },
+  { id: 4, name: "Back" },
+  { id: 5, name: "Forward" },
+  { id: 6, name: "DPI" },
+] as const;
+
+export const DAREU_BUTTON_ACTIONS = [
+  "Left Click", "Right Click", "Middle Click", "Back", "Forward",
+  "DPI Cycle", "DPI Up", "DPI Down",
+] as const;
+
+const BUTTON_MASKS = new Map<string, number>([
+  ["Left Click", 1],
+  ["Right Click", 2],
+  ["Middle Click", 4],
+  ["Back", 8],
+  ["Forward", 16],
+]);
+
+const DPI_BUTTON_ACTIONS = new Map<string, number>([
+  ["DPI Cycle", 1],
+  ["DPI Up", 2],
+  ["DPI Down", 3],
+]);
+
+function assertAddress(address: number): void {
+  if (!Number.isInteger(address) || address < 0 || address > DAREU_MAX_BUFFER_ADDRESS) {
+    throw new RangeError(`Dareu buffer address must be an integer from 0 to ${DAREU_MAX_BUFFER_ADDRESS}.`);
+  }
+}
+
+function assertBufferRange(address: number, length: number): void {
+  assertAddress(address);
+  if (!Number.isInteger(length) || length < 1 || address + length > DAREU_MAX_BUFFER_ADDRESS + 1) {
+    throw new RangeError("Dareu buffer range must stay within the 16-bit address space.");
+  }
+}
+
+function frame(command: number): Uint8Array {
+  const full = new Uint8Array(DAREU_REPORT_SIZE + 1);
+  full[0] = DAREU_REPORT_ID;
+  full[1] = command;
+  return full;
+}
+
+function sealFrame(full: Uint8Array): Uint8Array {
+  full[full.length - 1] = dareuChecksum(full);
+  return full.slice(1);
+}
+
+/**
+ * Jm checksum.  The vendor calculates it over every byte except the final
+ * checksum slot; output frames include report ID 8 in that sum.
+ */
+export function dareuChecksum(bytes: Uint8Array): number {
+  if (bytes.length < 2) throw new RangeError("Dareu checksum needs a payload byte and checksum slot.");
+  let sum = 0;
+  for (let index = 0; index < bytes.length - 1; index++) sum += bytes[index];
+  return (sum < 55 ? 85 - sum : 341 - sum) & 0xff;
+}
+
+/** Append the per-value checksum stored in Jm configuration memory. */
+export function dareuWithMemoryChecksum(data: Uint8Array): Uint8Array {
+  const result = new Uint8Array(data.length + 1);
+  result.set(data);
+  result[result.length - 1] = dareuChecksum(result);
+  return result;
+}
+
+export function dareuHasValidMemoryChecksum(bytes: Uint8Array): boolean {
+  return bytes.length >= 2 && bytes[bytes.length - 1] === dareuChecksum(bytes);
+}
+
+/** 16-byte body for report ID 8; callers pass this to `sendReport(8, body)`. */
+export function dareuCheckActiveRequest(): Uint8Array {
+  return sealFrame(frame(COMMAND.CHECK_ACTIVE));
+}
+
+/** 16-byte body for the Jm battery-status request. */
+export function dareuGetBatteryRequest(): Uint8Array {
+  return sealFrame(frame(COMMAND.GET_BATTERY));
+}
+
+/** Read the one-based JmMouse profile currently active on the mouse. */
+export function dareuGetActiveProfileRequest(): Uint8Array {
+  return sealFrame(frame(COMMAND.GET_ACTIVE_PROFILE));
+}
+
+/** Switch the active JmMouse profile using the mouse (0x81) target. */
+export function dareuSetActiveProfileRequest(profile: number): Uint8Array {
+  if (!Number.isInteger(profile) || profile < 1 || profile > DAREU_PROFILE_COUNT) {
+    throw new RangeError(`Dareu profile must be between 1 and ${DAREU_PROFILE_COUNT}.`);
+  }
+  const full = frame(COMMAND.SET_ACTIVE_PROFILE);
+  full[5] = 0x81;
+  full[6] = profile - 1;
+  return sealFrame(full);
+}
+
+/** Get the paired mouse firmware version (two-byte big-endian Jm value). */
+export function dareuGetMouseFirmwareRequest(): Uint8Array {
+  return sealFrame(frame(COMMAND.GET_MOUSE_FIRMWARE));
+}
+
+/** Get the receiver firmware version (two-byte big-endian Jm value). */
+export function dareuGetReceiverFirmwareRequest(): Uint8Array {
+  return sealFrame(frame(COMMAND.GET_RECEIVER_FIRMWARE));
+}
+
+/** A reply must be a 16-byte report for the requested command, not event 10. */
+export function dareuMatchesReply(request: Uint8Array, reply: Uint8Array): boolean {
+  if (request.length !== DAREU_REPORT_SIZE || reply.length !== DAREU_REPORT_SIZE || reply[0] === 10 || request[0] !== reply[0]) {
+    return false;
+  }
+  // Read-buffer replies echo the request address and length. Matching those
+  // fields prevents an earlier asynchronous read reply from being treated as
+  // the answer to the next read.
+  return request[0] !== COMMAND.READ_BUFFER
+    || (request[2] === reply[2] && request[3] === reply[3] && request[4] === reply[4]);
+}
+
+/** Decode a well-formed battery reply. Status is intentionally left raw. */
+export function dareuDecodeBattery(reply: Uint8Array): { percent: number; status: number } | null {
+  if (reply.length !== DAREU_REPORT_SIZE || reply[0] !== COMMAND.GET_BATTERY || reply[5] > 100) return null;
+  return { percent: reply[5], status: reply[6] };
+}
+
+export function dareuDecodeActiveProfile(reply: Uint8Array): number | null {
+  const profile = reply[5];
+  return reply.length === DAREU_REPORT_SIZE
+    && reply[0] === COMMAND.GET_ACTIVE_PROFILE
+    && profile !== undefined
+    && profile < DAREU_PROFILE_COUNT
+    ? profile + 1
+    : null;
+}
+
+/** Decode the exact two-byte big-endian version reported by Jm firmware. */
+export function dareuDecodeFirmwareVersion(reply: Uint8Array, command: 18 | 29): number | null {
+  if (reply.length !== DAREU_REPORT_SIZE || reply[0] !== command) return null;
+  return (reply[5]! << 8) | reply[6]!;
+}
+
+function readBufferRequest(address: number, length: number): Uint8Array {
+  assertBufferRange(address, length);
+  if (length > DAREU_MAX_BUFFER_CHUNK) {
+    throw new RangeError(`Dareu buffer requests may read at most ${DAREU_MAX_BUFFER_CHUNK} bytes.`);
+  }
+  const full = frame(COMMAND.READ_BUFFER);
+  full[3] = address >> 8;
+  full[4] = address & 0xff;
+  full[5] = length;
+  return sealFrame(full);
+}
+
+/** Split a bounded memory read into the vendor protocol's ten-byte requests. */
+export function dareuReadBufferRequests(address: number, length: number): Uint8Array[] {
+  assertBufferRange(address, length);
+  const requests: Uint8Array[] = [];
+  for (let offset = 0; offset < length; offset += DAREU_MAX_BUFFER_CHUNK) {
+    requests.push(readBufferRequest(address + offset, Math.min(DAREU_MAX_BUFFER_CHUNK, length - offset)));
+  }
+  return requests;
+}
+
+/** Extract the requested data from a matching Jm buffer-read reply. */
+export function dareuDecodeReadBufferReply(request: Uint8Array, reply: Uint8Array): Uint8Array | null {
+  if (!dareuMatchesReply(request, reply) || request[0] !== COMMAND.READ_BUFFER) return null;
+  const length = request[4];
+  if (length < 1 || length > DAREU_MAX_BUFFER_CHUNK || reply.length < 5 + length) return null;
+  return reply.slice(5, 5 + length);
+}
+
+function writeBufferRequest(address: number, data: Uint8Array): Uint8Array {
+  assertBufferRange(address, data.length);
+  if (data.length > DAREU_MAX_BUFFER_CHUNK) {
+    throw new RangeError(`Dareu buffer requests may write at most ${DAREU_MAX_BUFFER_CHUNK} bytes.`);
+  }
+  const full = frame(COMMAND.WRITE_BUFFER);
+  full[3] = address >> 8;
+  full[4] = address & 0xff;
+  full[5] = data.length;
+  full.set(data, 6);
+  return sealFrame(full);
+}
+
+/** Split a bounded memory write into ten-byte commands without mutating data. */
+export function dareuWriteBufferRequests(address: number, data: Uint8Array): Uint8Array[] {
+  assertBufferRange(address, data.length);
+  const requests: Uint8Array[] = [];
+  for (let offset = 0; offset < data.length; offset += DAREU_MAX_BUFFER_CHUNK) {
+    requests.push(writeBufferRequest(address + offset, data.slice(offset, offset + DAREU_MAX_BUFFER_CHUNK)));
+  }
+  return requests;
+}
+
+export function dareuIsValidDpi(dpi: number): boolean {
+  return Number.isInteger(dpi)
+    && dpi >= DAREU_DPI_MIN
+    && dpi <= DAREU_DPI_MAX
+    && (dpi - DAREU_DPI_MIN) % DAREU_DPI_STEP === 0;
+}
+
+/** Convert a UI DPI value to the legacy Jm sensor-map identifier. */
+export function dareuDpiId(dpi: number): number | null {
+  if (!dareuIsValidDpi(dpi)) return null;
+  const index = dpi / DAREU_DPI_STEP - 1;
+  return index < 256 ? index : index < 512 ? (index - 256) | 0x4400 : (index - 512) | 0x8800;
+}
+
+/** Convert a legacy Jm sensor-map identifier to its exact UI DPI value. */
+export function dareuDpiFromId(id: number): number | null {
+  if (!Number.isInteger(id) || id < 0 || id > 0xffff) return null;
+  const high = id >> 8;
+  const index = high === 0 ? id : high === 0x44 ? 256 + (id & 0xff) : high === 0x88 ? 512 + (id & 0xff) : -1;
+  const dpi = DAREU_DPI_STEP * (index + 1);
+  return dareuIsValidDpi(dpi) ? dpi : null;
+}
+
+export function dareuPollingRateId(hz: number, transport: "wired" | "receiver"): number | null {
+  const id = POLLING_RATE_IDS.get(hz);
+  return id !== undefined && (transport === "receiver" || hz <= 1000) ? id : null;
+}
+
+export function dareuPollingRateHz(id: number, transport: "wired" | "receiver"): number | null {
+  for (const [hz, candidate] of POLLING_RATE_IDS) {
+    if (candidate === id && (transport === "receiver" || hz <= 1000)) return hz;
+  }
+  return null;
+}
+
+export function dareuIsValidDpiLedSetting(effect: number, brightness: number, speed: number): boolean {
+  return DAREU_DPI_LED_EFFECTS.includes(effect as (typeof DAREU_DPI_LED_EFFECTS)[number])
+    && Number.isInteger(brightness)
+    && brightness >= DAREU_DPI_LED_BRIGHTNESS_RANGE[0]
+    && brightness <= DAREU_DPI_LED_BRIGHTNESS_RANGE[1]
+    && Number.isInteger(speed)
+    && speed >= DAREU_DPI_LED_SPEED_RANGE[0]
+    && speed <= DAREU_DPI_LED_SPEED_RANGE[1];
+}
+
+export function dareuIsValidSleepTimeout(seconds: number): boolean {
+  return (DAREU_SLEEP_TIMEOUT_SECONDS as readonly number[]).includes(seconds);
+}
+
+/** Decode one Jm button record. Unknown, macro, and corrupt records stay opaque. */
+export function dareuDecodeButtonAssignment(record: Uint8Array): string | null {
+  if (record.length !== 4 || !dareuHasValidMemoryChecksum(record) || record[2] !== 0) {
+    return null;
+  }
+  const actions = record[0] === 1 ? BUTTON_MASKS : record[0] === 2 ? DPI_BUTTON_ACTIONS : null;
+  if (!actions) return null;
+  for (const [action, value] of actions) {
+    if (record[1] === value) return action;
+  }
+  return null;
+}
+
+/** Encode only the ordinary mouse-button mappings proven in Dareu's Jm panel. */
+export function dareuEncodeButtonAssignment(action: string): Uint8Array | null {
+  const mask = BUTTON_MASKS.get(action);
+  if (mask !== undefined) return dareuWithMemoryChecksum(new Uint8Array([1, mask, 0]));
+  const dpiAction = DPI_BUTTON_ACTIONS.get(action);
+  return dpiAction === undefined ? null : dareuWithMemoryChecksum(new Uint8Array([2, dpiAction, 0]));
+}
+
+export interface DareuDpiLedState {
+  mode: 0 | 1 | 2;
+  brightness: number;
+  speed: number;
+}
+
+/** Decode the four checksum-protected values in the DPI-indicator block. */
+export function dareuDecodeDpiLedState(buffer: Uint8Array): DareuDpiLedState | null {
+  if (buffer.length !== 8) return null;
+  for (let offset = 0; offset < buffer.length; offset += 2) {
+    if (!dareuHasValidMemoryChecksum(buffer.slice(offset, offset + 2))) return null;
+  }
+  const enabled = buffer[6];
+  const rawMode = buffer[0];
+  const mode = enabled === 0 ? 0 : rawMode === 1 || rawMode === 2 ? rawMode : null;
+  const brightness = Math.round((buffer[2] * 10) / 255);
+  const speed = buffer[4];
+  if (mode === null || !dareuIsValidDpiLedSetting(mode, brightness, speed)) return null;
+  return { mode, brightness, speed };
+}
+
+export function dareuEncodeDpiLedBrightness(brightness: number): Uint8Array | null {
+  if (!Number.isInteger(brightness)
+    || brightness < DAREU_DPI_LED_BRIGHTNESS_RANGE[0]
+    || brightness > DAREU_DPI_LED_BRIGHTNESS_RANGE[1]) return null;
+  // Matches the vendor panel's assignment into a Uint8Array (truncate, don't round).
+  return dareuWithMemoryChecksum(new Uint8Array([Math.floor((255 * brightness) / 10)]));
+}

--- a/src/drivers/dareu/hid.test.ts
+++ b/src/drivers/dareu/hid.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dareuChecksum, dareuDpiId, dareuEncodeButtonAssignment, dareuWithMemoryChecksum } from "@openmouse/protocol/dareu";
+import { DareuHidClient } from "./hid.ts";
+
+type Sent = { reportId: number; data: Uint8Array };
+
+class FakeDareuDevice {
+  vendorId = 0x260d;
+  productId = 0x1114;
+  productName = "2.4G Wireless Receiver";
+  opened = false;
+  collections = [
+    { usagePage: 0xff05, usage: 0, children: [], featureReports: [], inputReports: [], outputReports: [] },
+    {
+      usagePage: 0xff02,
+      usage: 2,
+      children: [],
+      featureReports: [],
+      inputReports: [{ reportId: 8, items: [{ reportSize: 8, reportCount: 16 }] }],
+      outputReports: [{ reportId: 8, items: [{ reportSize: 8, reportCount: 16 }] }],
+    },
+  ];
+  readonly memory = new Uint8Array(7000);
+  readonly sent: Sent[] = [];
+  maxInFlight = 0;
+  private inFlight = 0;
+  private profile = 1;
+  private listeners = new Set<(event: HIDInputReportEvent) => void>();
+
+  constructor() {
+    this.writePair(0, 16);
+    this.writePair(2, 5);
+    this.writePair(4, 2);
+    [400, 800, 1600, 3200, 6400].forEach((dpi, stage) => this.writeDpi(stage, dpi));
+    this.writePair(76, 2);
+    this.writePair(78, 127);
+    this.writePair(80, 3);
+    this.writePair(82, 1);
+    this.writePair(173, 18);
+    this.writePair(181, 1);
+    this.writePair(183, 18);
+    ["Left Click", "Right Click", "Middle Click", "Back", "Forward", "DPI Cycle"].forEach((action, index) => {
+      this.memory.set(dareuEncodeButtonAssignment(action)!, 96 + index * 4);
+    });
+    const macro = new Uint8Array([6, 1, 0, 0]);
+    macro[3] = dareuChecksum(macro);
+    this.memory.set(macro, 112);
+  }
+
+  async open(): Promise<void> { this.opened = true; }
+  async close(): Promise<void> { this.opened = false; }
+
+  addEventListener(type: string, listener: (event: HIDInputReportEvent) => void): void {
+    if (type === "inputreport") this.listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: HIDInputReportEvent) => void): void {
+    if (type === "inputreport") this.listeners.delete(listener);
+  }
+
+  async sendReport(reportId: number, data: BufferSource): Promise<void> {
+    const frame = new Uint8Array(data as ArrayBufferLike);
+    this.sent.push({ reportId, data: frame });
+    this.inFlight += 1;
+    this.maxInFlight = Math.max(this.maxInFlight, this.inFlight);
+    try {
+      if (frame[0] === 7) {
+        const address = frame[2]! << 8 | frame[3]!;
+        this.memory.set(frame.slice(5, 5 + frame[4]!), address);
+      }
+      const reply = new Uint8Array(16);
+      reply[0] = frame[0]!;
+      if (frame[0] === 3) reply[5] = 1;
+      if (frame[0] === 4) { reply[5] = 86; reply[6] = 1; }
+      if (frame[0] === 14) reply[5] = this.profile - 1;
+      if (frame[0] === 15) this.profile = frame[5]! + 1;
+      if (frame[0] === 18) { reply[5] = 1; reply[6] = 0x30; }
+      if (frame[0] === 29) { reply[5] = 1; reply[6] = 1; }
+      if (frame[0] === 8) {
+        const address = frame[2]! << 8 | frame[3]!;
+        reply.set(frame.slice(0, 5));
+        reply.set(this.memory.slice(address, address + frame[4]!), 5);
+      }
+      queueMicrotask(() => this.listeners.forEach((listener) =>
+        listener({ reportId, data: new DataView(reply.buffer) } as HIDInputReportEvent)));
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    } finally {
+      this.inFlight -= 1;
+    }
+  }
+
+  private writePair(address: number, value: number): void {
+    this.memory.set(dareuWithMemoryChecksum(new Uint8Array([value])), address);
+  }
+
+  private writeDpi(stage: number, dpi: number): void {
+    const id = dareuDpiId(dpi);
+    if (id === null) throw new Error("test DPI must be encodable");
+    const record = new Uint8Array([id & 0xff, id & 0xff, id >> 8, 0]);
+    record[3] = dareuChecksum(record);
+    this.memory.set(record, 12 + stage * 4);
+  }
+}
+
+function device(productId = 0x1114): HIDDevice {
+  const fake = new FakeDareuDevice();
+  fake.productId = productId;
+  return fake as unknown as HIDDevice;
+}
+
+function fake(device: HIDDevice): FakeDareuDevice {
+  return device as unknown as FakeDareuDevice;
+}
+
+test("Dareu only claims the measured VID, PID, service, and report-8 collection", () => {
+  const receiver = device();
+  const wired = device(0x1117);
+  assert.equal(DareuHidClient.isSupported(receiver), true);
+  assert.equal(DareuHidClient.isSupported(wired), true);
+  assert.equal(DareuHidClient.isSupported({ ...receiver, vendorId: 0x1234 }), false);
+  fake(receiver).collections[1]!.outputReports[0]!.items[0]!.reportCount = 15;
+  assert.equal(DareuHidClient.isSupported(receiver), false);
+});
+
+test("Dareu reads legacy DPI, profiles, firmware, and leaves macros read-only", async () => {
+  const receiver = device();
+  const status = await new DareuHidClient(receiver).readStatus();
+
+  assert.equal(status.batteryPercent, 86);
+  assert.equal(status.batteryState, "Charging");
+  assert.equal(status.dpi, 1600);
+  assert.equal(status.dpiY, undefined);
+  assert.equal(status.supportsSeparateDpiAxes, false);
+  assert.deepEqual(status.dpiStages, [400, 800, 1600, 3200, 6400]);
+  assert.equal(status.pollingRateHz, 2000);
+  assert.deepEqual(status.supportedPollingRates, [125, 250, 500, 1000, 2000, 4000]);
+  assert.equal(status.activeProfile, 1);
+  assert.equal(status.profileCount, 4);
+  assert.deepEqual(status.fixedButtons, ["Forward"]);
+  assert.equal(status.buttonMappings?.Forward, "Custom (read-only)");
+  assert.equal(status.buttonMappings?.DPI, "DPI Cycle");
+  assert.equal(status.dpiLedMode, 2);
+  assert.equal(status.dpiLedBrightness, 5);
+  assert.equal(status.dpiLedSpeed, 3);
+  assert.equal(status.dpiLedSleepTimeout, 180);
+  assert.equal(status.sleepTimeout, 180);
+  assert.equal(status.ui?.powerOverview, true);
+  assert.deepEqual(status.firmware, ["Mouse 1.30", "Receiver 1.01"]);
+});
+
+test("Dareu writes legacy DPI, profiles, and settings serially with read-back", async () => {
+  const receiver = device();
+  const client = new DareuHidClient(receiver);
+
+  await Promise.all([client.setDpi(1800), client.setPollingRate(4000)]);
+  await client.setButtonMapping("Back", "Forward");
+  await client.setButtonMapping("DPI", "DPI Up");
+  await client.setProfile(3);
+  await client.setDpiLedSleepTimeout(600);
+  await client.setSleepTimeout(300);
+
+  const record = fake(receiver).memory.slice(12 + 2 * 4, 12 + 3 * 4);
+  assert.deepEqual([...record], [35, 35, 0, 15]);
+  assert.equal(fake(receiver).memory[0], 32);
+  assert.equal(fake(receiver).memory[96 + 3 * 4 + 1], 16);
+  assert.deepEqual([...fake(receiver).memory.slice(116, 120)], [2, 2, 0, 81]);
+  assert.equal(fake(receiver).memory[173], 60);
+  assert.equal(fake(receiver).memory[181], 1);
+  assert.equal(fake(receiver).memory[183], 30);
+  assert.equal(fake(receiver).maxInFlight, 1);
+  assert.equal((await client.readStatus()).activeProfile, 3);
+});
+
+test("Dareu applies breathing after acknowledging the DPI-indicator enable write", async () => {
+  const receiver = device();
+  const client = new DareuHidClient(receiver);
+
+  await client.setDpiLighting(2, 4, 5);
+
+  const writes = fake(receiver).sent
+    .filter(({ data }) => data[0] === 7)
+    .map(({ data }) => [data[2], data[3], data[5]]);
+  assert.deepEqual(writes, [[0, 82, 1], [0, 76, 2], [0, 78, 102], [0, 80, 5]]);
+  assert.equal((await client.readStatus()).dpiLedMode, 2);
+});
+
+test("Dareu rejects unsupported rates and unknown button records before writing them", async () => {
+  const receiver = device();
+  const client = new DareuHidClient(receiver);
+  await assert.rejects(client.setButtonMapping("Forward", "Back"), /unknown or macro/i);
+  const writesBefore = fake(receiver).sent.filter(({ data }) => data[0] === 7).length;
+  await assert.rejects(client.setPollingRate(8000), /unavailable/i);
+  await assert.rejects(client.setDpiAxes(800, 850), /shared X\/Y/i);
+  await assert.rejects(client.setProfile(5), /between 1 and 4/i);
+  assert.equal(fake(receiver).sent.filter(({ data }) => data[0] === 7).length, writesBefore);
+
+  const wired = new DareuHidClient(device(0x1117));
+  await assert.rejects(wired.setPollingRate(4000), /unavailable/i);
+});

--- a/src/drivers/dareu/hid.ts
+++ b/src/drivers/dareu/hid.ts
@@ -1,0 +1,534 @@
+import type { MouseStatus } from "../mouse-types.ts";
+import {
+  DAREU_BUTTON_ACTIONS,
+  DAREU_BUTTONS,
+  DAREU_COMMAND_USAGE,
+  DAREU_COMMAND_USAGE_PAGE,
+  DAREU_DIRECT_PRODUCT_ID,
+  DAREU_DPI_LED_BRIGHTNESS_RANGE,
+  DAREU_DPI_LED_EFFECTS,
+  DAREU_DPI_LED_SPEED_RANGE,
+  DAREU_DPI_MAX,
+  DAREU_DPI_MIN,
+  DAREU_DPI_STEP,
+  DAREU_MAX_BUFFER_CHUNK,
+  DAREU_MEMORY_ADDRESS,
+  DAREU_PROFILE_COUNT,
+  DAREU_PRODUCT_IDS,
+  DAREU_RECEIVER_PRODUCT_ID,
+  DAREU_RECEIVER_USAGE,
+  DAREU_RECEIVER_USAGE_PAGE,
+  DAREU_REPORT_ID,
+  DAREU_REPORT_SIZE,
+  DAREU_SLEEP_TIMEOUT_SECONDS,
+  DAREU_VENDOR_ID,
+  DAREU_WIRED_POLLING_RATES,
+  DAREU_WIRELESS_POLLING_RATES,
+  dareuCheckActiveRequest,
+  dareuChecksum,
+  dareuDecodeActiveProfile,
+  dareuDecodeBattery,
+  dareuDecodeButtonAssignment,
+  dareuDecodeDpiLedState,
+  dareuDecodeFirmwareVersion,
+  dareuDecodeReadBufferReply,
+  dareuDpiFromId,
+  dareuDpiId,
+  dareuEncodeButtonAssignment,
+  dareuEncodeDpiLedBrightness,
+  dareuGetBatteryRequest,
+  dareuGetActiveProfileRequest,
+  dareuGetMouseFirmwareRequest,
+  dareuGetReceiverFirmwareRequest,
+  dareuHasValidMemoryChecksum,
+  dareuIsValidDpiLedSetting,
+  dareuIsValidSleepTimeout,
+  dareuMatchesReply,
+  dareuPollingRateHz,
+  dareuPollingRateId,
+  dareuReadBufferRequests,
+  dareuSetActiveProfileRequest,
+  dareuWithMemoryChecksum,
+  dareuWriteBufferRequests,
+} from "@openmouse/protocol/dareu";
+
+const RESPONSE_TIMEOUT_MS = 800;
+const MAX_DPI_STAGES = 5;
+
+type DpiStage = { x: number; y: number };
+type DpiConfig = { stageCount: number; activeStage: number; stages: DpiStage[] };
+
+/**
+ * Dareu's Jm channel uses report 8 directly through both the wired mouse and
+ * the TM265 2.4 GHz receiver. Writes are exactly the vendor panel's bounded
+ * memory records and are followed by a fresh read before being reported done.
+ */
+export class DareuHidClient {
+  readonly device: HIDDevice;
+  private waiter: {
+    request: Uint8Array;
+    resolve: (reply: Uint8Array) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  } | null = null;
+  private queue: Promise<void> = Promise.resolve();
+
+  private readonly onInputReport = (event: HIDInputReportEvent): void => {
+    if (event.reportId !== DAREU_REPORT_ID) return;
+    const reply = new Uint8Array(event.data.buffer.slice(event.data.byteOffset, event.data.byteOffset + event.data.byteLength));
+    const waiter = this.waiter;
+    if (!waiter || !dareuMatchesReply(waiter.request, reply)) return;
+    clearTimeout(waiter.timer);
+    this.waiter = null;
+    waiter.resolve(reply);
+  };
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+  }
+
+  static isSupported(device: HIDDevice): boolean {
+    if (device.vendorId !== DAREU_VENDOR_ID || !(DAREU_PRODUCT_IDS as readonly number[]).includes(device.productId)) return false;
+    const collections = this.flattenCollections(device.collections);
+    const hasReceiverService = collections.some((collection) =>
+      collection.usagePage === DAREU_RECEIVER_USAGE_PAGE && collection.usage === DAREU_RECEIVER_USAGE);
+    const hasCommandChannel = collections.some((collection) =>
+      collection.usagePage === DAREU_COMMAND_USAGE_PAGE
+      && collection.usage === DAREU_COMMAND_USAGE
+      && collection.inputReports.some((report) => report.reportId === DAREU_REPORT_ID && this.reportLength(report) === DAREU_REPORT_SIZE)
+      && collection.outputReports.some((report) => report.reportId === DAREU_REPORT_ID && this.reportLength(report) === DAREU_REPORT_SIZE));
+    return hasReceiverService && hasCommandChannel;
+  }
+
+  isWirelessPath(): boolean {
+    return this.device.productId === DAREU_RECEIVER_PRODUCT_ID;
+  }
+
+  getSleepOptions(): number[] {
+    return [...DAREU_SLEEP_TIMEOUT_SECONDS];
+  }
+
+  getDpiOptions(): number[] {
+    const options: number[] = [];
+    for (let dpi = DAREU_DPI_MIN; dpi <= DAREU_DPI_MAX; dpi += DAREU_DPI_STEP) options.push(dpi);
+    return options;
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+    this.device.removeEventListener("inputreport", this.onInputReport);
+    this.device.addEventListener("inputreport", this.onInputReport);
+  }
+
+  async close(): Promise<void> {
+    this.device.removeEventListener("inputreport", this.onInputReport);
+    this.failWaiter(new Error("The Dareu device was closed."));
+    if (this.device.opened) await this.device.close();
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      const battery = await this.readBattery().catch(() => null);
+      const activeProfile = await this.readActiveProfile().catch(() => null);
+      const dpi = await this.readDpiConfig().catch(() => null);
+      const polling = await this.readPollingRate().catch(() => null);
+      const lighting = await this.readDpiLighting().catch(() => null);
+      const dpiLedSleep = await this.readDpiLedSleepTimeout().catch(() => null);
+      const sleep = await this.readSleepTimeout().catch(() => null);
+      const buttons = await this.readButtons().catch(() => null);
+      const mouseFirmware = await this.readMouseFirmware().catch(() => null);
+      const receiverFirmware = this.isWirelessPath() ? await this.readReceiverFirmware().catch(() => null) : null;
+      const wireless = this.isWirelessPath();
+      const verified = dpi !== null || polling !== null;
+
+      return {
+        brand: "Dareu",
+        name: "Dareu A950 PRO Mg",
+        ui: {
+          family: "dareu",
+          settingsReady: verified,
+          valuesVerified: verified,
+          hideUnsupportedPollingRates: true,
+          hideSleepCard: sleep === null,
+          showAdvancedSection: lighting !== null || sleep !== null,
+          powerOverview: lighting !== null || sleep !== null,
+          defaultDisplayName: "Dareu A950 PRO Mg",
+          dpiStageEditor: dpi ? {
+            maxStages: MAX_DPI_STAGES,
+            countEditable: true,
+            minDpi: DAREU_DPI_MIN,
+            maxDpi: DAREU_DPI_MAX,
+            stepDpi: DAREU_DPI_STEP,
+          } : undefined,
+          dpiLighting: lighting ? {
+            modes: DAREU_DPI_LED_EFFECTS,
+            brightness: this.range(DAREU_DPI_LED_BRIGHTNESS_RANGE),
+            speed: this.range(DAREU_DPI_LED_SPEED_RANGE),
+            sleepTimeouts: dpiLedSleep === null ? undefined : DAREU_SLEEP_TIMEOUT_SECONDS,
+          } : undefined,
+        },
+        batteryPercent: battery?.percent ?? null,
+        batteryState: battery ? this.batteryState(battery.percent, battery.status) : "Unknown",
+        dpi: dpi?.stages[dpi.activeStage]?.x ?? 0,
+        // TM271F declares DpiXOnly. Its legacy records share one high byte,
+        // so exposing separate axes would create combinations the vendor UI
+        // itself cannot encode.
+        supportsSeparateDpiAxes: false,
+        dpiStages: dpi?.stages.map((stage) => stage.x),
+        activeDpiStage: dpi?.activeStage,
+        pollingRateHz: polling ?? 0,
+        supportedPollingRates: wireless ? [...DAREU_WIRELESS_POLLING_RATES] : [...DAREU_WIRED_POLLING_RATES],
+        activeProfile,
+        profileCount: activeProfile === null ? undefined : DAREU_PROFILE_COUNT,
+        buttonMappings: buttons?.mappings,
+        buttonOptions: buttons ? [...DAREU_BUTTON_ACTIONS] : undefined,
+        fixedButtons: buttons?.fixed,
+        connectionType: wireless ? "Wireless" : "Wired",
+        connectionDetail: wireless ? "2.4 GHz receiver" : "USB",
+        dpiLedMode: lighting?.mode ?? null,
+        dpiLedBrightness: lighting?.brightness ?? null,
+        dpiLedSpeed: lighting?.speed ?? null,
+        dpiLedSleepTimeout: dpiLedSleep,
+        sleepTimeout: sleep,
+        liftOffDistance: null,
+        firmware: [
+          mouseFirmware === null ? null : `Mouse ${this.formatFirmware(mouseFirmware)}`,
+          receiverFirmware === null ? null : `Receiver ${this.formatFirmware(receiverFirmware)}`,
+        ].filter((value): value is string => value !== null),
+      };
+    });
+  }
+
+  async setPollingRate(rate: number): Promise<number> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      const id = dareuPollingRateId(rate, this.transport());
+      if (id === null) throw new Error(`${rate.toLocaleString()} Hz is unavailable on this Dareu connection.`);
+      await this.readPollingRate();
+      await this.writeBuffer(DAREU_MEMORY_ADDRESS.pollingRate, dareuWithMemoryChecksum(new Uint8Array([id])));
+      const confirmed = await this.readPollingRate();
+      if (confirmed !== rate) throw new Error(`The mouse kept ${confirmed.toLocaleString()} Hz instead of ${rate.toLocaleString()} Hz.`);
+      return confirmed;
+    });
+  }
+
+  async setDpi(dpi: number, dpiY = dpi): Promise<number> {
+    return await this.setDpiAxes(dpi, dpiY).then(({ x }) => x);
+  }
+
+  async setDpiAxes(x: number, y: number): Promise<{ x: number; y: number }> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      if (x !== y) throw new Error("This Dareu model exposes one shared X/Y DPI value.");
+      const config = await this.readDpiConfig();
+      await this.writeDpiStage(config, config.activeStage, x);
+      const confirmed = (await this.readDpiConfig()).stages[config.activeStage]!;
+      if (confirmed.x !== x || confirmed.y !== y) throw new Error("The mouse did not confirm the requested X/Y DPI values.");
+      return { x: confirmed.x, y: confirmed.y };
+    });
+  }
+
+  async setDpiStageValue(stage: number, dpi: number): Promise<number> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      const config = await this.readDpiConfig();
+      this.assertStage(config, stage);
+      await this.writeDpiStage(config, stage, dpi);
+      const confirmed = (await this.readDpiConfig()).stages[stage]!;
+      if (confirmed.x !== dpi) throw new Error(`The mouse kept ${confirmed.x.toLocaleString()} DPI instead of ${dpi.toLocaleString()} DPI.`);
+      return confirmed.x;
+    });
+  }
+
+  async setDpiStageCount(count: number): Promise<number> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      if (!Number.isInteger(count) || count < 1 || count > MAX_DPI_STAGES) throw new Error(`Dareu supports 1–${MAX_DPI_STAGES} DPI stages.`);
+      const config = await this.readDpiConfig();
+      const active = Math.min(config.activeStage, count - 1);
+      await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiHeader, new Uint8Array([
+        count, dareuChecksum(new Uint8Array([count, 0])), active, dareuChecksum(new Uint8Array([active, 0])),
+      ]));
+      const confirmed = await this.readDpiConfig();
+      if (confirmed.stageCount !== count || confirmed.activeStage !== active) throw new Error("The mouse did not confirm its DPI stage count.");
+      return confirmed.stageCount;
+    });
+  }
+
+  async setActiveDpiStage(stage: number): Promise<number> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      const config = await this.readDpiConfig();
+      this.assertStage(config, stage);
+      await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiHeader + 2, dareuWithMemoryChecksum(new Uint8Array([stage])));
+      const confirmed = await this.readDpiConfig();
+      if (confirmed.activeStage !== stage) throw new Error(`The mouse kept DPI stage ${confirmed.activeStage + 1}.`);
+      return confirmed.activeStage;
+    });
+  }
+
+  async setProfile(profile: number): Promise<void> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      await this.exchange(dareuSetActiveProfileRequest(profile));
+      const confirmed = await this.readActiveProfile();
+      if (confirmed !== profile) throw new Error(`The mouse kept profile ${confirmed} instead of ${profile}.`);
+    });
+  }
+
+  async setDpiLighting(mode: number, brightness: number, speed: number): Promise<void> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      if (!dareuIsValidDpiLedSetting(mode, brightness, speed)) throw new Error("Unsupported Dareu DPI indicator setting.");
+      await this.readDpiLighting();
+      if (mode === 0) {
+        await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiLedEnabled, dareuWithMemoryChecksum(new Uint8Array([0])));
+      } else {
+        const brightnessData = dareuEncodeDpiLedBrightness(brightness);
+        if (!brightnessData) throw new Error("Unsupported Dareu DPI indicator brightness.");
+        await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiLedEnabled, dareuWithMemoryChecksum(new Uint8Array([1])));
+        await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiLed, dareuWithMemoryChecksum(new Uint8Array([mode])));
+        await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiLed + 2, brightnessData);
+        await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiLed + 4, dareuWithMemoryChecksum(new Uint8Array([speed])));
+      }
+      const confirmed = await this.readDpiLighting();
+      if (confirmed.mode !== mode || (mode !== 0 && (confirmed.brightness !== brightness || confirmed.speed !== speed))) {
+        throw new Error("The mouse did not confirm the requested DPI indicator settings.");
+      }
+    });
+  }
+
+  async setDpiLedSleepTimeout(seconds: number): Promise<number> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      if (!dareuIsValidSleepTimeout(seconds)) throw new Error("Unsupported Dareu DPI indicator sleep timeout.");
+      await this.readDpiLedSleepTimeout();
+      await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiLedSleep, dareuWithMemoryChecksum(new Uint8Array([seconds / 10])));
+      const confirmed = await this.readDpiLedSleepTimeout();
+      if (confirmed !== seconds) throw new Error("The mouse did not confirm the DPI indicator sleep timeout.");
+      return confirmed;
+    });
+  }
+
+  async setSleepTimeout(seconds: number): Promise<number> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      if (!dareuIsValidSleepTimeout(seconds)) throw new Error("Unsupported Dareu mouse sleep timeout.");
+      await this.readSleepTimeout();
+      if (seconds === 0) {
+        await this.writeBuffer(DAREU_MEMORY_ADDRESS.sleepEnabled, dareuWithMemoryChecksum(new Uint8Array([0])));
+      } else {
+        await this.writeBuffer(DAREU_MEMORY_ADDRESS.sleepEnabled, dareuWithMemoryChecksum(new Uint8Array([1])));
+        await this.writeBuffer(DAREU_MEMORY_ADDRESS.sleepTimeout, dareuWithMemoryChecksum(new Uint8Array([seconds / 10])));
+      }
+      const confirmed = await this.readSleepTimeout();
+      if (confirmed !== seconds) throw new Error("The mouse did not confirm its sleep timeout.");
+      return confirmed;
+    });
+  }
+
+  async setButtonMapping(button: string, action: string): Promise<void> {
+    return await this.serialized(async () => {
+      await this.ensureActive();
+      const index = DAREU_BUTTONS.findIndex((candidate) => candidate.name === button);
+      const encoded = dareuEncodeButtonAssignment(action);
+      if (index < 0 || !encoded) throw new Error("This Dareu button mapping is read-only.");
+      const current = await this.readBuffer(DAREU_MEMORY_ADDRESS.buttonAssignments + index * 4, 4);
+      if (!dareuDecodeButtonAssignment(current)) throw new Error("This Dareu button has an unknown or macro assignment and is read-only.");
+      await this.writeBuffer(DAREU_MEMORY_ADDRESS.buttonAssignments + index * 4, encoded);
+      const confirmed = dareuDecodeButtonAssignment(await this.readBuffer(DAREU_MEMORY_ADDRESS.buttonAssignments + index * 4, 4));
+      if (confirmed !== action) throw new Error("The mouse did not confirm the requested button mapping.");
+    });
+  }
+
+  private async readBattery(): Promise<{ percent: number; status: number }> {
+    const battery = dareuDecodeBattery(await this.exchange(dareuGetBatteryRequest()));
+    if (!battery) throw new Error("The Dareu battery reply was invalid.");
+    return battery;
+  }
+
+  private async readActiveProfile(): Promise<number> {
+    const profile = dareuDecodeActiveProfile(await this.exchange(dareuGetActiveProfileRequest()));
+    if (profile === null) throw new Error("The Dareu active-profile reply was invalid.");
+    return profile;
+  }
+
+  private async readMouseFirmware(): Promise<number> {
+    const version = dareuDecodeFirmwareVersion(await this.exchange(dareuGetMouseFirmwareRequest()), 18);
+    if (version === null) throw new Error("The Dareu mouse firmware reply was invalid.");
+    return version;
+  }
+
+  private async readReceiverFirmware(): Promise<number> {
+    const version = dareuDecodeFirmwareVersion(await this.exchange(dareuGetReceiverFirmwareRequest()), 29);
+    if (version === null) throw new Error("The Dareu receiver firmware reply was invalid.");
+    return version;
+  }
+
+  private async readDpiConfig(): Promise<DpiConfig> {
+    const header = await this.readBuffer(DAREU_MEMORY_ADDRESS.dpiHeader, 4);
+    if (!dareuHasValidMemoryChecksum(header.slice(0, 2)) || !dareuHasValidMemoryChecksum(header.slice(2, 4))) {
+      throw new Error("The Dareu DPI header checksum is invalid.");
+    }
+    const stageCount = header[0]!;
+    const activeStage = header[2]!;
+    if (stageCount < 1 || stageCount > MAX_DPI_STAGES || activeStage >= stageCount) throw new Error("The Dareu DPI stage header is invalid.");
+    const data = await this.readBuffer(DAREU_MEMORY_ADDRESS.dpiLegacyStages, stageCount * 4);
+    const stages: DpiStage[] = [];
+    for (let stage = 0; stage < stageCount; stage += 1) {
+      const raw = data.slice(stage * 4, stage * 4 + 4);
+      if (!dareuHasValidMemoryChecksum(raw)) throw new Error(`Dareu DPI stage ${stage + 1} has an invalid checksum.`);
+      const x = dareuDpiFromId(raw[0]! | raw[2]! << 8);
+      const y = dareuDpiFromId(raw[1]! | raw[2]! << 8);
+      if (x === null || y === null) throw new Error(`Dareu DPI stage ${stage + 1} is invalid.`);
+      stages.push({ x, y });
+    }
+    return { stageCount, activeStage, stages };
+  }
+
+  private async readPollingRate(): Promise<number> {
+    const data = await this.readBuffer(DAREU_MEMORY_ADDRESS.pollingRate, 2);
+    if (!dareuHasValidMemoryChecksum(data)) throw new Error("The Dareu polling-rate checksum is invalid.");
+    const rate = dareuPollingRateHz(data[0]!, this.transport());
+    if (rate === null) throw new Error("The Dareu polling-rate value is unsupported on this connection.");
+    return rate;
+  }
+
+  private async readDpiLighting(): Promise<{ mode: 0 | 1 | 2; brightness: number; speed: number }> {
+    const lighting = dareuDecodeDpiLedState(await this.readBuffer(DAREU_MEMORY_ADDRESS.dpiLed, 8));
+    if (!lighting) throw new Error("The Dareu DPI indicator data is invalid.");
+    return lighting;
+  }
+
+  private async readDpiLedSleepTimeout(): Promise<number> {
+    const data = await this.readBuffer(DAREU_MEMORY_ADDRESS.dpiLedSleep, 2);
+    if (!dareuHasValidMemoryChecksum(data)) throw new Error("The Dareu DPI indicator sleep checksum is invalid.");
+    const seconds = data[0]! * 10;
+    if (!dareuIsValidSleepTimeout(seconds)) throw new Error("The Dareu DPI indicator sleep value is unsupported.");
+    return seconds;
+  }
+
+  private async readSleepTimeout(): Promise<number> {
+    const enabled = await this.readBuffer(DAREU_MEMORY_ADDRESS.sleepEnabled, 2);
+    if (!dareuHasValidMemoryChecksum(enabled) || (enabled[0] !== 0 && enabled[0] !== 1)) {
+      throw new Error("The Dareu sleep enable value is invalid.");
+    }
+    if (enabled[0] === 0) return 0;
+    const value = await this.readBuffer(DAREU_MEMORY_ADDRESS.sleepTimeout, 2);
+    if (!dareuHasValidMemoryChecksum(value)) throw new Error("The Dareu sleep timeout checksum is invalid.");
+    const seconds = value[0]! * 10;
+    if (!dareuIsValidSleepTimeout(seconds) || seconds === 0) throw new Error("The Dareu sleep timeout is invalid.");
+    return seconds;
+  }
+
+  private async readButtons(): Promise<{ mappings: Record<string, string>; fixed: string[] }> {
+    const data = await this.readBuffer(DAREU_MEMORY_ADDRESS.buttonAssignments, DAREU_BUTTONS.length * 4);
+    const mappings: Record<string, string> = {};
+    const fixed: string[] = [];
+    DAREU_BUTTONS.forEach((button, index) => {
+      const action = dareuDecodeButtonAssignment(data.slice(index * 4, index * 4 + 4));
+      mappings[button.name] = action ?? "Custom (read-only)";
+      if (!action) fixed.push(button.name);
+    });
+    return { mappings, fixed };
+  }
+
+  private async writeDpiStage(config: DpiConfig, stage: number, dpi: number): Promise<void> {
+    this.assertStage(config, stage);
+    const id = dareuDpiId(dpi);
+    if (id === null) throw new Error(`Dareu DPI must be ${DAREU_DPI_MIN}–${DAREU_DPI_MAX.toLocaleString()} in ${DAREU_DPI_STEP}-DPI steps.`);
+    const data = new Uint8Array([id & 0xff, id & 0xff, id >> 8, 0]);
+    data[3] = dareuChecksum(data);
+    await this.writeBuffer(DAREU_MEMORY_ADDRESS.dpiLegacyStages + stage * 4, data);
+  }
+
+  private async ensureActive(): Promise<void> {
+    const response = await this.exchange(dareuCheckActiveRequest());
+    if (response[5] !== 1) throw new Error("The Dareu mouse is offline. Wake it or pair it to this receiver, then retry.");
+  }
+
+  private async readBuffer(address: number, length: number): Promise<Uint8Array> {
+    const bytes = new Uint8Array(length);
+    const requests = dareuReadBufferRequests(address, length);
+    for (let index = 0; index < requests.length; index += 1) {
+      const request = requests[index]!;
+      const chunk = dareuDecodeReadBufferReply(request, await this.exchange(request));
+      if (!chunk) throw new Error(`Dareu memory read failed at 0x${(address + index * DAREU_MAX_BUFFER_CHUNK).toString(16)}.`);
+      bytes.set(chunk, index * DAREU_MAX_BUFFER_CHUNK);
+    }
+    return bytes;
+  }
+
+  private async writeBuffer(address: number, data: Uint8Array): Promise<void> {
+    for (const request of dareuWriteBufferRequests(address, data)) {
+      // Jm's SetBuffer waits for each command-7 reply. This matters for the
+      // DPI LED transition: enable (82) must land before effect (76).
+      await this.exchange(request);
+    }
+  }
+
+  private async exchange(request: Uint8Array): Promise<Uint8Array> {
+    await this.open();
+    if (this.waiter) throw new Error("Another Dareu request is already in progress.");
+    const response = new Promise<Uint8Array>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.waiter?.resolve === resolve) this.waiter = null;
+        reject(new Error(`The Dareu mouse did not answer command 0x${request[0]!.toString(16)}.`));
+      }, RESPONSE_TIMEOUT_MS);
+      this.waiter = { request, resolve, reject, timer };
+    });
+    try {
+      await this.device.sendReport(DAREU_REPORT_ID, new Uint8Array(request));
+    } catch (error) {
+      this.failWaiter(error instanceof Error ? error : new Error(String(error)));
+    }
+    return await response;
+  }
+
+  private serialized<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.queue.then(operation, operation);
+    this.queue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  private failWaiter(error: Error): void {
+    const waiter = this.waiter;
+    if (!waiter) return;
+    clearTimeout(waiter.timer);
+    this.waiter = null;
+    waiter.reject(error);
+  }
+
+  private assertStage(config: DpiConfig, stage: number): void {
+    if (!Number.isInteger(stage) || stage < 0 || stage >= config.stageCount) throw new Error(`DPI stage must be between 1 and ${config.stageCount}.`);
+  }
+
+  private transport(): "wired" | "receiver" {
+    return this.device.productId === DAREU_DIRECT_PRODUCT_ID ? "wired" : "receiver";
+  }
+
+  private range([minimum, maximum]: readonly [number, number]): number[] {
+    return Array.from({ length: maximum - minimum + 1 }, (_, index) => minimum + index);
+  }
+
+  private formatFirmware(version: number): string {
+    return `${(version >>> 8).toString(16).toUpperCase()}.${(version & 0xff).toString(16).padStart(2, "0").toUpperCase()}`;
+  }
+
+  private batteryState(percent: number, status: number): MouseStatus["batteryState"] {
+    // Dareu's Energy page defines 0x01 and 0x02 as charging. Other status
+    // values have no vendor label, so retain Unknown rather than invent one.
+    if (status === 1 || status === 2) return "Charging";
+    if (status === 0) return percent === 100 ? "Full" : "Discharging";
+    return "Unknown";
+  }
+
+  private static flattenCollections(collections: readonly HIDCollectionInfo[]): HIDCollectionInfo[] {
+    return collections.flatMap((collection) => [collection, ...this.flattenCollections(collection.children)]);
+  }
+
+  private static reportLength(report: HIDReportInfo): number {
+    return report.items.reduce((sum, item) => sum + item.reportSize * item.reportCount, 0) / 8;
+  }
+}

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -42,6 +42,8 @@ export interface MouseUiHints {
   showAdvancedSection?: boolean;
   /** Always show battery column (even wired with null %). */
   forceShowBattery?: boolean;
+  /** Group the device's battery, DPI-indicator, and sleep controls on Overview. */
+  powerOverview?: boolean;
   /**
    * Extra sentence appended to the connected status line, for drivers whose
    * connection is deliberately limited (e.g. why settings are unavailable).
@@ -70,6 +72,8 @@ export interface MouseUiHints {
     modes: readonly (0 | 1 | 2)[];
     brightness: readonly number[];
     speed: readonly number[];
+    /** Optional DPI-indicator-only sleep values in seconds. */
+    sleepTimeouts?: readonly number[];
   };
 }
 
@@ -144,7 +148,7 @@ export interface AtkReceiverInfo {
 }
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "Corsair" | "Microsoft";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "Corsair" | "Microsoft" | "Dareu";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;
@@ -195,6 +199,8 @@ export interface MouseStatus {
   profileNames?: string[];
   /** Every action `setButtonMapping` will accept, in display order. */
   buttonOptions?: string[];
+  /** Button names the device reported in an unknown or macro encoding. */
+  fixedButtons?: string[];
   deviceMode?: "Onboard" | "Host" | "Unknown";
   unitId?: string | null;
   modelId?: string | null;
@@ -275,6 +281,8 @@ export interface MouseStatus {
   dpiLedMode?: number | null;
   dpiLedBrightness?: number | null;
   dpiLedSpeed?: number | null;
+  /** DPI-indicator-only sleep timeout in seconds, distinct from mouse sleep. */
+  dpiLedSleepTimeout?: number | null;
   liftOffDistance: "Low" | "Medium" | "High" | null;
   /**
    * A single lift-off height the device tunes continuously, for mice whose

--- a/src/drivers/registry.test.ts
+++ b/src/drivers/registry.test.ts
@@ -38,6 +38,12 @@ function collection(
 
 function collectionShapes(): HIDCollectionInfo[][] {
   const shapes: HIDCollectionInfo[][] = [[]];
+  // Dareu's receiver exposes a service collection beside its report-8 command
+  // channel; retain both so strict multi-collection drivers are exercisable.
+  shapes.push([
+    collection(0xff05, 0),
+    collection(0xff02, 2, { input: [8], output: [8] }),
+  ]);
   shapes.push(USAGE_PAGES.map((page) =>
     collection(page, 1, { feature: REPORT_IDS, input: REPORT_IDS, output: REPORT_IDS })));
   for (const page of USAGE_PAGES) {

--- a/src/drivers/registry.ts
+++ b/src/drivers/registry.ts
@@ -47,9 +47,10 @@ import { MchoseHidClient } from "./mchose/hid.ts";
 import { MchoseDockHidClient } from "./mchose/dock-hid.ts";
 import { KsnakeHidClient } from "./ksnake/hid.ts";
 import { MicrosoftHidClient } from "./microsoft/hid.ts";
+import { DareuHidClient } from "./dareu/hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient | PulsarXs1HidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient | MicrosoftHidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient | MicrosoftHidClient | DareuHidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -59,6 +60,7 @@ export interface DeviceDriver {
 }
 
 export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
+  { brand: "Dareu", supports: (device) => DareuHidClient.isSupported(device), create: (device) => new DareuHidClient(device), score: () => 9 },
   { brand: "Zaunkoenig", supports: (device) => ZaunkoenigHidClient.isSupported(device), create: (device) => new ZaunkoenigHidClient(device), score: () => 10 },
   { brand: "Corsair", supports: (device) => CorsairHidClient.isSupported(device), create: (device) => new CorsairHidClient(device), score: () => 8 },
   { brand: "Finalmouse", supports: (device) => FinalmouseHidClient.isSupported(device), create: (device) => new FinalmouseHidClient(device), score: () => 10 },

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -67,6 +67,12 @@ import {
   WALLHACK_MOUSE_USAGE_PAGE,
   WALLHACK_VENDOR_ID,
 } from "@openmouse/protocol/wallhack";
+import {
+  DAREU_COMMAND_USAGE,
+  DAREU_COMMAND_USAGE_PAGE,
+  DAREU_PRODUCT_IDS,
+  DAREU_VENDOR_ID,
+} from "@openmouse/protocol/dareu";
 
 export const VENDOR_ID = {
   pulsar: 0x3710,
@@ -107,7 +113,16 @@ export const VENDOR_ID = {
   ksnakeUsb: 0xa8a4, // K-snake X11 wired
   ksnakeDongle: 0xa8a5, // K-snake X11 2.4 GHz dongle
   microsoft: 0x045E,
+  dareu: DAREU_VENDOR_ID,
 } as const;
+
+/** Exact PID and report-8 command collection measured on the TM265 receiver. */
+export const DAREU_HID_FILTERS: HIDDeviceFilter[] = [...DAREU_PRODUCT_IDS].map((productId) => ({
+  vendorId: DAREU_VENDOR_ID,
+  productId,
+  usagePage: DAREU_COMMAND_USAGE_PAGE,
+  usage: DAREU_COMMAND_USAGE,
+}));
 
 /**
  * SteelSeries ships keyboards, headsets, and USB audio under 0x1038, so there
@@ -467,6 +482,7 @@ export const MICROSOFT_HID_FILTERS: HIDDeviceFilter[] = [...MICROSOFT_PRODUCTS].
 );
 
 export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
+  ...DAREU_HID_FILTERS,
   ...ZAUNKOENIG_PRODUCT_IDS.map((productId) => ({
     vendorId: ZAUNKOENIG_VENDOR_ID,
     productId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export * as vgn from "./vgn/index.js";
 export * as wlmouse from "./wlmouse/index.js";
 export * as zaunkoenig from "./zaunkoenig/index.js";
 export * as corsair from "./corsair/index.js";
+export * as dareu from "./dareu/index.js";
 export * as gwolves from "./gwolves/index.js";
 export * as glorious from "./glorious/index.js";
 export * as ksnake from "./ksnake/index.js";


### PR DESCRIPTION
Resolves conflicts in #78, supersedes it.

Original PR by the contributor added a new, fully independent Dareu A950 PRO Mg driver (Jm-family protocol) under a brand-new vendor id (0x260d), which does not overlap with any existing vendor id or shared codec. The only conflicts were additive changes to `src/drivers/registry.ts`, `src/drivers/vendors.ts`, and `src/drivers/mouse-types.ts` from other PRs merged in the meantime (Incott, HyperX, MCHOSE V3, GearHub brand). Resolved by combining both sides' additions; no logic was altered.

Verified: `npm run check` (build + full test suite + pack dry-run) passes, 1468/1468 tests green.

Claude-Session: https://claude.ai/code/session_01JfTcrhgBuFh8QiLvbtdJCX