### PR TITLE
feat(mchose): add A5 Pro Max v1 support (resolves #77)

### DIFF
--- a/docs/mchose-a5-gen1.md
+++ b/docs/mchose-a5-gen1.md
@@ -9,7 +9,9 @@ The vendor's `xvi_models.xlsx` model table names VID `0x2023`, wired PID
 `0xF019`, 1K receiver `0xF013`, and 4K receiver `0xF015`. The matching firmware
 package contains updaters labelled with the same IDs. Its model row declares
 three profiles, six DPI stages, 26,000 DPI, wired rates 125/500/1000 Hz and
-receiver rates 125/250/500/1000 Hz.
+receiver rates 125/250/500/1000 Hz. The wired `0xF019` path and 1K receiver
+`0xF013` path were exercised on owned retail hardware. The 4K receiver identity
+`0xF015` is recognized but is not marked hardware-verified.
 
 Requests are 64-byte feature bodies. Bytes 2-5 are route, payload length,
 page and command; command data begins at byte 6. Replies begin with `0xA1` and

--- a/docs/mchose-a5-gen1.md
+++ b/docs/mchose-a5-gen1.md
@@ -1,0 +1,20 @@
+# MCHOSE A5 Pro Max first-generation protocol
+
+This driver covers the original A5 Pro Max, not the current M HUB A7 V2
+protocol. It uses XVI's 64-byte feature-report protocol.
+
+## Evidence
+
+The vendor's `xvi_models.xlsx` model table names VID `0x2023`, wired PID
+`0xF019`, 1K receiver `0xF013`, and 4K receiver `0xF015`. The matching firmware
+package contains updaters labelled with the same IDs. Its model row declares
+three profiles, six DPI stages, 26,000 DPI, wired rates 125/500/1000 Hz and
+receiver rates 125/250/500/1000 Hz.
+
+Requests are 64-byte feature bodies. Bytes 2-5 are route, payload length,
+page and command; command data begins at byte 6. Replies begin with `0xA1` and
+echo page and command in bytes 4-5. The implementation was ported from the
+standalone A5 Pro Max WebHID driver, where the device path was exercised on
+retail hardware.
+
+Do not add vendor binaries, extracted resources, or firmware to this repository.

--- a/src/drivers/mchose/a5-gen1-hid.test.ts
+++ b/src/drivers/mchose/a5-gen1-hid.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MchoseA5ProMaxHidClient } from "./a5-gen1-hid.ts";
+
+function collection(reportId = 0): HIDCollectionInfo {
+  return { usagePage: 0xffff, usage: 1, type: 0, children: [], inputReports: [], outputReports: [], featureReports: [{ reportId, items: [] }] };
+}
+
+function firstGenDevice(productId = 0xf019): HIDDevice {
+  let profile = 1;
+  let polling = 1;
+  const dpi = [400, 800, 1600, 3200, 6400, 12000];
+  let active = 3;
+  let reply = new Uint8Array(64);
+  return {
+    vendorId: 0x2023, productId, productName: "MCHOSE", opened: true,
+    collections: [collection()], oninputreport: null,
+    open: async () => {}, close: async () => {}, forget: async () => {},
+    addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => true,
+    sendReport: async () => {}, receiveFeatureReport: async () => new DataView(reply.buffer),
+    sendFeatureReport: async (_id, source) => {
+      const request = source instanceof Uint8Array ? source : new Uint8Array(source as ArrayBuffer);
+      const page = request[4]!, command = request[5]!;
+      if (page === 0 && command === 0x05) profile = request[6]!;
+      if (page === 1 && command === 0x00) polling = request[6]!;
+      if (page === 1 && command === 0x02) active = request[7]!;
+      reply = new Uint8Array(64);
+      reply.set([0xa1, 0, 2, request[3]!, page, command]);
+      if (page === 0 && command === 0x81) reply.set([1, 0, 15, 0], 6);
+      if (page === 0 && command === 0x83) reply.set([0, 82], 6);
+      if (page === 0 && command === 0x85) reply[6] = profile;
+      if (page === 0 && command === 0x87) reply.set([0x03, 0x84], 6);
+      if (page === 0 && command === 0x88) reply[7] = 4;
+      if (page === 1 && command === 0x80) reply[6] = polling;
+      if (page === 1 && command === 0x81) {
+        reply[7] = dpi.length;
+        dpi.forEach((value, index) => reply.set([(value >> 8) & 0xff, value & 0xff, (value >> 8) & 0xff, value & 0xff], 8 + index * 4));
+      }
+      if (page === 1 && command === 0x82) reply[7] = active;
+      if (page === 1 && command === 0x88) reply[6] = 1;
+      if (page === 1 && [0x84, 0x89, 0x8a].includes(command)) reply[6] = 1;
+      if (page === 1 && command === 0x01) {
+        const count = request[7]!;
+        dpi.splice(0, dpi.length, ...Array.from({ length: count }, (_, index) => (request[8 + index * 4]! << 8) | request[9 + index * 4]!));
+      }
+    },
+  } as HIDDevice;
+}
+
+describe("MchoseA5ProMaxHidClient", () => {
+  it("claims only known XVI products on the feature collection", () => {
+    assert.equal(MchoseA5ProMaxHidClient.isSupported(firstGenDevice()), true);
+    assert.equal(MchoseA5ProMaxHidClient.isSupported({ ...firstGenDevice(), productId: 0xf017 } as HIDDevice), false);
+  });
+
+  it("reads the A5 Pro Max status and exposes the wired rate set", async () => {
+    const status = await new MchoseA5ProMaxHidClient(firstGenDevice()).readStatus();
+    assert.equal(status.name, "MCHOSE A5 Pro Max");
+    assert.equal(status.dpi, 1600);
+    assert.equal(status.pollingRateHz, 1000);
+    assert.deepEqual(status.supportedPollingRates, [125, 500, 1000]);
+    assert.equal(status.batteryPercent, 82);
+    assert.equal(status.ui?.settingsReady, true);
+  });
+
+  it("changes polling rate with read-back", async () => {
+    const client = new MchoseA5ProMaxHidClient(firstGenDevice());
+    await client.setPollingRate(500);
+    assert.equal((await client.readStatus()).pollingRateHz, 500);
+  });
+});

--- a/src/drivers/mchose/a5-gen1-hid.test.ts
+++ b/src/drivers/mchose/a5-gen1-hid.test.ts
@@ -6,7 +6,7 @@ function collection(reportId = 0): HIDCollectionInfo {
   return { usagePage: 0xffff, usage: 1, type: 0, children: [], inputReports: [], outputReports: [], featureReports: [{ reportId, items: [] }] };
 }
 
-function firstGenDevice(productId = 0xf019): HIDDevice {
+function firstGenDevice(productId = 0xf019, sent: Uint8Array[] = []): HIDDevice {
   let profile = 1;
   let polling = 1;
   const dpi = [400, 800, 1600, 3200, 6400, 12000];
@@ -20,6 +20,7 @@ function firstGenDevice(productId = 0xf019): HIDDevice {
     sendReport: async () => {}, receiveFeatureReport: async () => new DataView(reply.buffer),
     sendFeatureReport: async (_id, source) => {
       const request = source instanceof Uint8Array ? source : new Uint8Array(source as ArrayBuffer);
+      sent.push(request.slice());
       const page = request[4]!, command = request[5]!;
       if (page === 0 && command === 0x05) profile = request[6]!;
       if (page === 1 && command === 0x00) polling = request[6]!;
@@ -63,9 +64,44 @@ describe("MchoseA5ProMaxHidClient", () => {
     assert.equal(status.ui?.settingsReady, true);
   });
 
+  it("exposes the hardware-verified 1K receiver path", async () => {
+    const status = await new MchoseA5ProMaxHidClient(firstGenDevice(0xf013)).readStatus();
+    assert.equal(status.name, "MCHOSE A5 Pro Max (1K receiver)");
+    assert.equal(status.connectionType, "Wireless");
+    assert.equal(status.connectionDetail, "2.4 GHz receiver");
+    assert.deepEqual(status.supportedPollingRates, [125, 250, 500, 1000]);
+  });
+
   it("changes polling rate with read-back", async () => {
     const client = new MchoseA5ProMaxHidClient(firstGenDevice());
     await client.setPollingRate(500);
     assert.equal((await client.readStatus()).pollingRateHz, 500);
+  });
+
+  it("emits every hardware-tested settings command", async () => {
+    const sent: Uint8Array[] = [];
+    const client = new MchoseA5ProMaxHidClient(firstGenDevice(0xf013, sent));
+    await client.setProfile(2);
+    await client.setDpiStageValue(0, 450);
+    await client.setActiveDpiStage(1);
+    await client.setDpiStageCount(4);
+    await client.setSleepTimeout(900);
+    await client.setDebounceTime(4);
+    await client.setLiftOffDistance("High");
+    await client.setMotionSync(true);
+    await client.setAngleSnapping(true);
+    await client.setRippleControl(true);
+
+    const wrote = (page: number, command: number, data: readonly number[]) => sent.some((frame) =>
+      frame[4] === page && frame[5] === command && data.every((value, index) => frame[6 + index] === value));
+    assert.equal(wrote(0, 0x05, [2]), true, "profile");
+    assert.equal(wrote(1, 0x01, [2]), true, "DPI stages");
+    assert.equal(wrote(1, 0x02, [2, 2]), true, "active DPI stage");
+    assert.equal(wrote(0, 0x07, [0x03, 0x84]), true, "sleep timeout");
+    assert.equal(wrote(0, 0x08, [2, 4]), true, "debounce");
+    assert.equal(wrote(1, 0x08, [2]), true, "lift-off distance");
+    assert.equal(wrote(1, 0x09, [1]), true, "Motion Sync");
+    assert.equal(wrote(1, 0x04, [1]), true, "angle snapping");
+    assert.equal(wrote(1, 0x0a, [1]), true, "ripple control");
   });
 });

--- a/src/drivers/mchose/a5-gen1-hid.ts
+++ b/src/drivers/mchose/a5-gen1-hid.ts
@@ -1,0 +1,245 @@
+import {
+  MCHOSE_A5_GEN1_DPI_MAX,
+  MCHOSE_A5_GEN1_DPI_MIN,
+  MCHOSE_A5_GEN1_DPI_STAGES,
+  MCHOSE_A5_GEN1_DPI_STEP,
+  MCHOSE_A5_GEN1_PRODUCTS,
+  MCHOSE_A5_GEN1_PROFILE_COUNT,
+  MCHOSE_A5_GEN1_RECEIVER_RATES,
+  MCHOSE_A5_GEN1_USAGE_PAGE,
+  MCHOSE_A5_GEN1_VENDOR_ID,
+  MCHOSE_A5_GEN1_WIRED_RATES,
+  mchoseA5Gen1DecodeDpi,
+  mchoseA5Gen1DecodeFirmware,
+  mchoseA5Gen1DecodeReply,
+  mchoseA5Gen1EncodeDpi,
+  mchoseA5Gen1EncodeRequest,
+  mchoseA5Gen1NormalizeDpi,
+  mchoseA5Gen1ReplyMatches,
+} from "@openmouse/protocol/mchose";
+import type { MouseStatus } from "../mouse-types.ts";
+
+const POLLING_CODES = new Map([[125, 0x08], [250, 0x04], [500, 0x02], [1000, 0x01]]);
+const POLLING_VALUES = new Map([...POLLING_CODES].map(([rate, code]) => [code, rate]));
+const delay = (ms: number): Promise<void> => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+function flatten(collections: readonly HIDCollectionInfo[]): HIDCollectionInfo[] {
+  return collections.flatMap((collection) => [collection, ...flatten(collection.children)]);
+}
+
+function featureReportIds(device: HIDDevice): number[] {
+  return flatten(device.collections)
+    .filter((collection) => collection.usagePage >= 0xff00)
+    .flatMap((collection) => collection.featureReports.map((report) => report.reportId));
+}
+
+export class MchoseA5ProMaxHidClient {
+  readonly device: HIDDevice;
+  readonly reportId: number;
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+    this.reportId = featureReportIds(device)[0] ?? 0;
+  }
+
+  static isSupported(device: HIDDevice): boolean {
+    return device.vendorId === MCHOSE_A5_GEN1_VENDOR_ID
+      && MCHOSE_A5_GEN1_PRODUCTS.has(device.productId)
+      && flatten(device.collections).some((collection) =>
+        collection.usagePage === MCHOSE_A5_GEN1_USAGE_PAGE && collection.featureReports.length > 0);
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) await this.device.open();
+  }
+
+  async close(): Promise<void> {
+    if (this.device.opened) await this.device.close();
+  }
+
+  async startNotifications(): Promise<boolean> { return false; }
+  displayName(): string { return MCHOSE_A5_GEN1_PRODUCTS.get(this.device.productId)?.name ?? "MCHOSE A5"; }
+  isWireless(): boolean { return !this.isWired(); }
+  getDpiOptions(): number[] { return []; }
+  getSleepOptions(): number[] { return [0, 60, 120, 300, 600, 900, 1800]; }
+  getDebounceMaxMs(): number { return 15; }
+
+  private isWired(): boolean {
+    return MCHOSE_A5_GEN1_PRODUCTS.get(this.device.productId)?.connection === "Wired";
+  }
+
+  private rates(): readonly number[] {
+    return this.isWired() ? MCHOSE_A5_GEN1_WIRED_RATES : MCHOSE_A5_GEN1_RECEIVER_RATES;
+  }
+
+  private request(length: number, page: number, command: number, data: readonly number[] = [], route = 2): Promise<Uint8Array> {
+    const run = async (): Promise<Uint8Array> => {
+      await this.open();
+      const payload = mchoseA5Gen1EncodeRequest({ length, page, command, data, route });
+      await this.device.sendFeatureReport(this.reportId, payload);
+      await delay(34);
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        const view = await this.device.receiveFeatureReport(this.reportId);
+        const raw = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+        const reply = mchoseA5Gen1DecodeReply(raw, this.reportId);
+        if (mchoseA5Gen1ReplyMatches(reply, page, command)) return reply;
+        if (attempt === 3) await this.device.sendFeatureReport(this.reportId, payload);
+        await delay(30);
+      }
+      throw new Error(`The MCHOSE A5 did not acknowledge page 0x${page.toString(16)} command 0x${command.toString(16)}.`);
+    };
+    const next = this.queue.then(run, run);
+    this.queue = next.catch(() => undefined);
+    return next;
+  }
+
+  private async optional<T>(read: () => Promise<T>): Promise<T | null> {
+    try { return await read(); } catch { return null; }
+  }
+
+  private async readDpi(profile: number): Promise<{ active: number; stages: number[] }> {
+    const table = mchoseA5Gen1DecodeDpi(await this.request(10, 1, 0x81, [profile, MCHOSE_A5_GEN1_DPI_STAGES]));
+    const activeReply = await this.request(2, 1, 0x82, [profile]);
+    return { active: Math.max(1, Math.min(table.count, activeReply[7] || 1)), stages: table.stages };
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    const firmware = await this.optional(async () => mchoseA5Gen1DecodeFirmware(await this.request(16, 0, 0x81)));
+    const batteryReply = await this.optional(() => this.request(2, 0, 0x83));
+    const profileReply = await this.optional(() => this.request(1, 0, 0x85));
+    const profile = profileReply?.[6] || 1;
+    const pollingReply = await this.optional(() => this.request(1, 1, 0x80));
+    const dpi = await this.optional(() => this.readDpi(profile));
+    const sleepReply = await this.optional(() => this.request(2, 0, 0x87));
+    const debounceReply = await this.optional(() => this.request(2, 0, 0x88, [profile]));
+    const lodReply = await this.optional(() => this.request(1, 1, 0x88));
+    const motionReply = await this.optional(() => this.request(1, 1, 0x89));
+    const angleReply = await this.optional(() => this.request(1, 1, 0x84));
+    const rippleReply = await this.optional(() => this.request(1, 1, 0x8a));
+    const activeIndex = Math.max(0, (dpi?.active ?? 1) - 1);
+    const rates = this.rates();
+    const product = MCHOSE_A5_GEN1_PRODUCTS.get(this.device.productId);
+
+    return {
+      brand: "MCHOSE",
+      name: product?.name ?? this.displayName(),
+      batteryPercent: batteryReply ? Math.min(100, batteryReply[7] ?? 0) : null,
+      batteryState: batteryReply?.[6] ? "Charging" : batteryReply ? "Discharging" : "Unknown",
+      dpi: dpi?.stages[activeIndex] ?? 0,
+      dpiStages: dpi?.stages,
+      activeDpiStage: dpi ? activeIndex : undefined,
+      pollingRateHz: pollingReply ? (POLLING_VALUES.get(pollingReply[6] ?? 0) ?? 0) : 0,
+      supportedPollingRates: [...rates],
+      activeProfile: profileReply ? profile : null,
+      profileCount: profileReply ? MCHOSE_A5_GEN1_PROFILE_COUNT : undefined,
+      debounceMs: debounceReply?.[7] ?? null,
+      sleepTimeout: sleepReply ? ((sleepReply[6] ?? 0) << 8) | (sleepReply[7] ?? 0) : null,
+      liftOffDistance: lodReply ? ((lodReply[6] ?? 1) === 2 ? "High" : "Low") : null,
+      supportedLiftOffDistances: ["Low", "High"],
+      motionSync: motionReply ? (motionReply[6] ?? 0) > 0 : null,
+      angleSnapping: angleReply ? (angleReply[6] ?? 0) > 0 : null,
+      rippleControl: rippleReply ? (rippleReply[6] ?? 0) > 0 : null,
+      connectionType: product?.connection,
+      connectionDetail: this.isWired() ? "Wired USB" : "2.4 GHz receiver",
+      firmware: firmware ? [`Mouse ${firmware}`] : [],
+      ui: {
+        family: "mchose-a5-gen1",
+        settingsReady: Boolean(dpi && pollingReply),
+        valuesVerified: Boolean(dpi && pollingReply),
+        defaultDisplayName: "MCHOSE A5 Pro Max",
+        forceShowBattery: true,
+        hideSignalCard: true,
+        hideUnsupportedPollingRates: true,
+        showAdvancedSection: true,
+        pollingNote: this.isWired()
+          ? "The first-generation wired firmware supports 125, 500 and 1000 Hz."
+          : "Applies to the connected 2.4 GHz receiver.",
+        dpiStageEditor: {
+          maxStages: MCHOSE_A5_GEN1_DPI_STAGES,
+          countEditable: true,
+          minDpi: MCHOSE_A5_GEN1_DPI_MIN,
+          maxDpi: MCHOSE_A5_GEN1_DPI_MAX,
+          stepDpi: MCHOSE_A5_GEN1_DPI_STEP,
+        },
+      },
+    };
+  }
+
+  async setPollingRate(hertz: number): Promise<void> {
+    if (!this.rates().includes(hertz as never)) throw new Error(`This connection does not support ${hertz} Hz.`);
+    const code = POLLING_CODES.get(hertz);
+    if (!code) throw new Error(`Unsupported polling rate ${hertz}.`);
+    await this.request(1, 1, 0x00, [code]);
+    const confirmed = POLLING_VALUES.get((await this.request(1, 1, 0x80))[6] ?? 0);
+    if (confirmed !== hertz) throw new Error("The mouse did not confirm the polling-rate change.");
+  }
+
+  async setProfile(profile: number): Promise<void> {
+    if (!Number.isInteger(profile) || profile < 1 || profile > MCHOSE_A5_GEN1_PROFILE_COUNT) throw new Error("Profile must be 1-3.");
+    await this.request(1, 0, 0x05, [profile]);
+    if (((await this.request(1, 0, 0x85))[6] || 1) !== profile) throw new Error("The mouse did not confirm the profile change.");
+  }
+
+  async setDpiStageValue(stage: number, value: number): Promise<void> {
+    const profile = (await this.request(1, 0, 0x85))[6] || 1;
+    const current = await this.readDpi(profile);
+    if (!Number.isInteger(stage) || stage < 0 || stage >= current.stages.length) throw new Error(`DPI stage must be 0-${current.stages.length - 1}.`);
+    const stages = [...current.stages];
+    stages[stage] = value;
+    await this.writeDpi(profile, stages, current.active);
+  }
+
+  async setActiveDpiStage(stage: number): Promise<void> {
+    const profile = (await this.request(1, 0, 0x85))[6] || 1;
+    const current = await this.readDpi(profile);
+    if (!Number.isInteger(stage) || stage < 0 || stage >= current.stages.length) throw new Error(`DPI stage must be 0-${current.stages.length - 1}.`);
+    await this.request(2, 1, 0x02, [profile, stage + 1]);
+    if ((await this.readDpi(profile)).active !== stage + 1) throw new Error("The mouse did not confirm the active DPI stage.");
+  }
+
+  async setDpiStageCount(count: number): Promise<void> {
+    const profile = (await this.request(1, 0, 0x85))[6] || 1;
+    const current = await this.readDpi(profile);
+    if (!Number.isInteger(count) || count < 1 || count > MCHOSE_A5_GEN1_DPI_STAGES) throw new Error("DPI stage count must be 1-6.");
+    const stages = [...current.stages];
+    while (stages.length < count) stages.push(stages.at(-1) ?? 800);
+    await this.writeDpi(profile, stages.slice(0, count), Math.min(current.active, count));
+  }
+
+  private async writeDpi(profile: number, stages: readonly number[], active: number): Promise<void> {
+    const data = mchoseA5Gen1EncodeDpi(profile, stages);
+    await this.request(data.length, 1, 0x01, data);
+    await this.request(2, 1, 0x02, [profile, active]);
+    const confirmed = await this.readDpi(profile);
+    const expected = stages.slice(0, MCHOSE_A5_GEN1_DPI_STAGES).map(mchoseA5Gen1NormalizeDpi);
+    if (confirmed.stages.length !== expected.length || confirmed.stages.some((value, index) => value !== expected[index])) {
+      throw new Error("The mouse did not confirm the DPI change.");
+    }
+  }
+
+  async setDpi(value: number): Promise<void> {
+    const profile = (await this.request(1, 0, 0x85))[6] || 1;
+    const current = await this.readDpi(profile);
+    await this.setDpiStageValue(current.active - 1, value);
+  }
+
+  async setSleepTimeout(seconds: number): Promise<void> {
+    const value = Math.max(0, Math.min(0xffff, Math.round(seconds)));
+    await this.request(2, 0, 0x07, [(value >> 8) & 0xff, value & 0xff]);
+  }
+
+  async setDebounceTime(milliseconds: number): Promise<void> {
+    if (!Number.isInteger(milliseconds) || milliseconds < 0 || milliseconds > 15) throw new Error("Debounce must be 0-15 ms.");
+    const profile = (await this.request(1, 0, 0x85))[6] || 1;
+    await this.request(2, 0, 0x08, [profile, milliseconds]);
+  }
+
+  async setLiftOffDistance(value: NonNullable<MouseStatus["liftOffDistance"]>): Promise<void> {
+    await this.request(1, 1, 0x08, [value === "High" ? 2 : 1]);
+  }
+
+  async setMotionSync(enabled: boolean): Promise<void> { await this.request(1, 1, 0x09, [enabled ? 1 : 0]); }
+  async setAngleSnapping(enabled: boolean): Promise<void> { await this.request(1, 1, 0x04, [enabled ? 1 : 0]); }
+  async setRippleControl(enabled: boolean): Promise<void> { await this.request(1, 1, 0x0a, [enabled ? 1 : 0]); }
+}

--- a/src/drivers/registry.ts
+++ b/src/drivers/registry.ts
@@ -45,11 +45,12 @@ import { GloriousHidClient } from "./glorious/hid.ts";
 import { GloriousClassicHidClient } from "./glorious/classic-hid.ts";
 import { MchoseHidClient } from "./mchose/hid.ts";
 import { MchoseDockHidClient } from "./mchose/dock-hid.ts";
+import { MchoseA5ProMaxHidClient } from "./mchose/a5-gen1-hid.ts";
 import { KsnakeHidClient } from "./ksnake/hid.ts";
 import { MicrosoftHidClient } from "./microsoft/hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient | PulsarXs1HidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | KsnakeHidClient | MicrosoftHidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | MchoseA5ProMaxHidClient | KsnakeHidClient | MicrosoftHidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -111,6 +112,7 @@ export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
   { brand: "SteelSeries", supports: (device) => SteelSeriesSenseiTenHidClient.isSupported(device), create: (device) => new SteelSeriesSenseiTenHidClient(device), score: () => 6 },
   { brand: "Glorious", supports: (device) => GloriousHidClient.isSupported(device), create: (device) => new GloriousHidClient(device), score: () => 5 },
   { brand: "Glorious", supports: (device) => GloriousClassicHidClient.isSupported(device), create: (device) => new GloriousClassicHidClient(device), score: () => 5 },
+  { brand: "MCHOSE", supports: (device) => MchoseA5ProMaxHidClient.isSupported(device), create: (device) => new MchoseA5ProMaxHidClient(device), score: () => 8 },
   { brand: "MCHOSE", supports: (device) => MchoseHidClient.isSupported(device), create: (device) => new MchoseHidClient(device), score: () => 7 },
   { brand: "MCHOSE", supports: (device) => MchoseDockHidClient.isSupported(device), create: (device) => new MchoseDockHidClient(device), score: () => 7 },
   { brand: "K-snake", supports: (device) => KsnakeHidClient.isSupported(device), create: (device) => new KsnakeHidClient(device), score: () => 5 },

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -10,6 +10,9 @@ import {
   MCHOSE_DOCK_PRODUCT_ID,
   MCHOSE_DOCK_USAGE,
   MCHOSE_DOCK_USAGE_PAGE,
+  MCHOSE_A5_GEN1_PRODUCTS,
+  MCHOSE_A5_GEN1_USAGE_PAGE,
+  MCHOSE_A5_GEN1_VENDOR_ID,
 } from "@openmouse/protocol/mchose";
 import {
   HIDPP_BLUETOOTH_USAGE_PAGE,
@@ -104,10 +107,19 @@ export const VENDOR_ID = {
   gloriousClassicIWired: 0x320f, // Model O V2 / Model I 2 wired
   gloriousO3: 0x3794, // Model O3 Wireless / receiver (newer CORE-v2 generation)
   mchose: 0x3837,
+  mchoseA5Gen1: MCHOSE_A5_GEN1_VENDOR_ID,
   ksnakeUsb: 0xa8a4, // K-snake X11 wired
   ksnakeDongle: 0xa8a5, // K-snake X11 2.4 GHz dongle
   microsoft: 0x045E,
 } as const;
+
+export const MCHOSE_A5_HID_FILTERS: HIDDeviceFilter[] = [
+  ...[...MCHOSE_A5_GEN1_PRODUCTS.keys()].map((productId) => ({
+    vendorId: MCHOSE_A5_GEN1_VENDOR_ID,
+    productId,
+    usagePage: MCHOSE_A5_GEN1_USAGE_PAGE,
+  })),
+];
 
 /**
  * SteelSeries ships keyboards, headsets, and USB audio under 0x1038, so there
@@ -490,6 +502,7 @@ export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
   { vendorId: VENDOR_ID.orbital, usagePage: 0xff0a, usage: 1 },
   // MCHOSE ships keyboards and audio devices under 0x3837 too, so this stays
   // narrowed to the mouse configuration collection rather than the whole VID.
+  ...MCHOSE_A5_HID_FILTERS,
   { vendorId: VENDOR_ID.mchose, usagePage: MCHOSE_CONFIG_USAGE_PAGE, usage: MCHOSE_CONFIG_USAGE },
   // The MagDock is a separate device on its own usage page; it carries the RGB.
   { vendorId: VENDOR_ID.mchose, productId: MCHOSE_DOCK_PRODUCT_ID, usagePage: MCHOSE_DOCK_USAGE_PAGE, usage: MCHOSE_DOCK_USAGE },

--- a/src/mchose/a5-gen1.test.ts
+++ b/src/mchose/a5-gen1.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  MCHOSE_A5_GEN1_PRODUCTS,
   mchoseA5Gen1DecodeDpi,
   mchoseA5Gen1DecodeReply,
   mchoseA5Gen1EncodeRequest,
@@ -9,6 +10,12 @@ import {
 } from "./a5-gen1.ts";
 
 describe("MCHOSE A5 first-generation codec", () => {
+  it("records verification only for hardware paths that were exercised", () => {
+    assert.equal(MCHOSE_A5_GEN1_PRODUCTS.get(0xf019)?.verified, true);
+    assert.equal(MCHOSE_A5_GEN1_PRODUCTS.get(0xf013)?.verified, true);
+    assert.equal(MCHOSE_A5_GEN1_PRODUCTS.get(0xf015)?.verified, false);
+  });
+
   it("builds the captured XVI request header", () => {
     const packet = mchoseA5Gen1EncodeRequest({ length: 2, page: 1, command: 0x88, data: [1, 4] });
     assert.equal(packet.length, 64);

--- a/src/mchose/a5-gen1.test.ts
+++ b/src/mchose/a5-gen1.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  mchoseA5Gen1DecodeDpi,
+  mchoseA5Gen1DecodeReply,
+  mchoseA5Gen1EncodeRequest,
+  mchoseA5Gen1NormalizeDpi,
+  mchoseA5Gen1ReplyMatches,
+} from "./a5-gen1.ts";
+
+describe("MCHOSE A5 first-generation codec", () => {
+  it("builds the captured XVI request header", () => {
+    const packet = mchoseA5Gen1EncodeRequest({ length: 2, page: 1, command: 0x88, data: [1, 4] });
+    assert.equal(packet.length, 64);
+    assert.deepEqual([...packet.slice(0, 8)], [0, 0, 2, 2, 1, 0x88, 1, 4]);
+  });
+
+  it("accepts replies with or without the report id", () => {
+    const body = Uint8Array.from([0xa1, 0, 2, 1, 1, 0x80, 1, ...Array(57).fill(0)]);
+    assert.deepEqual(mchoseA5Gen1DecodeReply(body, 7), body);
+    assert.deepEqual(mchoseA5Gen1DecodeReply(Uint8Array.from([7, ...body]), 7), body);
+    assert.equal(mchoseA5Gen1ReplyMatches(body, 1, 0x80), true);
+  });
+
+  it("decodes big-endian duplicated DPI pairs", () => {
+    const reply = new Uint8Array(64);
+    reply[7] = 2;
+    reply.set([0x03, 0x20, 0x03, 0x20, 0x06, 0x40, 0x06, 0x40], 8);
+    assert.deepEqual(mchoseA5Gen1DecodeDpi(reply), { count: 2, stages: [800, 1600] });
+  });
+
+  it("quantizes DPI to the model's 50-step range", () => {
+    assert.equal(mchoseA5Gen1NormalizeDpi(1674), 1650);
+    assert.equal(mchoseA5Gen1NormalizeDpi(99999), 26000);
+  });
+});

--- a/src/mchose/a5-gen1.ts
+++ b/src/mchose/a5-gen1.ts
@@ -12,7 +12,7 @@ export interface MchoseA5Gen1Product {
 /** A5 Pro Max identities exercised by the standalone WebHID driver. */
 export const MCHOSE_A5_GEN1_PRODUCTS: ReadonlyMap<number, MchoseA5Gen1Product> = new Map([
   [0xf019, { name: "MCHOSE A5 Pro Max", connection: "Wired", verified: true }],
-  [0xf013, { name: "MCHOSE A5 Pro Max (1K receiver)", connection: "Wireless", verified: false }],
+  [0xf013, { name: "MCHOSE A5 Pro Max (1K receiver)", connection: "Wireless", verified: true }],
   [0xf015, { name: "MCHOSE A5 Pro Max (4K receiver)", connection: "Wireless", verified: false }],
 ]);
 

--- a/src/mchose/a5-gen1.ts
+++ b/src/mchose/a5-gen1.ts
@@ -1,0 +1,83 @@
+/** First-generation MCHOSE A5 protocol, distinct from the current M HUB protocol. */
+export const MCHOSE_A5_GEN1_VENDOR_ID = 0x2023;
+export const MCHOSE_A5_GEN1_USAGE_PAGE = 0xffff;
+export const MCHOSE_A5_GEN1_REPORT_LENGTH = 64;
+
+export interface MchoseA5Gen1Product {
+  name: string;
+  connection: "Wired" | "Wireless";
+  verified: boolean;
+}
+
+/** A5 Pro Max identities exercised by the standalone WebHID driver. */
+export const MCHOSE_A5_GEN1_PRODUCTS: ReadonlyMap<number, MchoseA5Gen1Product> = new Map([
+  [0xf019, { name: "MCHOSE A5 Pro Max", connection: "Wired", verified: true }],
+  [0xf013, { name: "MCHOSE A5 Pro Max (1K receiver)", connection: "Wireless", verified: false }],
+  [0xf015, { name: "MCHOSE A5 Pro Max (4K receiver)", connection: "Wireless", verified: false }],
+]);
+
+export const MCHOSE_A5_GEN1_PROFILE_COUNT = 3;
+export const MCHOSE_A5_GEN1_DPI_STAGES = 6;
+export const MCHOSE_A5_GEN1_DPI_MIN = 50;
+export const MCHOSE_A5_GEN1_DPI_MAX = 26000;
+export const MCHOSE_A5_GEN1_DPI_STEP = 50;
+export const MCHOSE_A5_GEN1_RECEIVER_RATES = [125, 250, 500, 1000] as const;
+export const MCHOSE_A5_GEN1_WIRED_RATES = [125, 500, 1000] as const;
+
+export interface MchoseA5Gen1Command {
+  length: number;
+  page: number;
+  command: number;
+  data?: readonly number[];
+  route?: number;
+}
+
+/** Build the 64-byte XVI feature-report body (the report id is passed separately). */
+export function mchoseA5Gen1EncodeRequest(input: MchoseA5Gen1Command): Uint8Array<ArrayBuffer> {
+  const payload = new Uint8Array(MCHOSE_A5_GEN1_REPORT_LENGTH);
+  payload[2] = input.route ?? 2;
+  payload[3] = input.length & 0xff;
+  payload[4] = input.page & 0xff;
+  payload[5] = input.command & 0xff;
+  payload.set((input.data ?? []).slice(0, 57), 6);
+  return payload;
+}
+
+/** Normalize WebHID implementations that include or omit the report id in returned data. */
+export function mchoseA5Gen1DecodeReply(raw: Uint8Array, reportId: number): Uint8Array {
+  if (raw.length === MCHOSE_A5_GEN1_REPORT_LENGTH + 1 && raw[0] === reportId) return raw.slice(1);
+  return raw.slice(0, MCHOSE_A5_GEN1_REPORT_LENGTH);
+}
+
+export function mchoseA5Gen1ReplyMatches(reply: Uint8Array, page: number, command: number): boolean {
+  return reply[0] === 0xa1 && reply[4] === page && reply[5] === command;
+}
+
+export function mchoseA5Gen1DecodeFirmware(reply: Uint8Array): string {
+  return [reply[6], reply[7], reply[8], reply[9]]
+    .map((part) => String(part ?? 0).padStart(2, "0"))
+    .join(".");
+}
+
+export function mchoseA5Gen1DecodeDpi(reply: Uint8Array): { count: number; stages: number[] } {
+  const count = Math.max(1, Math.min(MCHOSE_A5_GEN1_DPI_STAGES, reply[7] || MCHOSE_A5_GEN1_DPI_STAGES));
+  const stages = Array.from({ length: count }, (_, index) => {
+    const offset = 8 + index * 4;
+    return ((reply[offset] ?? 0) << 8) | (reply[offset + 1] ?? 0);
+  });
+  return { count, stages };
+}
+
+export function mchoseA5Gen1NormalizeDpi(value: number): number {
+  return Math.max(MCHOSE_A5_GEN1_DPI_MIN, Math.min(
+    MCHOSE_A5_GEN1_DPI_MAX,
+    Math.round(value / MCHOSE_A5_GEN1_DPI_STEP) * MCHOSE_A5_GEN1_DPI_STEP,
+  ));
+}
+
+export function mchoseA5Gen1EncodeDpi(profile: number, stages: readonly number[]): number[] {
+  const normalized = stages.slice(0, MCHOSE_A5_GEN1_DPI_STAGES).map(mchoseA5Gen1NormalizeDpi);
+  const data = [profile, normalized.length];
+  for (const dpi of normalized) data.push((dpi >> 8) & 0xff, dpi & 0xff, (dpi >> 8) & 0xff, dpi & 0xff);
+  return data;
+}

--- a/src/mchose/index.ts
+++ b/src/mchose/index.ts
@@ -540,6 +540,7 @@ export function mchosePollingRates(
 
 export * from "./buttons.ts";
 export * from "./dock.ts";
+export * from "./a5-gen1.ts";
 
 /**
  * Profile names, read one at a time with `0x12 0x68 <index>`. The reply is the


### PR DESCRIPTION
Resolves conflicts in #77, supersedes it.

Original PR by the contributor added a new, fully independent MCHOSE A5 Pro Max first-generation (XVI protocol) driver under vendor id 0x2023, distinct from the existing M HUB MCHOSE vendor id (0x3837) used by the A7 V2/V3 drivers — no overlap, no shared codec. The only conflicts were additive changes to `src/drivers/registry.ts`, `src/drivers/vendors.ts`, and `src/mchose/index.ts` from other PRs merged in the meantime (Incott, HyperX, MCHOSE V3). Resolved by combining both sides' additions; no logic was altered.

Verified: `npm run check` (build + full test suite + pack dry-run) passes, 1488/1488 tests green.

Claude-Session: https://claude.ai/code/session_01JfTcrhgBuFh8QiLvbtdJCX