### PR TITLE
Incott: model detection, buttons, per-axis DPI, macros, and four protocol corrections

### DIFF
--- a/captures/incott-8k-wireless/macro-upload-2026-09-11.hex
+++ b/captures/incott-8k-wireless/macro-upload-2026-09-11.hex
@@ -1,0 +1,65 @@
+# Macro upload: the transport, captured 2026-09-11
+#
+# Taken by instrumenting Incott's own configurator at incott.net/mouse/ with
+# tools/hid-probes/vendor-macro-capture.js (IncottHub), which hooks
+# sendReport as well as the two feature-report methods the 2026-09-07 session
+# used. Saving "first macro" to buffer 3 and binding it to a button.
+#
+# THE ANSWER: each chunk is a 32-byte OUTPUT report on report id 0x09.
+# Nothing else in this protocol uses an output report, which is exactly why
+# reading the bundle could not find it - `document.elsDevice` is defined in
+# none of the shipped files, and the HID method names resolve through
+# variables at runtime, so the string `sendFeatureReport` never appears
+# literally anywhere.
+#
+# The connect log also reported what node-hid enumeration cannot see:
+#     page 0xff05  feature: 0x9  output: 0x9
+# One collection, both report kinds on the same id.
+
+TX feature id=0x09  07 0a 00 20 03 00 00 00
+TX OUTPUT  id=0x09  03 01 01 00 01 0f 7c 00 81 0f e6 05 01 0e 9d 00 81 0e 50 04 01 09 87 00 81 09 b1 06 01 1c 8c 00
+TX feature id=0x09  07 0a 01 20 03 00 00 00
+TX OUTPUT  id=0x09  81 1c 00 00 00 00 ... (zeros to 32)
+TX feature id=0x09  07 0a 02 20 03 00 00 00      chunks 2-8 are all zeros:
+TX OUTPUT  id=0x09  00 00 ... (zeros)            the step area past the macro
+   ... same shape through chunk 8 ...
+TX feature id=0x09  07 0a 09 20 03 00 00 00
+TX OUTPUT  id=0x09  4d 61 63 72 6f 34 00 00 00 00 00 00 00 00 00 00 a4 00 00 00 10 00 e8 e8 90 0e ba 8f 10 00 08 00
+
+# Then the button binding, which confirms the fJuji encoding `slot << 16 | 9`:
+TX feature id=0x09  06 04 09 00 03 00 00 00      wire button 4 -> 0x00030009 = macro slot 3
+
+# ---------------------------------------------------------------------------
+# THE BUFFER, decoded against the vendor UI that produced it
+#
+# The UI showed: "first macro", "Cycle until any key is pressed", Cycle 1
+# times, and content:
+#     L 124ms > L 1510ms > K 157ms > K 1104ms > F 135ms > F 1713ms > Y 140ms > Y
+#
+#   [0]        03        buffer id 3
+#   [1]        01        loop 1 = until any key is pressed
+#   [2..3]     01 00     cycle count 1
+#   [4..35]              eight 4-byte events, press 0x01 / release 0x81:
+#                          01 0f 7c 00   L down,  124 ms     (L = HID 0x0F)
+#                          81 0f e6 05   L up,   1510 ms
+#                          01 0e 9d 00   K down,  157 ms     (K = HID 0x0E)
+#                          81 0e 50 04   K up,   1104 ms
+#                          01 09 87 00   F down,  135 ms     (F = HID 0x09)
+#                          81 09 b1 06   F up,   1713 ms
+#                          01 1c 8c 00   Y down,  140 ms     (Y = HID 0x1C)
+#                          81 1c 00 00   Y up,      0 ms
+#   [36..287]  00        unused step area
+#   [288..293] "Macro4"  ASCII name, '1' + buffer id
+#   [304..307] a4 00 00 00   size = 164 = (8 + 1) * 4 + 128
+#   [308..311] 10 00 e8 e8   constant in every buffer the vendor builds
+#   [312..315] 90 0e ba 8f   uid, LE32
+#   [316..317] 10 00         steps * 2
+#   [318]      08            step count
+#
+# CORRECTION THIS CAPTURE FORCED: the size field had been transcribed as
+# `(steps + 1) * 132`, which would have written 1188 here instead of 164. The
+# deobfuscation pass used to recover the vendor's source folded the constant
+# `4 + 128` into `132` before anyone read it - a transcription bug on this
+# side, not anything the vendor's code does. Every macro this driver built
+# would have carried a wrong size, and re-reading the transcription could
+# never have caught it. Only a real buffer did.

--- a/captures/incott-8k-wireless/profile-index-2026-09-11.hex
+++ b/captures/incott-8k-wireless/profile-index-2026-09-11.hex
@@ -1,0 +1,35 @@
+# Onboard profiles: the index is real, the storage is not (2026-09-11)
+# node-hid, 093A:522C (wireless). Browser tab closed — the app's refresh
+# timer contends for the shared response buffer and blanks every read.
+
+# 1. The index is genuinely on-device: readable, writable, and it sticks.
+09 86 09  ->  09 86 09 00 00 00 00 00 02     profile 0
+   wrote 09 06 09 01  -> index reads 1
+   wrote 09 06 09 02  -> index reads 2
+   wrote 09 06 09 03  -> index reads 3       (0-3, four slots)
+
+# 2. But every slot reported IDENTICAL settings:
+#      DPI 400/800/1600/2400/3200/6400 | cycle 6@1 | poll 0 | lod 0 | deb 4 | fire 3/10
+#
+#    That is the AMBIGUOUS case, not an answer — equally consistent with
+#    "no per-profile storage" and "per-profile storage where all four slots
+#    happen to match". The same trap that made the per-axis DPI read look
+#    non-existent. Making them differ is what settles it:
+
+   on profile 0: stage 0 = 400 DPI
+   switch to profile 1, write stage 0 = 1000  -> reads 1000
+   switch to profile 0                        -> reads 1000   <-- NOT 400
+
+# 3. THE RESULT: there is ONE settings store. Writing on one slot changes
+#    what every other slot reports, so the profile index does not gate any
+#    device behaviour. It is a number the mouse remembers, nothing more.
+#
+#    This explains the 2026-09-10 capture without contradiction: the vendor
+#    tool replays ~23 setting writes on every profile switch BECAUSE the
+#    mouse stores nothing per slot. The index is a host-readable signal —
+#    press the "Profile switch" button (favProfile, 0x0000F10A) and the
+#    mouse bumps the index; software that is running notices and pushes the
+#    matching configuration from ITS OWN storage.
+#
+#    Consequence: with no such software running, switching profiles — by
+#    button or by command — changes nothing the user can perceive.

--- a/captures/incott-8k-wireless/wired-dpi-ceiling-2026-09-11.hex
+++ b/captures/incott-8k-wireless/wired-dpi-ceiling-2026-09-11.hex
@@ -1,0 +1,51 @@
+# Wired DPI ceiling + a cable-ONLY identity frame, 2026-09-11
+# tools/hid-probes/dpi-ceiling.mjs (IncottHub), node-hid, 093A:622C.
+#
+# The mouse was on the USB cable with the 2.4 GHz dongle UNPLUGGED. That is
+# what makes this capture new: the 2026-09-08 "wired" enumeration was taken
+# with the dongle still in the port, so it was really cable+dongle.
+
+connection : WIRED (0x622C)
+identity   : 09 8f 01 0e 00 f1 00 00 00
+DPI cycle  : 6 stages, stage 1 active
+
+# 1. THE DPI CEILING: no wired cap. Every value was stored and read back
+#    exactly, including 45000 — above the 32000 the vendor's PAW3395 DPI
+#    table stops at. The driver's flat INCOTT_DPI_MAX of 45000 is correct on
+#    both links; no per-connection ceiling is needed (unlike polling rate).
+
+   wrote 30000 -> reads 30000   ACCEPTED
+   wrote 32000 -> reads 32000   ACCEPTED
+   wrote 32050 -> reads 32050   ACCEPTED
+   wrote 35000 -> reads 35000   ACCEPTED
+   wrote 40000 -> reads 40000   ACCEPTED
+   wrote 45000 -> reads 45000   ACCEPTED
+
+restored stage 1 -> 800 DPI OK
+
+# 2. THE IDENTITY FRAME IS NOT FIXED. Compare the two wired captures:
+#
+#   cable + dongle (2026-09-08):  09 8f 01 0e 02 f0 f1 00 ff
+#   cable only     (2026-09-11):  09 8f 01 0e 00 f1 00 00 00
+#                                            ^^ ^^ ^^
+#                                            |  |  +-- byte 6
+#                                            |  +----- byte 5
+#                                            +-------- byte 4, receiver type
+#
+#    byte 4 is 0x02 when the 8 KHz receiver is present and 0x00 when it is
+#    not, which is consistent and was already decoded. What was NOT known is
+#    that the sensor slot MOVES with it: with the dongle present the sensor
+#    (0xF1 = PAW3950) sits at byte 6 and byte 5 holds 0xF0; with the dongle
+#    gone the same 0xF1 sits at byte 5 and byte 6 is empty.
+#
+#    This vindicates the vendor's connection-dependent index
+#    (`iswireless ? 5 : 4` over its report-id-less buffer = frame bytes 6:5),
+#    which this driver had dismissed as a cosmetic bug and replaced with a
+#    fixed byte 6. Cable-only, fixed byte 6 reads 0x00 and reports PAW3395 —
+#    dropping the "Pro" from the model name.
+#
+#    The DPI result above independently settles which sensor is fitted: a
+#    PAW3395 tops out at 32000 in the vendor's own table, and this mouse
+#    stored 45000 over the cable. It is a PAW3950 on every link, so ANY slot
+#    reading 0xF1 is the answer regardless of which one the connection puts
+#    it in.

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -1021,8 +1021,13 @@ count to clamp the active stage into the new range). `setDpiStageCount`
 resizes the cycle, leaves every stored stage value untouched, and clamps the
 active stage rather than leaving it pointing past the end.
 
-**Untested on hardware:** no capture exists of a cycle shorter than six,
-because the vendor tool was never driven to make one. The decode is proven,
-but the resize path is exercised only against the fake device. Setting the
-count to 3 in the vendor tool and re-reading `09 83` would confirm it in
-seconds.
+**CONFIRMED on hardware 2026-09-11.** The device owner set the cycle to three
+stages through this driver and cycled the mouse through all three, which is
+the first direct evidence of a cycle shorter than six on this hardware —
+until then the resize path was exercised only against the fake device, and no
+capture of a non-six count existed at all, because the vendor tool had never
+been driven to make one.
+
+This also settles the count reading itself by a second route: a device that
+rotates through exactly three stages after being told `09 03 03 <idx>` is
+reading that byte as a cycle length, not echoing a sub-command.

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -591,7 +591,7 @@ in "Unresolved unknowns" below: the fix would be finding the read the vendor
 tool itself uses to display separate X and Y DPI values, if it has one. See
 `captures/incott-8k-wireless/vendor-tool-session-2026-09-10.hex`.
 
-## Onboard profiles are NOT a device feature (2026-09-10)
+## Onboard profiles: the settings are replayed by the host (2026-09-10, corrected below)
 
 Switching the vendor UI from "Onboard 1" to "Onboard 2" was instrumented end
 to end. **It emitted no profile-select command at all.** Instead it replayed
@@ -601,23 +601,36 @@ performance mode, lift-off, the three sensor toggles, receiver LED, debounce
 and sleep, roughly 23 writes in total, indistinguishable from a user manually
 re-entering every setting by hand.
 
-**There is no on-device command to search for here.** "Onboard profiles" are
-a construct of the vendor's own configurator software, which apparently
-stores a full settings snapshot per named slot and replays it wholesale on
-selection; the mouse itself has no concept of a stored, selectable profile.
-Recording this so nobody spends time hunting for a `0x0N`/profile-select
-opcode that does not exist.
+The settings themselves are a construct of the vendor's own configurator,
+which stores a full snapshot per named slot and replays it wholesale on
+selection. Nothing in the capture suggests the mouse stores per-slot
+settings of its own.
 
-One write at the very end of each replay is not accounted for by any known
-setting: `09 06 09 <00|01>`. Button indices only run 0-5 (`INCOTT_BUTTON_COUNT`),
-so `09` here is not a button index — this is a distinct write under command
-`0x06`. **Leading hypothesis, UNCONFIRMED**: the vendor UI has an "Invert the
-left and right button" toggle, and the two onboard slots in this session
-happened to have that toggle in different states. This was not tested in
-isolation (toggling that control on its own with nothing else changed), so it
-remains a hypothesis, not a confirmed mapping — do not implement it from this
-capture alone. See
-`captures/incott-8k-wireless/vendor-tool-session-2026-09-10.hex`.
+### CORRECTION 2026-09-10: a profile-select command DOES exist
+
+The paragraph that stood here said "there is no on-device command to search
+for" and offered a hypothesis for one unexplained write. Both were wrong, and
+the vendor's own deobfuscated bundle names the write directly:
+
+```js
+setProfileIndex(index)  { [6, 9, index, 0, 0, 0, 0, 0] }   // -> 09 06 09 <index>
+readProfileIndex()      { readKEY(9) }                     // -> 09 86 09
+```
+
+That is exactly the `09 06 09 <00|01>` write logged at the end of each
+replay, and the **"invert left and right button" hypothesis recorded for it
+was wrong** — it is the profile index. The vendor also reads it back at
+connect time, so the mouse genuinely stores a selectable index.
+
+What survives from the original finding: switching slots still replays ~23
+ordinary setting writes, so the index alone does not appear to make the mouse
+swap a stored configuration. Whether the device stores anything at all
+against that index is untested.
+
+Neither command is implemented here — both are transcriptions, unverified on
+hardware. See
+`captures/incott-8k-wireless/vendor-tool-session-2026-09-10.hex` and the
+model-identification section at the end of this document.
 
 ## READS: verified on hardware
 
@@ -723,35 +736,36 @@ capture session has resolved. **Do not resolve these by guessing.**
   given write. **Left unchanged pending a hardware check**: set 0.7 mm in the
   vendor tool, then read `0x84`/`0x01` (or the packed form) and see which
   value comes back.
-- **Button payload semantics.** The three bytes `incottDecodeButtonBinding`
-  returns (`b0`/`b1`/`b2`) are deliberately unnamed: whether they encode a
-  key code, a macro reference, or a remap target is not established. Needs a
-  hardware check: write a series of known key bindings through the vendor
-  tool and see how the three bytes change.
-- **Which sensor is fitted.** PAW3395 caps at 32000 DPI, PAW3950 at 45000.
-  The 25000 DPI write confirmed on 2026-09-08 is below both known ceilings,
-  so it does not distinguish them. This driver assumes 45000 (the higher
-  ceiling) for every unit since the sensor variant cannot currently be read;
-  confirming the cap on a PAW3395 unit (and finding a way to detect which
-  sensor is fitted, if one exists) is an open question.
-- **What `0x86` sub `0x09` means.** The vendor tool queries this
-  specifically (`09 86 09`); its payload is undecoded and is not a button
-  index (buttons only go up to 5).
-- **The byte layout of the `0x8f` identity response.** The raw bytes are
-  captured and shown as-is in the details panel (see
-  `incottDecodeIdentity`), but no field within them (firmware version,
-  hardware revision, etc.) has been decoded.
-- **DPI per-axis read.** The 2026-09-10 capture found a write-side axis byte
-  (payload index 7: 0 = both, 1 = X only, 2 = Y only — see "DPI write axis
-  byte" below) but no corresponding per-axis READ: probing `0x82` with the
-  axis byte set to 0, 1 and 2 returned the identical value every time. Without
-  a read to verify a Y-only write against, this driver does not implement
-  independent X/Y DPI. Needs a hardware check: find the read the vendor tool
-  itself uses to display separate X and Y DPI values (if it does).
-- **The `09 06 09 <00|01>` write seen at the end of an onboard-profile
-  replay.** See "Onboard profiles are not a device feature" below. Leading
-  hypothesis: the vendor UI's "Invert the left and right button" toggle —
-  UNCONFIRMED, not tested in isolation.
+- **Button payload semantics — encoding now transcribed, still unverified.**
+  The three bytes `incottDecodeButtonBinding` returns (`b0`/`b1`/`b2`) remain
+  deliberately unnamed here. The vendor's bundle assembles a binding as a
+  32-bit little-endian word (`[6, index, k1, k2, k3, k4, 0, 0]`, read back at
+  frame bytes 3-6), and its semantic tables are known — categories
+  `fMouse=1, fKeyboard=2, fMedia=3, fJuji=4, fAdv=5, fCmd=6`. What is NOT
+  established is how a category/function pair maps into that word: the one
+  observed sample (`1,12` -> `07 00 03`) does not fall out of the obvious
+  packings. Needs a hardware check: bind one button to a series of known
+  functions and capture each.
+- **The remaining `0x8f` identity bytes.** Bytes 2-6 are decoded (model,
+  receiver, sensor — see the model-identification section at the end of this
+  document). Bytes 7-8 (`00 ff` on this device) are still unknown; a firmware
+  version is the obvious candidate but nothing confirms it.
+- **DPI per-axis read — probably does not exist.** The 2026-09-10 capture
+  found a write-side axis byte (payload index 7: 0 = both, 1 = X, 2 = Y) but
+  no per-axis READ: probing `0x82` with the axis byte set to 0, 1 and 2
+  returned the identical value every time. The vendor's own code matches
+  this — `setResolution` sends two writes distinguished by that flag and has
+  no per-axis read at all, so its UI must track X and Y host-side. Without a
+  read to verify a Y-only write against, this driver still does not implement
+  independent X/Y DPI.
+
+Resolved since this list was written (kept for the record):
+
+- ~~**Which sensor is fitted.**~~ Byte 6 of the identity reply: `0xF0` =
+  PAW3395, `0xF1` = PAW3950.
+- ~~**What `0x86` sub `0x09` means.**~~ The onboard profile index.
+- ~~**The `09 06 09 <00|01>` write.**~~ The profile-index write, not a
+  left/right invert toggle — see the correction under "Onboard profiles".
 
 ## Attribution
 
@@ -769,6 +783,14 @@ vendor's own WebHID configurator, and `write-roundtrip.hex` (2026-09-08)
 taken directly from hardware with node-hid while performing real,
 subsequently-restored writes — none of the three is reproduced from
 IncottHIDApp.
+
+The identity byte map (model code, receiver type, sensor) and the command
+layouts listed as transcriptions above were established by reading the
+vendor's own publicly served configurator bundle at `incott.net/mouse/js/`
+for interoperability. No vendor code is copied into this driver: what is
+reused is the wire format — which byte carries which field — reimplemented
+here with its own decoders, tests and hardware confirmation where a device
+was available to give it.
 
 ## Lift-off distance mapping — resolved 2026-09-08
 
@@ -788,43 +810,126 @@ Only the 0.7 mm point was read back directly. Hardware `0` and `1` are 1 mm and
 was testable proved correct, but neither of those two values has been read
 individually.
 
-## Model identification is not solved (searched 2026-09-10)
+## Model identification: SOLVED 2026-09-10 — it is `0x8F`
 
-The HID product string only names the model over the cable
-(`incott Esports G23V2Pro mouse`); on the 2.4 GHz dongle it reports the generic
-`incott 8K wireless mouse`. Incott's own configurator nevertheless displays
-`G23V2Pro` while wireless, so the model is derivable somehow. This is what was
-ruled out looking for it.
+The identity reply was sitting in the very first capture taken for this
+driver, undecoded for three days:
 
-**The sensor id is not in any feature report.** The vendor's device definition
-picks the DPI ceiling from a sensor id (`0x3395` PAW3395 caps at 32000,
-`0x3950` PAW3950 at 45000), and this unit's own profile export records
-`dpisensor:14672` = `0x3950`. Every query command `0x80`-`0x8F` was swept
-against sub-commands `0x00`-`0x1F` and **no response contains `0x3950` in
-either byte order**. The tool does not read it as a raw 16-bit value.
+```
+09 8f 01 0e 02 f0 f1 00 ff        captures/incott-8k-wireless/query-sweep-0x80-0x8f.hex
+```
 
-**It must therefore come from the startup reads.** The captured init sequence
-performs only six: `0x8F`, `0x8E`/`0x01`, `0x89`, `0x83`, `0x85`/`0x03` and
-`0x86`/`0x09`. The only identity-shaped response is:
+### Why the earlier search failed
 
-    09 8f 01 0e 02 f0 f1 00
+The previous section of this document (kept below in summary) recorded model
+identification as unsolved after sweeping every query command `0x80`-`0x8F`
+against sub-commands `0x00`-`0x1F` looking for the sensor id `0x3950` as a
+raw 16-bit value. **It is not transmitted as one.** The sensor is a single
+byte — `0xF0`/`0xF1` — expanded into `0x3395`/`0x3950` by a lookup on the
+host. No amount of sweeping would have found it, and the model itself is a
+different byte again.
 
-Byte 3 (`0x01`) is a plausible model code, but that is **one sample from one
-device** and it is equally consistent with a firmware major version. It is not
-implemented on that basis — an earlier battery hypothesis in this driver was
-adopted from a single coincidental match and later disproven by a charge cycle.
-One sample is not evidence.
+The first search also stopped at "the vendor's JavaScript is obfuscated".
+That was true but not an obstacle: the obfuscation is mechanical and reverses
+in a few lines — decode `\uXXXX` escapes, fold the `(A^B)` junk arithmetic to
+constants, and reverse the `"abc".split("").reverse().join("")` string
+literals. `readDps()` is then plain to read.
 
-**The vendor's JavaScript is deliberately obfuscated**, which is why static
-analysis stops here: property names appear as unicode escape sequences (for
-example `sensor` for `sensor`), control flow
-is padded with junk XOR arithmetic, and identifiers are scrambled. Nothing
-matching `sendFeatureReport` or `navigator.hid` appears literally in any shipped
-file. The derivation runs through an internal object (`getStDPI(ace.sensor)`);
-recovering it means deobfuscating the bundle, not grepping it.
+### The byte map
 
-**What would settle it cheaply:** determine whether different Incott models
-enumerate under different USB product ids. If a G23 and a G23V2 differ, model
-detection needs no protocol work at all and is trivially verifiable. If they
-share `093A:522C`, the identity response has to be decoded, which needs a
-capture from a second model — this contributor has only a G23V2Pro.
+`rData` in the vendor's code is the report **without** the report id, so
+`rData[n]` is `frame[n+1]` here. Transcribed from its `readDps()`:
+
+| Frame byte | Meaning | This device |
+| --- | --- | --- |
+| 2 | guard, must be `0x01` | `0x01` |
+| 3 | **model code** | `0x0E` = G23V2 |
+| 4 | receiver type, `0x02` = 8 KHz | `0x02` |
+| 5 | sensor profile, WIRED link | `0xF0` = PAW3395 |
+| 6 | sensor profile, WIRELESS link | `0xF1` = PAW3950 |
+| 7-8 | still undecoded | `00 ff` |
+
+Model codes, and the names the vendor's `text_en` bundle gives them:
+
+| Code | Vendor internal | Displayed |
+| --- | --- | --- |
+| `0x01` | `Ghero` | Ghero |
+| `0x02` | `G23` | G23 |
+| `0x03` | `G24` | G24 |
+| `0x06` | `G29` | Zero 29 (零29) |
+| `0x08` | `G23V2` | G23V2 |
+| `0x09` | `FM23` | Zero 39 (零39) |
+| `0x0E` | `G23V2` | G23V2 |
+
+`0x08` and `0x0E` are both G23V2 — the vendor tests them in one branch. Only
+the `0x0E` row is confirmed against hardware here; the rest are transcribed
+from a dispatch table that is authoritative for models this contributor does
+not own.
+
+The sensor decides the "Pro" suffix: the vendor appends `Pro` when the sensor
+is `0x3950`, which is how `G23V2Pro` appears for a device whose HID product
+string only ever says `incott 8K wireless mouse`.
+
+### The one inference, and how to falsify it
+
+Bytes 5 and 6 **disagree on this device** (`f0 f1`), and the vendor picks
+between them by connection (`let i = this.iswireless ? 5 : 4`). Read as
+hardware identity that is a contradiction — a mouse does not change sensors
+when a cable goes in — so the vendor's own tool necessarily labels this one
+physical mouse `G23V2Pro` on the dongle and `G23V2` on the cable.
+
+Read as a per-link **capability** profile it is consistent: the value feeds
+`getStDPI(sensor)`, which selects a DPI ceiling (PAW3395 -> 32000,
+PAW3950 -> 45000), and the cable is already the reduced-capability path on
+this device, capping polling at 1000 Hz.
+
+`incottDecodeIdentity` therefore reads the fitted sensor from **byte 6**
+unconditionally, so the decoded name is stable across connections. This is
+the only inference in that decoder rather than a transcription.
+
+**To falsify it:** connect the mouse by cable and read what the vendor tool
+displays. If it shows `G23V2Pro` while wired, byte 5 is not a wired
+capability profile and this reading is wrong. A per-link DPI ceiling is
+deliberately NOT implemented — nothing has confirmed the cable caps DPI at
+32000.
+
+### What this replaces
+
+`MouseStatus.name` now comes from the identity reply, falling back to
+`incottNormalizeProductName` only when the query fails or the model code is
+outside the table above. The product string is no longer the primary source:
+it names a model over the cable and not on the dongle, so relying on it
+renamed the mouse depending on how it was plugged in.
+
+### Product ids cannot distinguish models — confirmed
+
+All six models enumerate as `093A:522C` (wireless) / `093A:622C` (wired).
+Two independent confirmations:
+
+- The vendor's own WebHID filter, recovered from the deobfuscated bundle, is
+  exactly those two product ids plus usage page `0xFF05`, usage `0x01`:
+  ```js
+  [{vendorId: 0x093A, productId: 0x622C, usagePage: 0xFF05, usage: 0x01},
+   {vendorId: 0x093A, productId: 0x522C, usagePage: 0xFF05, usage: 0x01}]
+  ```
+  This independently confirms the `0xFF05` collection match this driver
+  already uses (see "Wired mode was completely broken" above).
+- [IncottHIDApp](https://github.com/romkazor/IncottHIDApp)'s compatibility
+  table lists Ghero, G23, G24, G23V2, Zero 29 and Zero 39 against the same
+  two ids, with three constants in `device.go` and no per-model table.
+
+### Leads recovered from the same source, not yet implemented
+
+These are transcriptions, unverified against hardware:
+
+- **Buttons** — read `0x86` sub = button index, value is a 32-bit
+  little-endian word at frame bytes 3-6 (`rData[5]<<24|rData[4]<<16|
+  rData[3]<<8|rData[2]`). Write is `0x06`:
+  `[6, index, k1, k2, k3, k4, 0, 0]`. This is the wire encoding the button
+  work was blocked on.
+- **Independent X/Y DPI** — one write per axis, distinguished by a flag at
+  byte 7: `[2, ix, dpiLo, dpiHi, 0, 0, 0, flag]` with flag `0` when X == Y,
+  then `1` for X and `2` for Y. There is no per-axis read, which is why a Y
+  write could never be verified.
+- **Profile select** — `[6, 9, index, 0, 0, 0, 0, 0]`, read back via
+  `0x86` sub `0x09`. See the correction in "Onboard profiles" above.

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -519,13 +519,20 @@ the earlier sweep.** The vendor tool teaches the same lesson for `0x86`,
 which it queries as `09 86 09` — not a button index (buttons only go up to
 5) and still undecoded.
 
-`0x82`/`0x83`/`0x84`/`0x85`/`0x86`/`0x8e` all echo their sub-command at byte
-2 of the reply. `0x82`, `0x83`, `0x84`, `0x85` and `0x8e` are registered as
-such in `SUB_ECHOING_QUERIES` (`src/drivers/incott/hid.ts`), since the driver
-queries all of them; `0x86` echoes identically (`incottDecodeButtonBinding`
-checks it directly via `incottFrameMatches`) but is not in that set because
-the driver itself never issues a `0x86` query — see `INCOTT_CMD_QUERY_BUTTON`
-in `src/incott/index.ts`.
+`0x82`/`0x84`/`0x85`/`0x86`/`0x8e` echo their sub-command at byte 2 of the
+reply, and all five are registered in `SUB_ECHOING_QUERIES`
+(`src/drivers/incott/hid.ts`). `0x86` joined that set on 2026-09-10 when
+button reads were wired up: six reads go out back to back against a single
+shared response buffer, so matching on the command byte alone would let one
+button's reply satisfy another's request.
+
+**`0x83` DOES NOT echo — corrected 2026-09-10.** It was listed here and
+registered in `SUB_ECHOING_QUERIES` for two sessions on the strength of a
+reply that appeared to echo the `0x06` sent with it. Byte 2 is the DPI stage
+COUNT: the vendor sends `09 83 00` and gets `09 83 06 01`, and a bare
+`09 83` sweep answers the same `06`. A byte the request never contained
+cannot be an echo — the assumption only survived because the count on the
+device under test happens to be six. See "DPI stage count" below.
 
 ## Performance mode: mapping VERIFIED 2026-09-10, now wired into the shared UI contract
 
@@ -680,8 +687,8 @@ device — see `captures/incott-8k-wireless/targeted-reads.hex`,
 
 - `0x81` answers the polling-rate query; byte 2 is confirmed data (see above).
 - `0x82` (with a sub-command 0-5) answers with that DPI stage's value.
-- `0x83` (with sub-command `0x06`) answers with the active DPI *stage index*
-  (0-5) — not a DPI value.
+- `0x83` (no sub-command) answers with the DPI cycle: byte 2 the stage COUNT,
+  byte 3 the active *stage index* — neither is a DPI value.
 - `0x84` (sensor) answers for sub-commands `0x00` (packed lift-off + motion
   sync), `0x01` (lift-off, symmetric), `0x02` (ripple control), `0x03`
   (angle snap), `0x04` (motion sync, symmetric), and `0x05` (performance
@@ -962,3 +969,60 @@ transcriptions, unverified against hardware:
   write could never be verified.
 - **Profile select** — `[6, 9, index, 0, 0, 0, 0, 0]`, read back via
   `0x86` sub `0x09`. See the correction in "Onboard profiles" above.
+
+## DPI stage count: a byte misread as a sub-command (2026-09-10)
+
+`0x83`'s reply byte 2 is the **stage count** — how many stages the DPI cycle
+rotates through — not a sub-command echo. The proof is in captures this
+driver already had:
+
+```
+TX 09 83 00      <- vendor sends sub-command 0x00
+RX 09 83 06 01   <- byte 2 comes back 0x06 anyway
+```
+
+and the bare `09 83` sweep in `query-sweep-0x80-0x8f.hex` answers
+`09 83 06 01` too. A byte the request never contained cannot be an echo.
+Byte 3 varies across the same session (`00`/`01`/`03`/`05`) while byte 2
+stays `06`: byte 3 is the active stage, byte 2 is the cycle length.
+
+The misreading survived two sessions because this contributor's mouse has a
+six-stage cycle and the driver happened to send `06`. Everything agreed with
+everything else, on one device, by coincidence — the same shape of mistake as
+the battery byte (a constant matched once) and the DPI stage index (an index
+that decoded to the right number once).
+
+### Two real bugs this was causing
+
+**Every DPI read would have failed on a shorter cycle.** `0x83` was in
+`SUB_ECHOING_QUERIES`, so the driver required reply byte 2 to equal the `06`
+it sent. On a mouse configured for four stages the reply carries `04`, no
+frame ever matched, and `activeDpiStage`, `dpi` and `dpiStages` all came back
+null — which sets `ui.settingsReady: false` and hides the entire settings
+grid. Removed from that set; `incottDecodeDpiCycle` matches on the command
+byte only.
+
+**Selecting a stage silently resized the cycle.** The `0x03` write carries
+the count and the index together (`09 03 <count> <stage>`), and the driver
+hardcoded `0x06` in the count position. Picking a different DPI stage on a
+four-stage mouse would have written six, growing the cycle back to the full
+table. `setActiveDpiStage` now reads the current count and writes it back
+unchanged.
+
+Neither bug was observable on the only available device, and neither would
+have been found by testing it.
+
+### What this adds
+
+`readStatus` publishes `dpiStages` trimmed to the live cycle and sets
+`dpiStageEditor.countEditable` (only while the cycle actually read — the
+count picker writes through `setDpiStageCount`, which needs a real current
+count to clamp the active stage into the new range). `setDpiStageCount`
+resizes the cycle, leaves every stored stage value untouched, and clamps the
+active stage rather than leaving it pointing past the end.
+
+**Untested on hardware:** no capture exists of a cycle shorter than six,
+because the vendor tool was never driven to make one. The decode is proven,
+but the resize path is exercised only against the fake device. Setting the
+count to 3 in the vendor tool and re-reading `09 83` would confirm it in
+seconds.

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -1133,3 +1133,63 @@ states that "assignment writes, shortcuts, and macros remain locked pending
 reversible validation", and Logitech's macro encoders are driver-internal
 rather than part of the shared contract. A macro contract shape is a question
 for the maintainers, not something to guess at.
+
+## 0x05/0x02 identified: Fire Key parameters (2026-09-11)
+
+The last unidentified command in this protocol. It is not a power or timing
+setting despite living in the `0x05` family alongside debounce and sleep — it
+configures **rapid fire**.
+
+The vendor calls it `setFKeyPm(lp, ir)` and calls it from exactly one place:
+applying a button whose binding is `favFIRE`.
+
+```js
+if (fMouse == pf.key[i].major && favFIRE == pf.key[i].minor) {
+  let lp = pf.key[i].itemdata & 0xffff;        if (lp > 3) lp = 3;
+  let ir = pf.key[i].itemdata >> 16 & 0xffff;  if (ir > 255) ir = 255;
+  await this.setFKeyPm(lp, ir);
+}
+```
+
+Its own `text_en` bundle names both fields:
+
+```
+"fire"  : "Fire Key"
+"fire1" : "Keep left-clicking according to the interval and times"
+"fire2" : "interval"
+```
+
+So `lp` is **times** (clicks per press, clamped to 3) and `ir` is the
+**interval** in milliseconds (clamped to 255).
+
+```
+write: 09 05 02 <times> <interval ms>
+read:  09 85 02  -> times at byte 3, interval at byte 4
+```
+
+**Hardware-confirmed 2026-09-11.** The device read `09 85 02 03 0a` — three
+clicks, 10 ms apart — and a round-trip wrote `1/50`, `2/20` and `3/255`,
+reading each back exactly before restoring `3/10`.
+
+The parameters are **global, not per-button**: the command carries no button
+index, so they apply to whichever button is bound to "Rapid fire"
+(`0x0218F00A` in `INCOTT_BUTTON_ACTIONS`).
+
+Not advertised through `MouseStatus` — the shared contract has no rapid-fire
+field, so `getFireKey`/`setFireKey` sit where `setReceiverLed` does: real,
+tested, and waiting for a control to hang them off.
+
+### Newly seen while sweeping: 0x85 sub 0x07
+
+The same read-only sweep turned up an undocumented responder:
+
+```
+sub 0x00: 09 85 00 00 00      sub 0x02: 09 85 02 03 0a   (fire key)
+sub 0x01: 09 85 01 04 00      sub 0x03: 09 85 03 3c 00   (sleep)
+sub 0x07: 09 85 07 01 0e 00                              (UNKNOWN)
+```
+
+Nothing else in `0x00`-`0x0f` answers. `01 0e` is suggestive — those are the
+same two values the identity reply carries at bytes 2 and 3 (guard `0x01`,
+model code `0x0E`) — but the vendor bundle never queries `0x85`/`0x07` at
+all, so there is no caller to name it. Recorded, not guessed at.

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -1169,6 +1169,14 @@ The parameters are **global, not per-button**: the command carries no button
 index, so they apply to whichever button is bound to "Rapid fire"
 (`0x0218F00A` in `INCOTT_BUTTON_ACTIONS`).
 
+**`times` = 0 is a fourth mode, not an absence of one** (confirmed against
+the vendor software 2026-09-11): the button fires continuously while held and
+stops on release, rather than sending a fixed burst. Worth recording how that
+was established — a write round-trip could never have shown it, because 0 is
+in range and reads back cleanly like any other value. The MEANING of a value
+is not something a round-trip tests, and only someone watching the vendor UI
+could supply it.
+
 Not advertised through `MouseStatus` — the shared contract has no rapid-fire
 field, so `getFireKey`/`setFireKey` sit where `setReceiverLed` does: real,
 tested, and waiting for a control to hang them off.

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -1026,16 +1026,16 @@ Two independent confirmations:
 
 ### Leads recovered from the same source, not yet implemented
 
-Buttons came from this source and are now **implemented and hardware-
-confirmed** — see "Buttons: DECODED and shipped" above. The rest are still
-transcriptions, unverified against hardware:
+Everything that came from this source has since been implemented and, where
+a device could show it, confirmed on hardware:
 
-- **Independent X/Y DPI** — one write per axis, distinguished by a flag at
-  byte 7: `[2, ix, dpiLo, dpiHi, 0, 0, 0, flag]` with flag `0` when X == Y,
-  then `1` for X and `2` for Y. There is no per-axis read, which is why a Y
-  write could never be verified.
-- **Profile select** — `[6, 9, index, 0, 0, 0, 0, 0]`, read back via
-  `0x86` sub `0x09`. See the correction in "Onboard profiles" above.
+- **Buttons** — see "Buttons: DECODED and shipped" above.
+- **Independent X/Y DPI** — `[2, ix, dpiLo, dpiHi, 0, 0, 0, flag]`, flag `0`
+  when X == Y then `1` for X and `2` for Y. The per-axis READ does exist; see
+  "Independent X/Y DPI" below for why an earlier probe concluded otherwise.
+- **Profile select** — `[6, 9, index]`, read back via `0x86` sub `0x09`. Real,
+  but it gates nothing: see "Onboard profiles" above.
+- **Macros** — `0x07` headers plus 32-byte OUTPUT reports; see "Macros" below.
 
 ## DPI stage count: a byte misread as a sub-command (2026-09-10)
 
@@ -1112,7 +1112,7 @@ The 320-byte macro buffer is fully transcribed from the vendor bundle's
 [5+4n]     HID keyboard usage code
 [6..7+4n]  delay after the event, LE16 ms
 [288..293] ASCII "Macro" then '1' + buffer id
-[304..307] (steps + 1) * 132, LE32
+[304..307] (steps + 1) * 4 + 128, LE32
 [308..311] 16, 0, 232, 232 — constant in every buffer the vendor builds
 [312..315] uid, LE32
 [316..317] steps * 2, LE16

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -680,10 +680,41 @@ replay, and the **"invert left and right button" hypothesis recorded for it
 was wrong** — it is the profile index. The vendor also reads it back at
 connect time, so the mouse genuinely stores a selectable index.
 
-What survives from the original finding: switching slots still replays ~23
-ordinary setting writes, so the index alone does not appear to make the mouse
-swap a stored configuration. Whether the device stores anything at all
-against that index is untested.
+### Settled 2026-09-11: the index is real, the storage is not
+
+"Whether the device stores anything against that index" is now tested. It
+does not.
+
+Reading every slot first looked like it might: all four reported identical
+settings. That is the AMBIGUOUS case rather than an answer — equally
+consistent with "no per-profile storage" and "per-profile storage where the
+slots happen to match", which is the same trap that made the per-axis DPI
+read look non-existent. Making them differ settles it:
+
+```
+on profile 0: stage 0 = 400 DPI
+switch to profile 1, write stage 0 = 1000  -> reads 1000
+switch to profile 0                        -> reads 1000   <-- not 400
+```
+
+**There is one settings store.** A write on any slot changes what every other
+slot reports, so the index gates no device behaviour.
+
+That explains the 2026-09-10 capture without contradiction: the vendor tool
+replays ~23 setting writes on a profile switch BECAUSE the mouse stores
+nothing per slot. The index is a host-readable signal — pressing the
+"Profile switch" button (`favProfile`, `0x0000F10A`) bumps it, and software
+that happens to be running notices and pushes the matching configuration
+from its own storage. With nothing running, switching profiles changes
+nothing perceptible.
+
+**So this driver does not publish `profileCount`/`activeProfile`/
+`setProfile`.** That contract is for onboard profiles — a device that holds
+configurations itself — and claiming it here would give the user a selector
+that appears to work and does nothing. OpenMouse's Profiles tab correctly
+reports profiles as unavailable for this mouse.
+
+See `captures/incott-8k-wireless/profile-index-2026-09-11.hex`.
 
 Neither command is implemented here — both are transcriptions, unverified on
 hardware. See

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -403,17 +403,56 @@ tool's own `09 86 09` query (payload still unexplained). It is now
 `INCOTT_CMD_QUERY_BUTTON`; `INCOTT_CMD_SET_BUTTON` (`0x06`) is the matching
 write.
 
-**This driver implements the codec ONLY** — `incottEncodeSetButtonBinding` /
-`incottDecodeButtonBinding` in `src/incott/index.ts` — encode/decode of the
-raw three-byte binding, plus a read for each of the six buttons. It
-deliberately does **not** attempt to model key codes, macros, or remapping
-semantics: the meaning of the three bytes is not established (button 5's
-payload shape, `07 00 03`, visibly differs from the other five's `01 00 fN`,
-suggesting it is a different *kind* of action — plausibly the DPI button —
-but this is an inference, not something the capture decodes), and
-OpenMouse's shared `MouseStatus` button-mapping contract
-(`buttonMappings`/`buttonOptions`) has its own shape this driver must not
-guess at. **Nothing here is wired into `IncottHidClient` or the UI.**
+### Buttons: DECODED and shipped (2026-09-10)
+
+The binding is a **32-bit little-endian action word**, not three opaque
+bytes, and the capture above turns out to confirm the entire mouse action
+table. The inference recorded here — that button 5's odd `07 00 03` shape
+meant a different *kind* of action, plausibly DPI — was right: it is
+`0x00030007`, which the vendor's encoder returns for its DPI-cycle function.
+
+| Wire index | Bytes | Word | Action |
+| --- | --- | --- | --- |
+| 0 | `01 00 f0` | `0x00F00001` | Left click |
+| 1 | `01 00 f1` | `0x00F10001` | Right click |
+| 2 | `01 00 f2` | `0x00F20001` | Middle click |
+| 3 | `01 00 f3` | `0x00F30001` | **Back** |
+| 4 | `01 00 f4` | `0x00F40001` | **Forward** |
+| 5 | `07 00 03` | `0x00030007` | DPI cycle |
+
+**A BUG this exposed.** `incottDecodeButtonBinding` read only response bytes
+3-5 and dropped the fourth, so any action above 24 bits decoded to a value
+that was never written — "Rapid fire" (`0x0218F00A`) came back as
+`0x0018F00A`. The vendor reads all four
+(`rData[5]<<24|rData[4]<<16|rData[3]<<8|rData[2]`). Fixed, with a regression
+test.
+
+**THE WIRE INDEX IS NOT THE DISPLAY POSITION.** Note rows 3 and 4 above:
+index 3 answers `0xF3` (back) and index 4 answers `0xF4` (forward). The
+vendor addresses buttons through an explicit `matrix` field in its per-model
+key table (`setMsK(dvar.key[i].matrix, code)`), and on this family Forward
+and Back are transposed; every other button's matrix equals its position.
+Using the array position silently remaps the wrong button — and looks like
+it worked. `INCOTT_BUTTON_WIRE_INDEX` encodes this, with a test pinning it.
+
+The rest of the action table (media keys, rapid fire, profile switch,
+disable) is transcribed from the vendor's `kf_hw()` encoder; see
+`INCOTT_BUTTON_ACTIONS`. Remapping was exercised end to end on hardware by
+the device owner on 2026-09-10 and behaves correctly.
+
+**Now wired into `IncottHidClient`**: `readStatus` publishes
+`buttonMappings`/`buttonOptions` and `setButtonMapping(button, action)`
+writes with a verified read-back, so OpenMouse's shared remapper renders
+with no app-side change. All six bindings are read or none are published —
+a partial read would show fabricated defaults, and the shared UI writes back
+what it displays. A binding outside the table reports as `Unknown (0x...)`
+for the same reason.
+
+**Deliberately NOT offered:** keyboard bindings, which are parametric rather
+than a fixed list (`(keycode & 255) << 16 | (modifiers & 255) << 8`, or
+`(keycode & 255) << 8 | 128` with no modifier) and cannot be expressed in the
+flat `buttonOptions` contract; and macros (`slot << 16 | 9`), which need the
+`0x07` upload command.
 
 ### Battery (2026-09-07, DISPROVEN 2026-09-08 — see the top of this document)
 
@@ -736,16 +775,6 @@ capture session has resolved. **Do not resolve these by guessing.**
   given write. **Left unchanged pending a hardware check**: set 0.7 mm in the
   vendor tool, then read `0x84`/`0x01` (or the packed form) and see which
   value comes back.
-- **Button payload semantics — encoding now transcribed, still unverified.**
-  The three bytes `incottDecodeButtonBinding` returns (`b0`/`b1`/`b2`) remain
-  deliberately unnamed here. The vendor's bundle assembles a binding as a
-  32-bit little-endian word (`[6, index, k1, k2, k3, k4, 0, 0]`, read back at
-  frame bytes 3-6), and its semantic tables are known — categories
-  `fMouse=1, fKeyboard=2, fMedia=3, fJuji=4, fAdv=5, fCmd=6`. What is NOT
-  established is how a category/function pair maps into that word: the one
-  observed sample (`1,12` -> `07 00 03`) does not fall out of the obvious
-  packings. Needs a hardware check: bind one button to a series of known
-  functions and capture each.
 - **The remaining `0x8f` identity bytes.** Bytes 2-6 are decoded (model,
   receiver, sensor — see the model-identification section at the end of this
   document). Bytes 7-8 (`00 ff` on this device) are still unknown; a firmware
@@ -761,6 +790,9 @@ capture session has resolved. **Do not resolve these by guessing.**
 
 Resolved since this list was written (kept for the record):
 
+- ~~**Button payload semantics.**~~ A 32-bit little-endian action word; the
+  six factory bindings confirm the mouse rows against hardware. See
+  "Buttons: DECODED and shipped".
 - ~~**Which sensor is fitted.**~~ Byte 6 of the identity reply: `0xF0` =
   PAW3395, `0xF1` = PAW3950.
 - ~~**What `0x86` sub `0x09` means.**~~ The onboard profile index.
@@ -920,13 +952,10 @@ Two independent confirmations:
 
 ### Leads recovered from the same source, not yet implemented
 
-These are transcriptions, unverified against hardware:
+Buttons came from this source and are now **implemented and hardware-
+confirmed** — see "Buttons: DECODED and shipped" above. The rest are still
+transcriptions, unverified against hardware:
 
-- **Buttons** — read `0x86` sub = button index, value is a 32-bit
-  little-endian word at frame bytes 3-6 (`rData[5]<<24|rData[4]<<16|
-  rData[3]<<8|rData[2]`). Write is `0x06`:
-  `[6, index, k1, k2, k3, k4, 0, 0]`. This is the wire encoding the button
-  work was blocked on.
 - **Independent X/Y DPI** — one write per axis, distinguished by a flag at
   byte 7: `[2, ix, dpiLo, dpiHi, 0, 0, 0, flag]` with flag `0` when X == Y,
   then `1` for X and `2` for Y. There is no per-axis read, which is why a Y

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -812,8 +812,9 @@ Resolved since this list was written (kept for the record):
 - ~~**Button payload semantics.**~~ A 32-bit little-endian action word; the
   six factory bindings confirm the mouse rows against hardware. See
   "Buttons: DECODED and shipped".
-- ~~**Which sensor is fitted.**~~ Byte 6 of the identity reply: `0xF0` =
-  PAW3395, `0xF1` = PAW3950.
+- ~~**Which sensor is fitted.**~~ PAW3950, settled twice over: the identity
+  reply carries `0xF1` in a sensor slot, and the mouse stored 45000 DPI over
+  the cable, which a PAW3395 cannot do.
 - ~~**What `0x86` sub `0x09` means.**~~ The onboard profile index.
 - ~~**The `09 06 09 <00|01>` write.**~~ The profile-index write, not a
   left/right invert toggle — see the correction under "Onboard profiles".
@@ -921,28 +922,57 @@ The sensor decides the "Pro" suffix: the vendor appends `Pro` when the sensor
 is `0x3950`, which is how `G23V2Pro` appears for a device whose HID product
 string only ever says `incott 8K wireless mouse`.
 
-### The one inference, and how to falsify it
+### The sensor slot moves with the receiver — corrected 2026-09-11
 
-Bytes 5 and 6 **disagree on this device** (`f0 f1`), and the vendor picks
-between them by connection (`let i = this.iswireless ? 5 : 4`). Read as
-hardware identity that is a contradiction — a mouse does not change sensors
-when a cable goes in — so the vendor's own tool necessarily labels this one
-physical mouse `G23V2Pro` on the dongle and `G23V2` on the cable.
+This section previously argued that bytes 5 and 6 were per-link *capability*
+profiles, that the vendor's connection-dependent index was a cosmetic bug
+because it renamed one physical mouse when a cable went in, and that reading
+byte 6 unconditionally was the better answer. **That was wrong**, and a
+cable-only capture disproved it:
 
-Read as a per-link **capability** profile it is consistent: the value feeds
-`getStDPI(sensor)`, which selects a DPI ceiling (PAW3395 -> 32000,
-PAW3950 -> 45000), and the cable is already the reduced-capability path on
-this device, capping polling at 1000 Hz.
+```
+cable + dongle (2026-09-08):  09 8f 01 0e 02 f0 f1 00 ff
+cable only     (2026-09-11):  09 8f 01 0e 00 f1 00 00 00
+                                         ^^ ^^ ^^
+                                         |  |  +-- byte 6
+                                         |  +----- byte 5
+                                         +-------- byte 4, receiver type
+```
 
-`incottDecodeIdentity` therefore reads the fitted sensor from **byte 6**
-unconditionally, so the decoded name is stable across connections. This is
-the only inference in that decoder rather than a transcription.
+The frame is not fixed. With the dongle present, byte 4 reports the receiver
+and the `0xF1` sits at byte 6; with the dongle gone, byte 4 is `0x00` and the
+same `0xF1` moves to byte 5. The vendor indexing by connection is therefore
+**correct behaviour**, not a bug — and reading byte 6 unconditionally reported
+a PAW3395 on a cable-only connection, dropping the "Pro" from the model name.
 
-**To falsify it:** connect the mouse by cable and read what the vendor tool
-displays. If it shows `G23V2Pro` while wired, byte 5 is not a wired
-capability profile and this reading is wrong. A per-link DPI ceiling is
-deliberately NOT implemented — nothing has confirmed the cable caps DPI at
-32000.
+The earlier reasoning had only one wired capture to go on, and that capture
+had been taken with the dongle still in the port, so it looked identical to
+the wireless one. "The frame is the same either way" was an artifact of the
+test setup, not a property of the device.
+
+**What the decoder does now:** reports the PAW3950 when EITHER slot carries
+`0xF1`. The fitted sensor is settled independently of this frame — see the
+DPI ceiling below — so the answer is whichever slot the current configuration
+happens to put it in. The vendor's index disagrees in exactly one case, cable
+AND dongle attached, where it reads byte 5's `0xF0`; that is the one
+configuration where a per-link byte cannot be describing this mouse.
+
+### There is no wired DPI ceiling (2026-09-11)
+
+`tools/hid-probes/dpi-ceiling.mjs` walked a ladder straddling the vendor's
+32000 limit on a cable-only connection. Every value was stored and read back
+exactly:
+
+```
+30000 ACCEPTED   32000 ACCEPTED   32050 ACCEPTED
+35000 ACCEPTED   40000 ACCEPTED   45000 ACCEPTED
+```
+
+So `INCOTT_DPI_MAX` stays flat at 45000 across both links — unlike the
+polling rate, which genuinely is capped at 1000 Hz over the cable. The
+vendor's PAW3395 table stopping at 32000 is a UI list, not a firmware limit,
+and this also settles which sensor is fitted: a PAW3395 could not have stored
+45000.
 
 ### What this replaces
 

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -1073,3 +1073,63 @@ been driven to make one.
 This also settles the count reading itself by a second route: a device that
 rotates through exactly three stages after being told `09 03 03 <idx>` is
 reading that byte as a cycle length, not echoing a sub-command.
+
+## Macros: format recovered, transport NOT (2026-09-11)
+
+The 320-byte macro buffer is fully transcribed from the vendor bundle's
+`juji_to_hw()` and encoded by `incottEncodeMacroBuffer`:
+
+```
+[0]        buffer id (0-9)
+[1]        loop mode  0 until key release, 1 until any key, 2 cycle
+[2..3]     cycle count, LE16
+[4+4n]     event flags: bit 0 always set, bit 7 set for a RELEASE
+[5+4n]     HID keyboard usage code
+[6..7+4n]  delay after the event, LE16 ms
+[288..293] ASCII "Macro" then '1' + buffer id
+[304..307] (steps + 1) * 132, LE32
+[308..311] 16, 0, 232, 232 — constant in every buffer the vendor builds
+[312..315] uid, LE32
+[316..317] steps * 2, LE16
+[318]      step count
+```
+
+Steps occupy bytes 4..287 at four bytes each, so 71 fit. The upload sends the
+buffer as ten 32-byte chunks, each announced by an ordinary 8-byte command
+(`09 07 0a <chunk> 20 <buffer id>`, `incottEncodeMacroChunkHeader`).
+
+**Nothing sends it, and this is why.** The call that carries each 32-byte
+chunk is `document.elsDevice` in the vendor bundle, and that function is
+**never defined in any file the page loads** — the eight scripts under
+`incott.net/mouse/js/` plus `js/lib/savepro.js` were all downloaded and
+searched. It cannot be recovered by reading further, either: no
+`sendFeatureReport` or `receiveFeatureReport` appears literally anywhere in
+the bundle, because the method names are resolved through variables at
+runtime (the same indirection that made `navigator.hid[mymethod1]` out of
+`requestDevice`).
+
+It is also not the ordinary path. Every command in this protocol is an 8-byte
+feature report on id `0x09`, which a 32-byte chunk does not fit. A read-only
+sweep of the other vendor collections on 2026-09-11 found the `0xFF00`
+collection answering no feature read at all, and the dead `0xFF05` collection
+answering none either (which independently re-confirms the two-collection
+finding above).
+
+**What would settle it:** instrument the vendor tool while it saves a macro,
+the way `vendor-tool-session.hex` was captured. That shows the transport
+directly instead of inferring it.
+
+Also worth noting, since it is a trap for anyone implementing this from the
+vendor's code: its own uploader slices `mda.slice(i * 32, i * 64)`, which
+yields an EMPTY chunk for `i = 0` and over-long ones afterwards. That is a bug
+in the vendor's uploader; `incottMacroChunks` does not reproduce it.
+
+### Why there is no UI for this either
+
+Independently of the transport, `MouseStatus` in `src/drivers/mouse-types.ts`
+has no macro field, so there is nowhere to publish macros even once they can
+be written. Upstream has deliberately deferred this elsewhere — the ATK card
+states that "assignment writes, shortcuts, and macros remain locked pending
+reversible validation", and Logitech's macro encoders are driver-internal
+rather than part of the shared contract. A macro contract shape is a question
+for the maintainers, not something to guess at.

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -448,11 +448,23 @@ a partial read would show fabricated defaults, and the shared UI writes back
 what it displays. A binding outside the table reports as `Unknown (0x...)`
 for the same reason.
 
-**Deliberately NOT offered:** keyboard bindings, which are parametric rather
-than a fixed list (`(keycode & 255) << 16 | (modifiers & 255) << 8`, or
-`(keycode & 255) << 8 | 128` with no modifier) and cannot be expressed in the
-flat `buttonOptions` contract; and macros (`slot << 16 | 9`), which need the
-`0x07` upload command.
+**Keyboard bindings ARE offered** (added 2026-09-11). The encoding is
+parametric — any of 256 keycodes against any of 256 modifier masks — and the
+two forms differ in shape, not just in a modifier value:
+
+    no modifier:   (keycode & 255) << 8  | 128
+    with modifier: (keycode & 255) << 16 | (modifiers & 255) << 8
+
+An unmodified key sets the `0x80` marker in the low byte and sits one byte
+lower than a chord does. The flat `buttonOptions` contract cannot express the
+whole space, so the table enumerates a curated set — letters, digits, F-keys,
+navigation and editing keys, the eight modifiers, and ~24 common chords — the
+same approach `src/mchose/buttons.ts` already takes in this repo. 127 actions
+in total. This was initially recorded as impossible to offer; that was wrong,
+and the MCHOSE driver was the counter-example sitting in the same tree.
+
+**Still NOT offered:** macros (`slot << 16 | 9`), which need the `0x07`
+upload command.
 
 ### Battery (2026-09-07, DISPROVEN 2026-09-08 — see the top of this document)
 

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -1123,31 +1123,48 @@ Steps occupy bytes 4..287 at four bytes each, so 71 fit. The upload sends the
 buffer as ten 32-byte chunks, each announced by an ordinary 8-byte command
 (`09 07 0a <chunk> 20 <buffer id>`, `incottEncodeMacroChunkHeader`).
 
-**Nothing sends it, and this is why.** The call that carries each 32-byte
-chunk is `document.elsDevice` in the vendor bundle, and that function is
-**never defined in any file the page loads** — the eight scripts under
-`incott.net/mouse/js/` plus `js/lib/savepro.js` were all downloaded and
-searched. It cannot be recovered by reading further, either: no
-`sendFeatureReport` or `receiveFeatureReport` appears literally anywhere in
-the bundle, because the method names are resolved through variables at
-runtime (the same indirection that made `navigator.hid[mymethod1]` out of
-`requestDevice`).
+**The transport is a 32-byte OUTPUT report on report id `0x09`** — captured
+2026-09-11 and implemented as `IncottHidClient.uploadMacro`. Nothing else in
+this protocol uses an output report, which is exactly why reading the bundle
+could not find it: `document.elsDevice` is defined in none of the shipped
+files, and the HID method names resolve through variables at runtime, so the
+string `sendFeatureReport` never appears literally anywhere in it.
 
-It is also not the ordinary path. Every command in this protocol is an 8-byte
-feature report on id `0x09`, which a 32-byte chunk does not fit. A read-only
-sweep of the other vendor collections on 2026-09-11 found the `0xFF00`
-collection answering no feature read at all, and the dead `0xFF05` collection
-answering none either (which independently re-confirms the two-collection
-finding above).
+Hooking `sendReport` in the browser showed it immediately. The connect log
+also reported something node-hid enumeration cannot see:
 
-**What would settle it:** instrument the vendor tool while it saves a macro,
-the way `vendor-tool-session.hex` was captured. That shows the transport
-directly instead of inferring it.
+```
+page 0xff05  feature: 0x9  output: 0x9
+```
 
-Also worth noting, since it is a trap for anyone implementing this from the
-vendor's code: its own uploader slices `mda.slice(i * 32, i * 64)`, which
-yields an EMPTY chunk for `i = 0` and over-long ones afterwards. That is a bug
-in the vendor's uploader; `incottMacroChunks` does not reproduce it.
+One collection, both report kinds on the same id. See
+`tools/hid-probes/vendor-macro-capture.js` in IncottHub for the
+instrumentation, and `captures/incott-8k-wireless/macro-upload-2026-09-11.hex`
+for the capture and its decode.
+
+There is no macro READ command, so `uploadMacro` is the one writer in this
+driver with nothing to verify against. Binding a button to `Macro <n>` and
+pressing it is the only confirmation available.
+
+### The correction this forced
+
+The size field at `[304..307]` had been transcribed as `(steps + 1) * 132`.
+It is `(steps + 1) * 4 + 128` — 164 for the captured 8-step macro, where the
+old formula would have written 1188. **The deobfuscation pass used to recover
+the vendor's source folded the constant `4 + 128` into `132` before anyone
+read it**, so this was a bug on this side rather than anything the vendor
+does. Every macro this driver built would have carried a wrong size, and
+re-reading the transcription could never have caught it — only a real buffer
+did. The encoder is now pinned byte-for-byte to that capture.
+
+### Also confirmed: macro button bindings
+
+The capture ended with `06 04 09 00 03 00`, binding wire button 4 to
+`0x00030009` — the `fJuji` encoding `slot << 16 | 9`.
+`incottButtonActionLabel` now names these (`Macro 4`) instead of reporting
+raw hex. `incottButtonActionCode` deliberately does NOT reverse them: nothing
+can assign a macro until there is a UI to author one, so an existing macro
+binding reads back correctly and is left alone.
 
 ### Why there is no UI for this either
 

--- a/docs/incott-testing.md
+++ b/docs/incott-testing.md
@@ -798,17 +798,11 @@ capture session has resolved. **Do not resolve these by guessing.**
   receiver, sensor — see the model-identification section at the end of this
   document). Bytes 7-8 (`00 ff` on this device) are still unknown; a firmware
   version is the obvious candidate but nothing confirms it.
-- **DPI per-axis read — probably does not exist.** The 2026-09-10 capture
-  found a write-side axis byte (payload index 7: 0 = both, 1 = X, 2 = Y) but
-  no per-axis READ: probing `0x82` with the axis byte set to 0, 1 and 2
-  returned the identical value every time. The vendor's own code matches
-  this — `setResolution` sends two writes distinguished by that flag and has
-  no per-axis read at all, so its UI must track X and Y host-side. Without a
-  read to verify a Y-only write against, this driver still does not implement
-  independent X/Y DPI.
-
 Resolved since this list was written (kept for the record):
 
+- ~~**DPI per-axis read.**~~ It exists: `09 82 <stage> <axis>`, echoed at
+  reply byte 8. The earlier probe saw one value for all three axes because X
+  and Y were both at the factory 1600 — see "Independent X/Y DPI" below.
 - ~~**Button payload semantics.**~~ A 32-bit little-endian action word; the
   six factory bindings confirm the mouse rows against hardware. See
   "Buttons: DECODED and shipped".
@@ -1193,3 +1187,68 @@ Nothing else in `0x00`-`0x0f` answers. `01 0e` is suggestive — those are the
 same two values the identity reply carries at bytes 2 and 3 (guard `0x01`,
 model code `0x0E`) — but the vendor bundle never queries `0x85`/`0x07` at
 all, so there is no caller to name it. Recorded, not guessed at.
+
+## Independent X/Y DPI: the per-axis read DOES exist (2026-09-11)
+
+This document previously recorded, under "Unresolved unknowns", that probing
+`0x82` with the axis byte set to 0, 1 and 2 "returned the identical value
+every time", and concluded there was no per-axis read — so a Y-only write
+could never be verified and independent axes were left unimplemented.
+
+**That conclusion was wrong, and the probe that produced it could not have
+shown anything else**: X and Y were both sitting at the factory 1600 at the
+time. Three identical readings are exactly what a working per-axis read
+returns when the two axes match. The test could not distinguish "no per-axis
+read" from "per-axis read whose axes happen to agree" — the same shape of
+mistake as the battery byte that matched once by coincidence.
+
+Setting the axes apart first settles it immediately:
+
+```
+09 82 02 01  ->  09 82 02 07 00 00 00 00 01     X = 400
+09 82 02 02  ->  09 82 02 3f 00 00 00 00 02     Y = 3200
+```
+
+### The wire format
+
+```
+write:  09 02 <stage> <lo> <hi> 00 00 <axis>     axis 0 both, 1 X, 2 Y
+read:   09 82 <stage> <axis>                     axis at REQUEST byte 3
+reply:  09 82 <stage> <lo> <hi> 00 00 00 <axis>  axis echoed at byte 8
+```
+
+**Hardware-confirmed 2026-09-11** on stage 3, writing and reading back three
+independent pairs before restoring:
+
+```
+wrote X= 800 Y=1600  ->  reads X= 800 Y=1600   OK
+wrote X=2400 Y= 400  ->  reads X=2400 Y= 400   OK
+wrote X=1000 Y=1000  ->  reads X=1000 Y=1000   OK
+```
+
+### The axis echo is load-bearing
+
+Reading X and then Y on the same stage sends two requests whose command AND
+sub-command are identical. The device latches one shared response buffer, so
+without matching the echo at byte 8 the second read is satisfied by the
+first's frame and both axes report the same number — reproducing the exact
+false reading that closed this question the first time.
+`incottFrameMatches` takes an optional axis for this, and
+`IncottTransactionQueue.request` passes it through.
+
+### What ships
+
+`setDpiStageAxis(stage, dpi, axis)` and `readDpiStageAxis(stage, axis)` on the
+client, and `readStatus` publishes `dpiY` for the active stage. That last one
+works with no app-side change: `MouseStatus.dpiY` already exists and the DPI
+card's summary line and the Diagnostics panel already render "X n · Y n DPI"
+from it. `dpiY` is OMITTED, not mirrored from X, when the axis read fails —
+the app then shows a single number rather than claiming the axes match.
+
+**The write UI is not generic yet.** `AxisControls` in `DpiCard.tsx` is
+`id="logitech-axis-controls"` and calls `applyLogitechAxisDpi`, which
+early-returns unless the client is a Logitech one. Generalising it is a small
+change of the same shape as `applyDeviceButtonMapping` — dispatch through
+`requireClientMethod` instead of a brand check — but it is an upstream call,
+so it is a question for the maintainers rather than something to change
+unilaterally.

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -182,6 +182,9 @@ function defaultState() {
     debounceMs: 4,
     sleepSeconds: 60,
     receiverLed: 0,
+    // Read from hardware 2026-09-11: 09 85 02 03 0a.
+    fireKeyTimes: 3,
+    fireKeyIntervalMs: 10,
     batteryByte: 0x38 as number | null, // 56%, captured 2026-09-07
     identity: [0x01, 0x0e, 0x02, 0xf0, 0xf1, 0x00, 0xff] as number[] | null,
     // The factory bindings read from hardware 2026-09-08, by WIRE index.
@@ -266,6 +269,7 @@ function fakeDevice(options: FakeOptions = {}) {
         return null;
       case 0x85:
         if (sub === 0x01) return frame(0x85, 0x01, state.debounceMs);
+        if (sub === 0x02) return frame(0x85, 0x02, state.fireKeyTimes, state.fireKeyIntervalMs);
         if (sub === 0x03) return frame(0x85, 0x03, state.sleepSeconds & 0xff, (state.sleepSeconds >> 8) & 0xff);
         return null;
       case 0x86: {
@@ -317,6 +321,7 @@ function fakeDevice(options: FakeOptions = {}) {
     else if (cmd === 0x04 && sub === 0x04) state.motionSync = value;
     else if (cmd === 0x04 && sub === 0x05) state.performanceMode = value;
     else if (cmd === 0x05 && sub === 0x01) state.debounceMs = value;
+    else if (cmd === 0x05 && sub === 0x02) { state.fireKeyTimes = value; state.fireKeyIntervalMs = payload[3] ?? 0; }
     else if (cmd === 0x05 && sub === 0x03) state.sleepSeconds = value | ((payload[3] ?? 0) << 8);
     else if (cmd === 0x08) state.receiverLed = sub; // no sub-command: mode sits at byte 1
     // cmd 0x06: `sub` is the button WIRE index, then the 32-bit action.
@@ -1302,4 +1307,30 @@ test("REGRESSION: battery is not read from the 0x8e/0x01 feature-report reply, e
   assert.notEqual(status.batteryPercent, 56);
   assert.equal(status.batteryPercent, null);
   assert.equal(status.batteryState, "Unknown");
+});
+
+test("getFireKey reads the rapid-fire parameters", async () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.deepEqual(await client.getFireKey(), { times: 3, intervalMs: 10 });
+});
+
+test("setFireKey writes both parameters and verifies the read-back", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.deepEqual(await client.setFireKey(2, 50), { times: 2, intervalMs: 50 });
+  assert.deepEqual([state.fireKeyTimes, state.fireKeyIntervalMs], [2, 50]);
+});
+
+test("setFireKey throws when the mouse does not take the value", async () => {
+  const { device } = fakeDevice({ ignoreWrites: true });
+  await assert.rejects(() => new IncottHidClient(device, fast).setFireKey(1, 20), /instead of 1 at 20 ms/);
+});
+
+test("setFireKey rejects out-of-range values without writing", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await assert.rejects(() => client.setFireKey(4, 10), RangeError);
+  await assert.rejects(() => client.setFireKey(3, 300), RangeError);
+  assert.deepEqual([state.fireKeyTimes, state.fireKeyIntervalMs], [3, 10]);
 });

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -1417,3 +1417,30 @@ test("readStatus omits both rather than guessing when the queries fail", async (
   assert.equal(status.incottFireKeyTimes, undefined);
   assert.equal(status.incottFireKeyIntervalMs, undefined);
 });
+
+test("setFireKey accepts 0 times, which is hold-to-fire rather than no fire", async () => {
+  // Confirmed against the vendor software 2026-09-11: 0 makes the button
+  // fire continuously while held and stop on release.
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  assert.deepEqual(await client.setFireKey(0, 25), { times: 0, intervalMs: 25 });
+  assert.equal(state.fireKeyTimes, 0);
+});
+
+test("setAxisDpi writes both axes of the active stage", async () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.setAxisDpi(800, 3200);
+  // Stage 1 is the active one in the default fake state.
+  assert.equal(await client.readDpiStageAxis(1, "x"), 800);
+  assert.equal(await client.readDpiStageAxis(1, "y"), 3200);
+});
+
+test("setAxisDpi sends a single linked write when the axes match", async () => {
+  const { device, sent } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.setAxisDpi(1600, 1600);
+  const dpiWrites = sent.filter((payload) => payload[0] === 0x02);
+  assert.equal(dpiWrites.length, 1, "one write, not one per axis");
+  assert.equal(dpiWrites[0]![7], 0, "the 'both' axis flag");
+});

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -729,10 +729,17 @@ test("readStatus hides the remapper entirely when a button read fails", async ()
 });
 
 test("readStatus reports an unrecognised binding as a raw code, not as a known action", async () => {
-  // A keyboard binding ('A', no modifier) is not in the action table.
-  const { device } = fakeDevice({ state: { buttons: [0x00000480, 0x00f10001, 0x00f20001, 0x00f30001, 0x00f40001, 0x00030007] } });
+  // A macro binding (`slot << 16 | 9`) — macros need the 0x07 upload command
+  // and are deliberately absent from the action table.
+  const { device } = fakeDevice({ state: { buttons: [0x00010009, 0x00f10001, 0x00f20001, 0x00f30001, 0x00f40001, 0x00030007] } });
   const status = await new IncottHidClient(device, fast).readStatus();
-  assert.equal(status.buttonMappings?.Left, "Unknown (0x00000480)");
+  assert.equal(status.buttonMappings?.Left, "Unknown (0x00010009)");
+});
+
+test("readStatus labels a keyboard binding read back from the mouse", async () => {
+  const { device } = fakeDevice({ state: { buttons: [0x00f00001, 0x00f10001, 0x00060100, 0x00f30001, 0x00f40001, 0x00030007] } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.buttonMappings?.Middle, "Ctrl + C");
 });
 
 test("setButtonMapping writes the action and verifies the read-back", async () => {

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -171,6 +171,9 @@ function defaultState() {
     // the exact values verified on hardware 2026-09-08. Stage 1 (800 DPI) is
     // active by default.
     dpiStagesWire: [7, 15, 31, 47, 63, 127],
+    // Y starts equal to X, as the factory table has it. That equality is
+    // exactly what hid the per-axis read from an earlier probe.
+    dpiStagesWireY: [7, 15, 31, 47, 63, 127],
     activeDpiStage: 1, // 0x83 response byte 3.
     dpiStageCount: 6, // 0x83 response byte 2 — the cycle length, not an echo.
     pollingWire: 0, // 1000 Hz
@@ -243,10 +246,14 @@ function fakeDevice(options: FakeOptions = {}) {
       case 0x81:
         return frame(0x81, state.pollingWire);
       case 0x82: {
-        // Per-stage DPI value read, little-endian at bytes 3-4. See
-        // incottDecodeDpiStage.
-        const wire = state.dpiStagesWire[sub];
-        return wire === undefined ? null : frame(0x82, sub, wire & 0xff, (wire >> 8) & 0xff);
+        // Per-stage DPI value read, little-endian at bytes 3-4. Request byte
+        // 2 selects the axis (0 both/X, 1 X, 2 Y) and the reply echoes it at
+        // byte 8 — see incottEncodeQueryDpiAxis.
+        const axis = payload[2] ?? 0;
+        const table = axis === 2 ? state.dpiStagesWireY : state.dpiStagesWire;
+        const wire = table[sub];
+        if (wire === undefined) return null;
+        return frame(0x82, sub, wire & 0xff, (wire >> 8) & 0xff, 0, 0, 0, axis);
       }
       case 0x83:
         // The DPI cycle: byte 2 the stage COUNT, byte 3 the active index.
@@ -303,7 +310,11 @@ function fakeDevice(options: FakeOptions = {}) {
     // cmd 0x02: `sub` here is a DPI STAGE INDEX (0-5), not a fixed
     // sub-command — the bug this driver used to have. See incottEncodeSetDpi.
     if (cmd === 0x02 && sub >= 0 && sub < state.dpiStagesWire.length) {
-      state.dpiStagesWire[sub] = value | ((payload[3] ?? 0) << 8);
+      // Payload byte 7 is the axis: 0 writes both, 1 X only, 2 Y only.
+      const wire = value | ((payload[3] ?? 0) << 8);
+      const axis = payload[7] ?? 0;
+      if (axis !== 2) state.dpiStagesWire[sub] = wire;
+      if (axis !== 1) state.dpiStagesWireY[sub] = wire;
     }
     // cmd 0x03: writes the CYCLE — byte 1 the stage count, byte 2 the active
     // index. Must never touch dpiStagesWire: this is the operation
@@ -1333,4 +1344,48 @@ test("setFireKey rejects out-of-range values without writing", async () => {
   await assert.rejects(() => client.setFireKey(4, 10), RangeError);
   await assert.rejects(() => client.setFireKey(3, 300), RangeError);
   assert.deepEqual([state.fireKeyTimes, state.fireKeyIntervalMs], [3, 10]);
+});
+
+test("readStatus publishes dpiY for the active stage", async () => {
+  // Stage 1 is active; give its axes different values.
+  const { device } = fakeDevice({ state: { dpiStagesWireY: [7, 31, 31, 47, 63, 127] } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.dpi, 800, "X");
+  assert.equal(status.dpiY, 1600, "Y");
+});
+
+test("readStatus omits dpiY rather than mirroring X when the axis read fails", async () => {
+  // Claiming the axes match would be a fabricated reading; the app falls
+  // back to showing a single number instead.
+  const { device } = fakeDevice({ silent: [0x82] });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.dpiY, undefined);
+});
+
+test("setDpiStageAxis writes one axis and leaves the other alone", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.setDpiStageAxis(2, 3200, "y");
+  assert.equal(await client.readDpiStageAxis(2, "y"), 3200);
+  assert.equal(await client.readDpiStageAxis(2, "x"), 1600, "X untouched");
+  assert.equal(state.dpiStagesWire[2], 31, "the X table did not move");
+});
+
+test("setDpiStageAxis with 'both' moves the two axes together", async () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.setDpiStageAxis(4, 400, "both");
+  assert.equal(await client.readDpiStageAxis(4, "x"), 400);
+  assert.equal(await client.readDpiStageAxis(4, "y"), 400);
+});
+
+test("REGRESSION: reading X then Y on one stage does not return X twice", async () => {
+  // The two requests carry an identical command and sub-command, so without
+  // matching the axis echo at byte 8 the second read is satisfied by the
+  // first's latched frame — the reading that made this driver conclude no
+  // per-axis read existed.
+  const { device } = fakeDevice({ state: { dpiStagesWireY: [7, 15, 63, 47, 63, 127] } });
+  const client = new IncottHidClient(device, fast);
+  assert.equal(await client.readDpiStageAxis(2, "x"), 1600);
+  assert.equal(await client.readDpiStageAxis(2, "y"), 3200);
 });

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -1352,6 +1352,8 @@ test("readStatus publishes dpiY for the active stage", async () => {
   const status = await new IncottHidClient(device, fast).readStatus();
   assert.equal(status.dpi, 800, "X");
   assert.equal(status.dpiY, 1600, "Y");
+  // The capability flag the shared UI gates the X/Y display on.
+  assert.equal(status.supportsSeparateDpiAxes, true);
 });
 
 test("readStatus omits dpiY rather than mirroring X when the axis read fails", async () => {
@@ -1360,6 +1362,7 @@ test("readStatus omits dpiY rather than mirroring X when the axis read fails", a
   const { device } = fakeDevice({ silent: [0x82] });
   const status = await new IncottHidClient(device, fast).readStatus();
   assert.equal(status.dpiY, undefined);
+  assert.equal(status.supportsSeparateDpiAxes, undefined, "no axes claimed without a reading");
 });
 
 test("setDpiStageAxis writes one axis and leaves the other alone", async () => {

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -1492,3 +1492,20 @@ test("uploadMacro fails clearly on a transport with no output-report support", a
     /cannot send output reports/,
   );
 });
+
+test("readStatus offers a PAW3395 model only the DPI its sensor reaches", async () => {
+  // A Ghero or any other PAW3395 unit in this family: the vendor's table
+  // stops at 32000 there, and advertising 45000 would offer DPI the mouse
+  // may silently refuse.
+  const { device } = fakeDevice({ state: { identity: [0x01, 0x01, 0x02, 0xf0, 0xf0, 0x00, 0xff] } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.name, "Ghero", "model code 0x01");
+  assert.equal(status.ui?.dpiStageEditor?.maxDpi, 32000);
+});
+
+test("readStatus keeps the full ceiling when identity cannot be read", async () => {
+  // Narrowing on a guess would hide DPI the mouse can actually reach.
+  const { device } = fakeDevice({ state: { identity: null } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.ui?.dpiStageEditor?.maxDpi, 45000);
+});

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -171,7 +171,8 @@ function defaultState() {
     // the exact values verified on hardware 2026-09-08. Stage 1 (800 DPI) is
     // active by default.
     dpiStagesWire: [7, 15, 31, 47, 63, 127],
-    activeDpiStage: 1, // 0x83/0x06's answer.
+    activeDpiStage: 1, // 0x83 response byte 3.
+    dpiStageCount: 6, // 0x83 response byte 2 — the cycle length, not an echo.
     pollingWire: 0, // 1000 Hz
     lodWire: 0, // 10 tenths mm -> Medium
     motionSync: 1,
@@ -245,8 +246,12 @@ function fakeDevice(options: FakeOptions = {}) {
         return wire === undefined ? null : frame(0x82, sub, wire & 0xff, (wire >> 8) & 0xff);
       }
       case 0x83:
-        // Active DPI *stage index* (0-5). See incottDecodeDpiStageIndex.
-        return sub === 0x06 ? frame(0x83, 0x06, state.activeDpiStage) : null;
+        // The DPI cycle: byte 2 the stage COUNT, byte 3 the active index.
+        // Answers whatever sub-command was sent, because byte 2 is data, not
+        // an echo — real hardware answers `09 83 00` with `09 83 06 01`, and
+        // this fake used to answer only sub 0x06, which is what let the
+        // driver's wrong echo assumption pass its tests.
+        return frame(0x83, state.dpiStageCount, state.activeDpiStage);
       case 0x84:
         // sub 0x00 is the legacy packed byte-7 form (still decodable via
         // incottDecodeLiftOff/incottDecodeMotionSync, cross-checked against
@@ -296,10 +301,13 @@ function fakeDevice(options: FakeOptions = {}) {
     if (cmd === 0x02 && sub >= 0 && sub < state.dpiStagesWire.length) {
       state.dpiStagesWire[sub] = value | ((payload[3] ?? 0) << 8);
     }
-    // cmd 0x03/sub 0x06: SELECTS the active stage — must never touch
-    // dpiStagesWire. This is the operation IncottHIDApp mislabels "set DPI"
-    // and the one the driver's setDpi() used to be conflated with.
-    else if (cmd === 0x03 && sub === 0x06 && value >= 0 && value < state.dpiStagesWire.length) {
+    // cmd 0x03: writes the CYCLE — byte 1 the stage count, byte 2 the active
+    // index. Must never touch dpiStagesWire: this is the operation
+    // IncottHIDApp mislabels "set DPI" and the one the driver's setDpi() used
+    // to be conflated with. The count is stored, so a driver that sends a
+    // hardcoded 6 here visibly resizes a shorter cycle.
+    else if (cmd === 0x03 && sub >= 1 && sub <= state.dpiStagesWire.length && value >= 0 && value < sub) {
+      state.dpiStageCount = sub;
       state.activeDpiStage = value;
     }
     else if (cmd === 0x01) state.pollingWire = sub; // no sub-command: wire value sits at byte 1
@@ -498,7 +506,7 @@ test("readStatus decodes every field from the device's current state", async () 
   assert.equal(status.activeDpiStage, 1);
   assert.deepEqual(status.ui?.dpiStageEditor, {
     maxStages: 6,
-    countEditable: false,
+    countEditable: true,
     minDpi: 50,
     maxDpi: 45000,
     stepDpi: 50,
@@ -614,6 +622,83 @@ test("supportedPollingRates offers the full ladder over the wireless connection"
   const status = await new IncottHidClient(device, fast).readStatus();
   assert.deepEqual(status.supportedPollingRates, [125, 250, 500, 1000, 2000, 4000, 8000]);
   assert.equal(status.ui?.pollingNote, "Up to 8,000 Hz wireless; 1,000 Hz over the cable.");
+});
+
+test("readStatus trims the published stage table to the cycle the mouse actually uses", async () => {
+  // The device keeps six stored values regardless; only the first `count` are
+  // in the rotation, and offering the rest would let the user select a stage
+  // the mouse never visits.
+  const { device } = fakeDevice({ state: { dpiStageCount: 4, activeDpiStage: 2 } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.deepEqual(status.dpiStages, [400, 800, 1600, 2400]);
+  assert.equal(status.activeDpiStage, 2);
+  assert.equal(status.dpi, 1600);
+});
+
+test("REGRESSION: a cycle shorter than six still reads, instead of failing the sub-echo match", async () => {
+  // 0x83's byte 2 is the stage count, which the driver used to require to
+  // equal the 0x06 it sent. On a four-stage mouse every DPI read returned
+  // null and the whole settings grid was hidden.
+  const { device } = fakeDevice({ state: { dpiStageCount: 3, activeDpiStage: 0 } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.ui?.settingsReady, true);
+  assert.equal(status.activeDpiStage, 0);
+  assert.deepEqual(status.dpiStages, [400, 800, 1600]);
+});
+
+test("REGRESSION: selecting a stage preserves the cycle length instead of resetting it to six", async () => {
+  // The count shares the write with the index. Sending a hardcoded 0x06 here
+  // silently grew a four-stage cycle back to six every time the user picked a
+  // different DPI stage.
+  const { device, state } = fakeDevice({ state: { dpiStageCount: 4, activeDpiStage: 0 } });
+  await new IncottHidClient(device, fast).setActiveDpiStage(3);
+  assert.equal(state.activeDpiStage, 3);
+  assert.equal(state.dpiStageCount, 4, "the cycle length must survive a stage select");
+});
+
+test("setActiveDpiStage refuses a stage outside the mouse's current cycle", async () => {
+  const { device, state } = fakeDevice({ state: { dpiStageCount: 3, activeDpiStage: 0 } });
+  await assert.rejects(
+    () => new IncottHidClient(device, fast).setActiveDpiStage(4),
+    /outside this mouse's 3-stage cycle/,
+  );
+  assert.equal(state.activeDpiStage, 0, "nothing was written");
+});
+
+test("setDpiStageCount resizes the cycle and leaves every stored DPI value alone", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  const before = [...state.dpiStagesWire];
+  await client.setDpiStageCount(3);
+  assert.equal(state.dpiStageCount, 3);
+  assert.deepEqual(state.dpiStagesWire, before, "stage values are untouched by a resize");
+  const status = await client.readStatus();
+  assert.deepEqual(status.dpiStages, [400, 800, 1600]);
+});
+
+test("setDpiStageCount clamps an active stage that would fall outside the new cycle", async () => {
+  // The active index rides along in the same write, so it cannot be left
+  // pointing past the end of the shortened cycle.
+  const { device, state } = fakeDevice({ state: { activeDpiStage: 5 } });
+  await new IncottHidClient(device, fast).setDpiStageCount(2);
+  assert.equal(state.dpiStageCount, 2);
+  assert.equal(state.activeDpiStage, 1);
+});
+
+test("setDpiStageCount rejects a count outside 1-6 without writing", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await assert.rejects(() => client.setDpiStageCount(0), RangeError);
+  await assert.rejects(() => client.setDpiStageCount(7), RangeError);
+  assert.equal(state.dpiStageCount, 6);
+});
+
+test("the stage-count picker is hidden when the cycle cannot be read", async () => {
+  // setDpiStageCount needs a real current count to preserve the active stage;
+  // offering the control against an unreadable one would write a guess.
+  const { device } = fakeDevice({ silent: [0x83] });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.ui?.dpiStageEditor?.countEditable, false);
 });
 
 test("readStatus publishes the six factory bindings by physical button name", async () => {

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -183,6 +183,10 @@ function defaultState() {
     receiverLed: 0,
     batteryByte: 0x38 as number | null, // 56%, captured 2026-09-07
     identity: [0x01, 0x0e, 0x02, 0xf0, 0xf1, 0x00, 0xff] as number[] | null,
+    // The factory bindings read from hardware 2026-09-08, by WIRE index.
+    // Note index 3 is Back and index 4 is Forward — the transposition in
+    // INCOTT_BUTTON_WIRE_INDEX.
+    buttons: [0x00f00001, 0x00f10001, 0x00f20001, 0x00f30001, 0x00f40001, 0x00030007] as number[],
   };
 }
 
@@ -259,6 +263,12 @@ function fakeDevice(options: FakeOptions = {}) {
         if (sub === 0x01) return frame(0x85, 0x01, state.debounceMs);
         if (sub === 0x03) return frame(0x85, 0x03, state.sleepSeconds & 0xff, (state.sleepSeconds >> 8) & 0xff);
         return null;
+      case 0x86: {
+        // Echoes the button index, then the 32-bit binding little-endian.
+        const code = state.buttons[sub];
+        if (code === undefined) return null;
+        return frame(0x86, sub, code & 0xff, (code >>> 8) & 0xff, (code >>> 16) & 0xff, (code >>> 24) & 0xff);
+      }
       case 0x88:
         return frame(0x88, state.receiverLed);
       case 0x89:
@@ -301,6 +311,11 @@ function fakeDevice(options: FakeOptions = {}) {
     else if (cmd === 0x05 && sub === 0x01) state.debounceMs = value;
     else if (cmd === 0x05 && sub === 0x03) state.sleepSeconds = value | ((payload[3] ?? 0) << 8);
     else if (cmd === 0x08) state.receiverLed = sub; // no sub-command: mode sits at byte 1
+    // cmd 0x06: `sub` is the button WIRE index, then the 32-bit action.
+    else if (cmd === 0x06 && sub >= 0 && sub < state.buttons.length) {
+      state.buttons[sub] =
+        ((value | ((payload[3] ?? 0) << 8) | ((payload[4] ?? 0) << 16) | ((payload[5] ?? 0) << 24)) >>> 0);
+    }
   };
 
   const device = {
@@ -599,6 +614,75 @@ test("supportedPollingRates offers the full ladder over the wireless connection"
   const status = await new IncottHidClient(device, fast).readStatus();
   assert.deepEqual(status.supportedPollingRates, [125, 250, 500, 1000, 2000, 4000, 8000]);
   assert.equal(status.ui?.pollingNote, "Up to 8,000 Hz wireless; 1,000 Hz over the cable.");
+});
+
+test("readStatus publishes the six factory bindings by physical button name", async () => {
+  const { device } = fakeDevice();
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.deepEqual(status.buttonMappings, {
+    Left: "Left click",
+    Right: "Right click",
+    Middle: "Middle click",
+    // Proves the wire transposition is undone: wire index 4 holds 0x00F40001
+    // (forward) and is published as Forward, not as the button at array
+    // position 4.
+    Forward: "Forward",
+    Back: "Back",
+    DPI: "DPI cycle",
+  });
+  assert.equal(status.buttonOptions?.[0], "Left click");
+  assert.ok(status.buttonOptions?.includes("Disabled"));
+});
+
+test("readStatus hides the remapper entirely when a button read fails", async () => {
+  // Partial assignments would be published as real ones, and the shared
+  // remapper writes back what it shows.
+  const { device } = fakeDevice({ silent: [0x86] });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.buttonMappings, undefined);
+  assert.equal(status.buttonOptions, undefined);
+});
+
+test("readStatus reports an unrecognised binding as a raw code, not as a known action", async () => {
+  // A keyboard binding ('A', no modifier) is not in the action table.
+  const { device } = fakeDevice({ state: { buttons: [0x00000480, 0x00f10001, 0x00f20001, 0x00f30001, 0x00f40001, 0x00030007] } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.buttonMappings?.Left, "Unknown (0x00000480)");
+});
+
+test("setButtonMapping writes the action and verifies the read-back", async () => {
+  const { device } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.setButtonMapping("Middle", "Mute");
+  const status = await client.readStatus();
+  assert.equal(status.buttonMappings?.Middle, "Mute");
+  // Nothing else moved.
+  assert.equal(status.buttonMappings?.Left, "Left click");
+  assert.equal(status.buttonMappings?.DPI, "DPI cycle");
+});
+
+test("setButtonMapping addresses Forward and Back by their wire index, not their position", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.setButtonMapping("Forward", "Disabled");
+  // Wire index 4 is Forward. If the driver had used the display position (3)
+  // it would have silently disabled Back instead.
+  assert.equal(state.buttons[4], 0);
+  assert.equal(state.buttons[3], 0x00f30001, "Back is untouched");
+});
+
+test("setButtonMapping rejects an unknown button or action without writing", async () => {
+  const { device, state } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await assert.rejects(() => client.setButtonMapping("Thumb", "Mute"), /no "Thumb" button/);
+  await assert.rejects(() => client.setButtonMapping("Middle", "Teleport"), /Unknown button action/);
+  assert.deepEqual(state.buttons, [0x00f00001, 0x00f10001, 0x00f20001, 0x00f30001, 0x00f40001, 0x00030007]);
+});
+
+test("setButtonMapping throws when the mouse does not take the binding", async () => {
+  const { device } = fakeDevice({ ignoreWrites: true });
+  const client = new IncottHidClient(device, fast);
+  await assert.rejects(() => client.setButtonMapping("Middle", "Mute"), /instead of Mute/);
 });
 
 test("readStatus reports the same model name wired as wireless", async () => {

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -1392,3 +1392,28 @@ test("REGRESSION: reading X then Y on one stage does not return X twice", async 
   assert.equal(await client.readDpiStageAxis(2, "x"), 1600);
   assert.equal(await client.readDpiStageAxis(2, "y"), 3200);
 });
+
+test("readStatus publishes the receiver LED mode and rapid-fire settings", async () => {
+  const { device } = fakeDevice({ state: { receiverLed: 2, fireKeyTimes: 2, fireKeyIntervalMs: 40 } });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.incottReceiverLedMode, 2);
+  assert.equal(status.incottFireKeyTimes, 2);
+  assert.equal(status.incottFireKeyIntervalMs, 40);
+});
+
+test("readStatus omits the receiver LED over the cable, where it has no meaning", async () => {
+  // There is no dongle in wired mode, so the control is absent rather than
+  // present-but-inert. Rapid fire is unaffected: it lives in the mouse.
+  const { device } = fakeDevice({ productId: INCOTT_PRODUCT_ID_WIRED });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.incottReceiverLedMode, undefined);
+  assert.equal(status.incottFireKeyTimes, 3);
+});
+
+test("readStatus omits both rather than guessing when the queries fail", async () => {
+  const { device } = fakeDevice({ silent: [0x85, 0x88] });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.incottReceiverLedMode, undefined);
+  assert.equal(status.incottFireKeyTimes, undefined);
+  assert.equal(status.incottFireKeyIntervalMs, undefined);
+});

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -232,6 +232,8 @@ function vendorCollection(usagePage: number = INCOTT_USAGE_PAGE): HIDCollectionI
 function fakeDevice(options: FakeOptions = {}) {
   const state: FakeState = { ...defaultState(), ...options.state };
   const sent: Uint8Array[] = [];
+  // OUTPUT reports, which only the macro upload uses.
+  const outputs: Array<{ reportId: number; bytes: Uint8Array }> = [];
   let buffer = new Uint8Array(64);
   let opened = false;
   // Only "inputreport" is ever registered by this driver; a single slot is
@@ -356,6 +358,13 @@ function fakeDevice(options: FakeOptions = {}) {
     close: async () => {
       opened = false;
     },
+    // Only the macro upload sends these; everything else is a feature report.
+    sendReport: async (reportId: number, data: BufferSource) => {
+      const view = ArrayBuffer.isView(data)
+        ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        : new Uint8Array(data as ArrayBuffer);
+      outputs.push({ reportId, bytes: new Uint8Array(view) });
+    },
     sendFeatureReport: async (_reportId: number, data: BufferSource) => {
       const view = ArrayBuffer.isView(data)
         ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
@@ -387,6 +396,7 @@ function fakeDevice(options: FakeOptions = {}) {
   return {
     device: device as unknown as HIDDevice,
     sent,
+    outputs,
     state,
     /**
      * Simulates the mouse's unsolicited input report arriving — only fires
@@ -745,11 +755,11 @@ test("readStatus hides the remapper entirely when a button read fails", async ()
 });
 
 test("readStatus reports an unrecognised binding as a raw code, not as a known action", async () => {
-  // A macro binding (`slot << 16 | 9`) — macros need the 0x07 upload command
-  // and are deliberately absent from the action table.
-  const { device } = fakeDevice({ state: { buttons: [0x00010009, 0x00f10001, 0x00f20001, 0x00f30001, 0x00f40001, 0x00030007] } });
+  // Nothing this driver can name — not a mouse, media, keyboard or macro
+  // encoding — so it must be reported rather than mislabelled.
+  const { device } = fakeDevice({ state: { buttons: [0x12345678, 0x00f10001, 0x00f20001, 0x00f30001, 0x00f40001, 0x00030007] } });
   const status = await new IncottHidClient(device, fast).readStatus();
-  assert.equal(status.buttonMappings?.Left, "Unknown (0x00010009)");
+  assert.equal(status.buttonMappings?.Left, "Unknown (0x12345678)");
 });
 
 test("readStatus labels a keyboard binding read back from the mouse", async () => {
@@ -1443,4 +1453,42 @@ test("setAxisDpi sends a single linked write when the axes match", async () => {
   const dpiWrites = sent.filter((payload) => payload[0] === 0x02);
   assert.equal(dpiWrites.length, 1, "one write, not one per axis");
   assert.equal(dpiWrites[0]![7], 0, "the 'both' axis flag");
+});
+
+test("uploadMacro interleaves ten headers with ten 32-byte output reports", async () => {
+  // Exactly the shape captured from the vendor tool: an 8-byte feature
+  // report announcing each chunk, then the chunk itself as an OUTPUT report
+  // on the same id.
+  const { device, sent, outputs } = fakeDevice();
+  const client = new IncottHidClient(device, fast);
+  await client.uploadMacro({
+    bufferId: 3,
+    loop: "untilAnyKey",
+    cycles: 1,
+    uid: 0x8fba0e90,
+    steps: [{ key: 0x0f, press: true, delayMs: 124 }, { key: 0x0f, press: false, delayMs: 1510 }],
+  });
+
+  const headers = sent.filter((payload) => payload[0] === 0x07);
+  assert.equal(headers.length, 10);
+  assert.equal(outputs.length, 10);
+  assert.ok(outputs.every((report) => report.bytes.length === 32), "every chunk is 32 bytes");
+  assert.ok(outputs.every((report) => report.reportId === 0x09), "same report id as the feature path");
+  headers.forEach((header, index) => {
+    assert.deepEqual([...header.slice(0, 5)], [0x07, 0x0a, index, 0x20, 0x03]);
+  });
+  // The chunks rejoin into the buffer the encoder produced.
+  const rejoined = outputs.flatMap((report) => [...report.bytes]);
+  assert.equal(rejoined.length, 320);
+  assert.deepEqual(rejoined.slice(0, 8), [0x03, 0x01, 0x01, 0x00, 0x01, 0x0f, 0x7c, 0x00]);
+});
+
+test("uploadMacro fails clearly on a transport with no output-report support", async () => {
+  const { device } = fakeDevice();
+  delete (device as unknown as { sendReport?: unknown }).sendReport;
+  const client = new IncottHidClient(device, fast);
+  await assert.rejects(
+    () => client.uploadMacro({ bufferId: 0, loop: "cycle", cycles: 1, uid: 0, steps: [] }),
+    /cannot send output reports/,
+  );
 });

--- a/src/drivers/incott/hid.test.ts
+++ b/src/drivers/incott/hid.test.ts
@@ -436,9 +436,11 @@ test("readStatus decodes every field from the device's current state", async () 
   // active.
   const status = await client.readStatus();
   assert.equal(status.brand, "Incott");
-  // Normalized for display (see incottNormalizeProductName): the raw string
-  // remains available as client.device.productName.
-  assert.equal(status.name, "8K wireless");
+  // Read FROM THE DEVICE, not from the product string: the dongle reports a
+  // generic "incott 8K wireless mouse" with no model in it, while the
+  // identity reply names the model (see `incottDecodeIdentity`). The raw
+  // string remains available as client.device.productName.
+  assert.equal(status.name, "G23V2 Pro");
   assert.equal(device.productName, "incott 8K wireless mouse", "the raw product string stays available on the device");
   assert.equal(status.connectionType, "Wireless");
   assert.equal(status.dpi, 800);
@@ -469,7 +471,7 @@ test("readStatus decodes every field from the device's current state", async () 
   assert.equal(status.ui?.family, "incott");
   assert.equal(status.ui?.showAdvancedSection, true);
   assert.equal(status.ui?.hideSignalCard, true);
-  assert.equal(status.ui?.defaultDisplayName, "8K wireless");
+  assert.equal(status.ui?.defaultDisplayName, "G23V2 Pro");
   assert.equal(status.ui?.hideUnsupportedPollingRates, true);
   assert.equal(status.ui?.pollingNote, "Up to 8,000 Hz wireless; 1,000 Hz over the cable.");
   // The mouse has a real internal battery even while wired, so the app's
@@ -599,15 +601,28 @@ test("supportedPollingRates offers the full ladder over the wireless connection"
   assert.equal(status.ui?.pollingNote, "Up to 8,000 Hz wireless; 1,000 Hz over the cable.");
 });
 
-test("readStatus normalizes the wired product string down to its real model name", async () => {
-  // Verified 2026-09-08: the real model name is only present in the wired
-  // product string. The wireless dongle's string is a generic name with no
-  // model in it — readStatus tidies whichever raw string it gets without
-  // inventing a model when wireless.
+test("readStatus reports the same model name wired as wireless", async () => {
+  // The wired product string does carry a model ("incott Esports G23V2Pro
+  // mouse", verified 2026-09-08) while the dongle's does not, so relying on
+  // it would name the mouse differently depending on how it is plugged in.
+  // The identity reply is the same either way, so the name is too. The raw
+  // string stays available for anything that wants it.
   const { device } = fakeDevice({ productId: INCOTT_PRODUCT_ID_WIRED, productName: "incott Esports G23V2Pro mouse" });
   const status = await new IncottHidClient(device, fast).readStatus();
-  assert.equal(status.name, "Esports G23V2Pro");
+  assert.equal(status.name, "G23V2 Pro");
   assert.equal(device.productName, "incott Esports G23V2Pro mouse", "the raw string stays available on the device");
+});
+
+test("readStatus falls back to the product string when the model code is unknown", async () => {
+  // An Incott model this table has never seen must report whatever the
+  // device called itself, never a guess.
+  const { device } = fakeDevice({
+    productId: INCOTT_PRODUCT_ID_WIRED,
+    productName: "incott Esports G99 mouse",
+    state: { identity: [0x01, 0x7f, 0x02, 0xf0, 0xf1, 0x00, 0xff] },
+  });
+  const status = await new IncottHidClient(device, fast).readStatus();
+  assert.equal(status.name, "Esports G99");
 });
 
 test("firmware falls back to a plain notice when identity cannot be read", async () => {
@@ -620,7 +635,9 @@ test("readStatus degrades to identity-only fields rather than fabricate the poll
   const { device } = fakeDevice({ silent: [0x81] });
   const client = new IncottHidClient(device, fast);
   const status = await client.readStatus();
-  assert.equal(status.name, "8K wireless");
+  // The identity query still answers here — only 0x81 is silent — so the
+  // model is still read from the device.
+  assert.equal(status.name, "G23V2 Pro");
   assert.equal(status.brand, "Incott");
   assert.equal(status.pollingRateHz, 0, "inert placeholder, never rendered because settingsReady is false");
   assert.equal(status.ui?.settingsReady, false);

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -897,6 +897,29 @@ export class IncottHidClient {
     return dpi;
   }
 
+  /**
+   * Sets both DPI axes on the ACTIVE stage — the shape a generic X/Y control
+   * needs, where `setDpiStageAxis` is per-stage and per-axis.
+   *
+   * Mirrors the vendor's own `setResolution`: one write with the "both" flag
+   * when the axes match, two axis-flagged writes when they differ. Named to
+   * match the method proposed upstream for a brand-agnostic axis control; if
+   * the maintainers settle on a different name this is the one line to
+   * rename.
+   */
+  async setAxisDpi(dpiX: number, dpiY: number): Promise<void> {
+    incottValidateDpi(dpiX);
+    incottValidateDpi(dpiY);
+    const stage = (await this.readDpiCycle())?.active ?? null;
+    if (stage === null) throw new Error("Could not read the active DPI stage to write.");
+    if (dpiX === dpiY) {
+      await this.setDpiStageAxis(stage, dpiX, "both");
+      return;
+    }
+    await this.setDpiStageAxis(stage, dpiX, "x");
+    await this.setDpiStageAxis(stage, dpiY, "y");
+  }
+
   /** Reads the DPI cycle (stage count + active stage) in one query. */
   private async readDpiCycle(): Promise<IncottDpiCycle | null> {
     return incottDecodeDpiCycle(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_NONE));

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -5,6 +5,7 @@ import {
   incottDecodeDebounce,
   incottDecodeDpiStage,
   incottDecodeDpiCycle,
+  incottDecodeFireKey,
   incottDecodeIdentity,
   incottDecodeInputStatus,
   incottDecodeLiftOffDirect,
@@ -18,6 +19,7 @@ import {
   incottEncodeSetDebounce,
   incottEncodeSetDpi,
   incottEncodeSetDpiCycle,
+  incottEncodeSetFireKey,
   incottEncodeSetLiftOff,
   incottEncodeSetPerformanceMode,
   incottEncodeSetPollingRate,
@@ -59,6 +61,7 @@ import {
   INCOTT_RESPONSE_LENGTH,
   INCOTT_SUB_ANGLE_SNAP,
   INCOTT_SUB_DEBOUNCE,
+  INCOTT_SUB_FIRE_KEY,
   INCOTT_SUB_LOD,
   INCOTT_SUB_MOTION_SYNC,
   INCOTT_SUB_NONE,
@@ -68,6 +71,7 @@ import {
   INCOTT_USAGE_PAGE,
   INCOTT_VENDOR_ID,
   type IncottDpiCycle,
+  type IncottFireKey,
   type IncottInputStatus,
 } from "../../incott/index.ts";
 
@@ -1058,6 +1062,35 @@ export class IncottHidClient {
     if (applied.code !== code) {
       throw new Error(`The mouse kept ${applied.label ?? "another binding"} on ${name} instead of ${actionLabel}.`);
     }
+  }
+
+  /**
+   * Reads the Fire Key (rapid-fire) parameters — how many clicks a button
+   * bound to "Rapid fire" sends, and how far apart. Global to the device: the
+   * command carries no button index.
+   */
+  async getFireKey(): Promise<IncottFireKey | null> {
+    return incottDecodeFireKey(await this.query(INCOTT_CMD_QUERY_TIMING, INCOTT_SUB_FIRE_KEY));
+  }
+
+  /**
+   * Writes the Fire Key parameters and verifies the read-back.
+   *
+   * Not advertised through `MouseStatus`: the shared contract has no
+   * rapid-fire field, so there is no generic control to publish this behind —
+   * the same position `setReceiverLed` is in. Kept for protocol parity and
+   * for whoever wires a control up.
+   */
+  async setFireKey(times: number, intervalMs: number): Promise<IncottFireKey> {
+    await this.write(incottEncodeSetFireKey(times, intervalMs));
+    const got = await this.getFireKey();
+    if (got === null) throw new Error("The mouse did not confirm the fire key change.");
+    if (got.times !== times || got.intervalMs !== intervalMs) {
+      throw new Error(
+        `The mouse kept ${got.times} clicks at ${got.intervalMs} ms instead of ${times} at ${intervalMs} ms.`,
+      );
+    }
+    return got;
   }
 
   async setReceiverLed(mode: number): Promise<number> {

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -21,6 +21,9 @@ import {
   incottEncodeSetReceiverLed,
   incottEncodeSetSleep,
   incottEncodeSetToggle,
+  incottButtonActionCode,
+  incottDecodeButtonBinding,
+  incottEncodeSetButtonBinding,
   incottFrameMatches,
   incottIsWiredProduct,
   incottLiftOffLabel,
@@ -29,6 +32,10 @@ import {
   incottPerformanceModeFromWire,
   incottPerformanceModeToWire,
   incottValidateDpi,
+  INCOTT_BUTTON_ACTIONS,
+  INCOTT_BUTTON_NAMES,
+  INCOTT_BUTTON_WIRE_INDEX,
+  INCOTT_CMD_QUERY_BUTTON,
   INCOTT_CMD_QUERY_DPI_STAGE,
   INCOTT_CMD_QUERY_DPI_STAGE_VALUE,
   INCOTT_CMD_QUERY_IDENTITY,
@@ -261,16 +268,17 @@ export async function incottSelectCollection<T extends FeatureTransport>(
  * this list to matter to. `incottDecodeBattery`'s own frame-matching in
  * `src/incott/index.ts` is unaffected by this list either way.
  *
- * `0x86` (button reads) shows the identical sub-echo pattern but is not
- * queried anywhere in this driver — see `INCOTT_CMD_QUERY_BUTTON` in
- * `src/incott/index.ts` for where to add it if a button read is ever wired
- * up here.
+ * `0x86` echoes the button index in the same position, and MUST stay in this
+ * list now that buttons are read: six reads go out back to back, and the
+ * device latches a single shared response buffer, so matching on the command
+ * byte alone would let button 2's reply satisfy button 3's request.
  */
 const SUB_ECHOING_QUERIES: readonly number[] = [
   INCOTT_CMD_QUERY_DPI_STAGE,
   INCOTT_CMD_QUERY_DPI_STAGE_VALUE,
   INCOTT_CMD_QUERY_SENSOR,
   INCOTT_CMD_QUERY_TIMING,
+  INCOTT_CMD_QUERY_BUTTON,
 ];
 
 function toggleWord(value: boolean | null): string {
@@ -696,12 +704,19 @@ export class IncottHidClient {
     // failure on every attempt.
     const supportedPollingRates = wired ? [...INCOTT_POLLING_STEPS_HZ_WIRED] : [...INCOTT_POLLING_STEPS_HZ];
 
+    // All six bindings, or nothing. A partial read would render some buttons
+    // with a real assignment and the rest with a fabricated default, which is
+    // worse than hiding the remapper: the shared UI writes back whatever it
+    // shows, so a wrong reading becomes a wrong write the moment anything
+    // else on the card is changed.
+    const buttonMappings = dead ? null : await this.readButtonMappings();
+
     const ui: MouseUiHints = {
       family: "incott",
       // The advanced section is the only place debounce, sleep, motion sync,
-      // angle snapping and ripple control render; Incott has no lighting, no
-      // onboard profiles, and no button remapping, so those cards stay hidden
-      // on their own (nothing populates the fields that gate them).
+      // angle snapping and ripple control render; Incott has no lighting and
+      // no onboard profiles, so those cards stay hidden on their own
+      // (nothing populates the fields that gate them).
       showAdvancedSection: true,
       // No command reports link quality.
       hideSignalCard: true,
@@ -784,6 +799,12 @@ export class IncottHidClient {
       batteryState: batteryCharging === null ? "Unknown" : batteryCharging ? "Charging" : "Discharging",
       liftOffDistance: liftOffTenths === null ? null : incottLiftOffLabel(liftOffTenths),
       supportedLiftOffDistances: ["Low", "Medium", "High"],
+      // Both fields together, or neither: the shared remapper only renders
+      // when it has the current assignments AND the list of actions it may
+      // write back.
+      ...(buttonMappings !== null
+        ? { buttonMappings, buttonOptions: INCOTT_BUTTON_ACTIONS.map(([label]) => label) }
+        : {}),
       motionSync,
       rippleControl,
       angleSnapping,
@@ -938,6 +959,51 @@ export class IncottHidClient {
    * omit the wiring outright when wired, matching the other wireless-only
    * behavior in this driver (see `INCOTT_POLLING_STEPS_HZ_WIRED`).
    */
+  /**
+   * Reads all six button bindings, keyed by the physical button name.
+   *
+   * Returns null unless every button answered: see the call site in
+   * `readStatus` for why a partial read is not published. A binding the
+   * action table does not know (a keyboard key, a macro) reports its raw code
+   * as `Unknown (0x...)` rather than being shown as one of the offered
+   * actions — the shared remapper writes back what it displays, so labelling
+   * an unknown binding as a known action would rewrite it on the next edit.
+   */
+  private async readButtonMappings(): Promise<Record<string, string> | null> {
+    const mappings: Record<string, string> = {};
+    for (const name of INCOTT_BUTTON_NAMES) {
+      const index = INCOTT_BUTTON_WIRE_INDEX[name];
+      const binding = incottDecodeButtonBinding(await this.query(INCOTT_CMD_QUERY_BUTTON, index), index);
+      if (binding === null) return null;
+      mappings[name] = binding.label ?? `Unknown (0x${binding.code.toString(16).padStart(8, "0")})`;
+    }
+    return mappings;
+  }
+
+  /**
+   * Reassigns one button, then reads it back and refuses to report success
+   * unless the device actually took the value.
+   *
+   * `button` is a physical name; the wire index it maps to is NOT the same
+   * number (Forward and Back are transposed — see
+   * `INCOTT_BUTTON_WIRE_INDEX`). This is a standalone command, so it cannot
+   * disturb DPI, polling or the other five buttons.
+   */
+  async setButtonMapping(button: string, actionLabel: string): Promise<void> {
+    const name = INCOTT_BUTTON_NAMES.find((candidate) => candidate === button);
+    if (name === undefined) throw new Error(`This mouse has no "${button}" button.`);
+    const code = incottButtonActionCode(actionLabel);
+    if (code === null) throw new Error(`Unknown button action "${actionLabel}".`);
+
+    const index = INCOTT_BUTTON_WIRE_INDEX[name];
+    await this.write(incottEncodeSetButtonBinding(index, code));
+    const applied = incottDecodeButtonBinding(await this.query(INCOTT_CMD_QUERY_BUTTON, index), index);
+    if (applied === null) throw new Error("The mouse did not confirm the button change.");
+    if (applied.code !== code) {
+      throw new Error(`The mouse kept ${applied.label ?? "another binding"} on ${name} instead of ${actionLabel}.`);
+    }
+  }
+
   async setReceiverLed(mode: number): Promise<number> {
     await this.write(incottEncodeSetReceiverLed(mode));
     const got = incottDecodeReceiverLed(await this.query(INCOTT_CMD_QUERY_RECEIVER_LED, INCOTT_SUB_NONE));

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -8,6 +8,7 @@ import {
   incottDecodeDpiCycle,
   incottDecodeFireKey,
   incottDecodeIdentity,
+  incottDpiMaxForSensor,
   incottDecodeInputStatus,
   incottDecodeLiftOffDirect,
   incottDecodePerformanceMode,
@@ -844,7 +845,12 @@ export class IncottHidClient {
       // writes through `setDpiStageCount`, which needs a real current count
       // to preserve the active stage, and offering it against an unreadable
       // one would write a guess.
-      dpiStageEditor: { maxStages: INCOTT_DPI_STAGE_COUNT, countEditable: dpiCycle !== null, minDpi: INCOTT_DPI_MIN, maxDpi: INCOTT_DPI_MAX, stepDpi: INCOTT_DPI_STEP },
+      // The ceiling follows the FITTED SENSOR, which the identity reply
+      // reports: the PAW3395 models in this family stop at 32000 in the
+      // vendor's own table where the PAW3950 reaches 45000. Falls back to the
+      // higher value when identity could not be read, since narrowing on a
+      // guess would hide DPI the mouse can actually do.
+      dpiStageEditor: { maxStages: INCOTT_DPI_STAGE_COUNT, countEditable: dpiCycle !== null, minDpi: INCOTT_DPI_MIN, maxDpi: incottDpiMaxForSensor(identity?.sensorId ?? null), stepDpi: INCOTT_DPI_STEP },
     };
 
     return {

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -740,6 +740,16 @@ export class IncottHidClient {
     // failure on every attempt.
     const supportedPollingRates = wired ? [...INCOTT_POLLING_STEPS_HZ_WIRED] : [...INCOTT_POLLING_STEPS_HZ];
 
+    // The receiver LED belongs to the 2.4 GHz dongle and means nothing over
+    // the cable, so it is not read at all when wired — the card then hides
+    // itself rather than offering a control that cannot do anything. See
+    // `setReceiverLed`.
+    const receiverLedMode = dead || wired
+      ? null
+      : incottDecodeReceiverLed(await this.query(INCOTT_CMD_QUERY_RECEIVER_LED, INCOTT_SUB_NONE));
+    // Rapid-fire parameters, global to the device — see `INCOTT_SUB_FIRE_KEY`.
+    const fireKey = dead ? null : await this.getFireKey();
+
     // All six bindings, or nothing. A partial read would render some buttons
     // with a real assignment and the rest with a fabricated default, which is
     // worse than hiding the remapper: the shared UI writes back whatever it
@@ -819,6 +829,13 @@ export class IncottHidClient {
       // renders it.
       dpi: dpi ?? 0,
       ...(dpiY !== null ? { dpiY, supportsSeparateDpiAxes: true } : {}),
+      // Omitted, not nulled, when unreadable or inapplicable: the app's
+      // Incott card renders only the fields that are present, so a wired
+      // connection simply has no receiver-LED control rather than a dead one.
+      ...(receiverLedMode !== null ? { incottReceiverLedMode: receiverLedMode } : {}),
+      ...(fireKey !== null
+        ? { incottFireKeyTimes: fireKey.times, incottFireKeyIntervalMs: fireKey.intervalMs }
+        : {}),
       // All six stages' stored values, only when every one of them answered
       // — see the loop above. Omitted (not fabricated) on a partial read.
       ...(dpiStages !== null ? { dpiStages } : {}),

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -818,7 +818,7 @@ export class IncottHidClient {
       // go here, but `ui.settingsReady: false` above means the app never
       // renders it.
       dpi: dpi ?? 0,
-      ...(dpiY !== null ? { dpiY } : {}),
+      ...(dpiY !== null ? { dpiY, supportsSeparateDpiAxes: true } : {}),
       // All six stages' stored values, only when every one of them answered
       // — see the loop above. Omitted (not fabricated) on a partial read.
       ...(dpiStages !== null ? { dpiStages } : {}),

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -4,6 +4,7 @@ import {
   incottDecodeButtonBinding,
   incottDecodeDebounce,
   incottDecodeDpiStage,
+  incottDecodeDpiStageAxis,
   incottDecodeDpiCycle,
   incottDecodeFireKey,
   incottDecodeIdentity,
@@ -15,6 +16,7 @@ import {
   incottDecodeSleep,
   incottDecodeToggle,
   incottEncodeQuery,
+  incottEncodeQueryDpiAxis,
   incottEncodeSetButtonBinding,
   incottEncodeSetDebounce,
   incottEncodeSetDpi,
@@ -46,6 +48,7 @@ import {
   INCOTT_CMD_QUERY_SENSOR,
   INCOTT_CMD_QUERY_TIMING,
   INCOTT_DEBOUNCE_MAX_MS,
+  INCOTT_DPI_AXIS,
   INCOTT_DPI_DEFAULT_STAGE_PRESETS,
   INCOTT_DPI_MAX,
   INCOTT_DPI_MIN,
@@ -70,6 +73,7 @@ import {
   INCOTT_SUB_SLEEP,
   INCOTT_USAGE_PAGE,
   INCOTT_VENDOR_ID,
+  type IncottDpiAxis,
   type IncottDpiCycle,
   type IncottFireKey,
   type IncottInputStatus,
@@ -130,8 +134,13 @@ export class IncottTransactionQueue {
    * no matching frame arrives. Never rejects: a device that stops answering
    * yields null so the caller can render an em dash instead of a stale value.
    */
-  request(payload: Uint8Array, cmd: number, sub: number | null): Promise<Uint8Array | null> {
-    const run = this.tail.then(() => this.exchange(payload, cmd, sub));
+  request(
+    payload: Uint8Array,
+    cmd: number,
+    sub: number | null,
+    axis: number | null = null,
+  ): Promise<Uint8Array | null> {
+    const run = this.tail.then(() => this.exchange(payload, cmd, sub, axis));
     // Keep the chain alive even if one exchange throws.
     this.tail = run.catch(() => undefined);
     return run;
@@ -158,6 +167,7 @@ export class IncottTransactionQueue {
     payload: Uint8Array,
     cmd: number,
     sub: number | null,
+    axis: number | null = null,
   ): Promise<Uint8Array | null> {
     try {
       // Discard anything latched by a previous exchange before sending.
@@ -166,7 +176,7 @@ export class IncottTransactionQueue {
       for (let attempt = 0; attempt < this.attempts; attempt += 1) {
         if (this.settleMs > 0) await this.sleep(this.settleMs);
         const frame = await this.read();
-        if (frame && incottFrameMatches(frame, cmd, sub)) return frame;
+        if (frame && incottFrameMatches(frame, cmd, sub, axis)) return frame;
       }
       return null;
     } catch {
@@ -632,6 +642,14 @@ export class IncottHidClient {
       ? dpiStageReads.slice(0, dpiCycle?.count ?? dpiStageReads.length)
       : null;
     const dpi = activeDpiStage === null ? null : dpiStageReads[activeDpiStage] ?? null;
+    // The active stage's Y axis, which the plain stage read above does not
+    // distinguish — that returns X. Published so the shared "X n · Y n DPI"
+    // summary is truthful on a mouse whose axes differ; omitted rather than
+    // mirrored from X when the read fails, so the app falls back to one
+    // number instead of claiming the axes match.
+    const dpiY = dead || activeDpiStage === null
+      ? null
+      : await this.readDpiStageAxis(activeDpiStage, "y");
     const pollingRateHz = dead
       ? null
       : incottDecodePollingRate(await this.query(INCOTT_CMD_QUERY_POLLING, INCOTT_SUB_NONE));
@@ -800,6 +818,7 @@ export class IncottHidClient {
       // go here, but `ui.settingsReady: false` above means the app never
       // renders it.
       dpi: dpi ?? 0,
+      ...(dpiY !== null ? { dpiY } : {}),
       // All six stages' stored values, only when every one of them answered
       // — see the loop above. Omitted (not fabricated) on a partial read.
       ...(dpiStages !== null ? { dpiStages } : {}),
@@ -1176,6 +1195,52 @@ export class IncottHidClient {
   private async query(cmd: number, sub: number): Promise<Uint8Array> {
     const matchSub = SUB_ECHOING_QUERIES.includes(cmd) ? sub : null;
     return (await this.queue.request(incottEncodeQuery(cmd, sub), cmd, matchSub)) ?? new Uint8Array(INCOTT_RESPONSE_LENGTH);
+  }
+
+  /**
+   * Reads ONE AXIS of one DPI stage. Separate from `query` because the axis
+   * has to be matched in the reply as well as sent: X and Y on the same stage
+   * are two requests with an identical command and sub-command, so the second
+   * would otherwise accept the first's latched frame.
+   */
+  private async queryDpiAxis(stage: number, axis: IncottDpiAxis): Promise<Uint8Array> {
+    const frame = await this.queue.request(
+      incottEncodeQueryDpiAxis(stage, axis),
+      INCOTT_CMD_QUERY_DPI_STAGE_VALUE,
+      stage,
+      INCOTT_DPI_AXIS[axis],
+    );
+    return frame ?? new Uint8Array(INCOTT_RESPONSE_LENGTH);
+  }
+
+  /** Reads one axis of one stage, or null when the device does not answer. */
+  async readDpiStageAxis(stage: number, axis: IncottDpiAxis): Promise<number | null> {
+    if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
+      throw new RangeError(`DPI stage out of range: ${stage}`);
+    }
+    return incottDecodeDpiStageAxis(await this.queryDpiAxis(stage, axis), stage, axis);
+  }
+
+  /**
+   * Writes one axis of one stage and verifies it by reading that axis back.
+   *
+   * Independent X and Y are real on this device — hardware-verified
+   * 2026-09-11, see `INCOTT_DPI_AXIS`. Writing `"both"` is what the ordinary
+   * `setDpiStageValue` does.
+   */
+  async setDpiStageAxis(stage: number, dpi: number, axis: IncottDpiAxis): Promise<number> {
+    if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
+      throw new RangeError(`DPI stage out of range: ${stage}`);
+    }
+    incottValidateDpi(dpi);
+    await this.write(incottEncodeSetDpi(stage, dpi, axis));
+    // "both" has no axis of its own to read back; X is the axis it lands on.
+    const readAxis: IncottDpiAxis = axis === "both" ? "x" : axis;
+    const got = await this.readDpiStageAxis(stage, readAxis);
+    if (got !== dpi) {
+      throw new Error(`The mouse kept ${got ?? "an unreadable"} ${readAxis.toUpperCase()} DPI instead of ${dpi}.`);
+    }
+    return dpi;
   }
 
   private async write(payload: Uint8Array): Promise<void> {

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -15,6 +15,8 @@ import {
   incottDecodeReceiverLed,
   incottDecodeSleep,
   incottDecodeToggle,
+  incottEncodeMacroBuffer,
+  incottEncodeMacroChunkHeader,
   incottEncodeQuery,
   incottEncodeQueryDpiAxis,
   incottEncodeSetButtonBinding,
@@ -30,6 +32,7 @@ import {
   incottEncodeSetToggle,
   incottFrameMatches,
   incottIsWiredProduct,
+  incottMacroChunks,
   incottLiftOffLabel,
   incottLiftOffTenths,
   incottNormalizeProductName,
@@ -77,6 +80,7 @@ import {
   type IncottDpiCycle,
   type IncottFireKey,
   type IncottInputStatus,
+  type IncottMacro,
 } from "../../incott/index.ts";
 
 type LiftOffLevel = "Low" | "Medium" | "High";
@@ -89,6 +93,13 @@ type LiftOffLevel = "Low" | "Medium" | "High";
 export interface FeatureTransport {
   sendFeatureReport(reportId: number, data: BufferSource): Promise<void>;
   receiveFeatureReport(reportId: number): Promise<DataView>;
+  /**
+   * OUTPUT report, used only by the macro upload — every other command in
+   * this protocol is an 8-byte FEATURE report. Optional because most
+   * transports (and the test fakes that predate macros) have no reason to
+   * implement it; `uploadMacro` reports a clear error when it is absent.
+   */
+  sendReport?(reportId: number, data: BufferSource): Promise<void>;
 }
 
 export interface IncottTransactionOptions {
@@ -158,6 +169,24 @@ export class IncottTransactionQueue {
       } catch {
         // A failed write surfaces as a failed read-back in the client.
       }
+    });
+    this.tail = run.catch(() => undefined);
+    return run;
+  }
+
+  /**
+   * Sends a 32-byte OUTPUT report, the macro upload's data path. Queued with
+   * everything else so it cannot interleave with the 8-byte header that
+   * announces it, and followed by a settle delay because the vendor waits
+   * 80 ms between the two halves of each chunk.
+   */
+  sendOutput(reportId: number, payload: Uint8Array): Promise<void> {
+    const run = this.tail.then(async () => {
+      if (!this.transport.sendReport) {
+        throw new Error("This transport cannot send output reports, which the macro upload needs.");
+      }
+      await this.transport.sendReport(reportId, toArrayBuffer(payload));
+      await this.sleep(this.settleMs);
     });
     this.tail = run.catch(() => undefined);
     return run;
@@ -918,6 +947,27 @@ export class IncottHidClient {
     }
     await this.setDpiStageAxis(stage, dpiX, "x");
     await this.setDpiStageAxis(stage, dpiY, "y");
+  }
+
+  /**
+   * Uploads one macro into an on-device buffer.
+   *
+   * Ten 32-byte chunks, each announced by an 8-byte feature report and then
+   * carried by a 32-byte OUTPUT report on the same id — the only place this
+   * protocol uses an output report at all. Captured from the vendor tool
+   * 2026-09-11; see `captures/incott-8k-wireless/macro-upload-2026-09-11.hex`.
+   *
+   * The device does not acknowledge any of it, so unlike every other setter
+   * here there is nothing to verify against: there is no macro read command.
+   * Bind a button to `Macro <n>` and press it — that is the only confirmation
+   * available.
+   */
+  async uploadMacro(macro: IncottMacro): Promise<void> {
+    const chunks = incottMacroChunks(incottEncodeMacroBuffer(macro));
+    for (const [index, chunk] of chunks.entries()) {
+      await this.write(incottEncodeMacroChunkHeader(index, macro.bufferId));
+      await this.queue.sendOutput(INCOTT_REPORT_ID, chunk);
+    }
   }
 
   /** Reads the DPI cycle (stage count + active stage) in one query. */

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -1,8 +1,10 @@
 import type { MouseStatus, MouseUiHints } from "../mouse-types.ts";
 import {
+  incottButtonActionCode,
+  incottDecodeButtonBinding,
   incottDecodeDebounce,
   incottDecodeDpiStage,
-  incottDecodeDpiStageIndex,
+  incottDecodeDpiCycle,
   incottDecodeIdentity,
   incottDecodeInputStatus,
   incottDecodeLiftOffDirect,
@@ -12,18 +14,16 @@ import {
   incottDecodeSleep,
   incottDecodeToggle,
   incottEncodeQuery,
-  incottEncodeSetActiveDpiStage,
+  incottEncodeSetButtonBinding,
   incottEncodeSetDebounce,
   incottEncodeSetDpi,
+  incottEncodeSetDpiCycle,
   incottEncodeSetLiftOff,
   incottEncodeSetPerformanceMode,
   incottEncodeSetPollingRate,
   incottEncodeSetReceiverLed,
   incottEncodeSetSleep,
   incottEncodeSetToggle,
-  incottButtonActionCode,
-  incottDecodeButtonBinding,
-  incottEncodeSetButtonBinding,
   incottFrameMatches,
   incottIsWiredProduct,
   incottLiftOffLabel,
@@ -59,7 +59,6 @@ import {
   INCOTT_RESPONSE_LENGTH,
   INCOTT_SUB_ANGLE_SNAP,
   INCOTT_SUB_DEBOUNCE,
-  INCOTT_SUB_DPI_STAGE,
   INCOTT_SUB_LOD,
   INCOTT_SUB_MOTION_SYNC,
   INCOTT_SUB_NONE,
@@ -68,6 +67,7 @@ import {
   INCOTT_SUB_SLEEP,
   INCOTT_USAGE_PAGE,
   INCOTT_VENDOR_ID,
+  type IncottDpiCycle,
   type IncottInputStatus,
 } from "../../incott/index.ts";
 
@@ -272,9 +272,15 @@ export async function incottSelectCollection<T extends FeatureTransport>(
  * list now that buttons are read: six reads go out back to back, and the
  * device latches a single shared response buffer, so matching on the command
  * byte alone would let button 2's reply satisfy button 3's request.
+ *
+ * `0x83` WAS in this list and has been removed. Its byte 2 is the DPI stage
+ * COUNT, not an echo — `09 83 00` answers `09 83 06 01` — so treating it as
+ * one only worked because this contributor's mouse has a six-stage cycle and
+ * the driver happened to send `06`. On a mouse configured for four stages
+ * every DPI read would have been rejected. See
+ * `INCOTT_DPI_STAGE_COUNT_DEFAULT`.
  */
 const SUB_ECHOING_QUERIES: readonly number[] = [
-  INCOTT_CMD_QUERY_DPI_STAGE,
   INCOTT_CMD_QUERY_DPI_STAGE_VALUE,
   INCOTT_CMD_QUERY_SENSOR,
   INCOTT_CMD_QUERY_TIMING,
@@ -593,9 +599,14 @@ export class IncottHidClient {
     // value. Per the driver's graceful-degradation contract, a device that
     // stops answering yields `dpi: null` / an omitted `dpiStages` here rather
     // than throwing or fabricating a value.
-    const activeDpiStage = dead
+    // One query answers both how many stages the cycle uses and which is
+    // live — see `incottDecodeDpiCycle`. The count is NOT assumed to be six:
+    // it is written back verbatim by every stage select, and publishing six
+    // rows for a four-stage cycle would offer stages the mouse never visits.
+    const dpiCycle = dead
       ? null
-      : incottDecodeDpiStageIndex(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_DPI_STAGE));
+      : incottDecodeDpiCycle(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_NONE));
+    const activeDpiStage = dpiCycle?.active ?? null;
     // Six sequential queries, deliberately NOT parallelized: the device has a
     // single shared response buffer (see `IncottTransactionQueue`'s class
     // comment), and concurrent requests would corrupt each other's replies.
@@ -609,9 +620,12 @@ export class IncottHidClient {
     }
     // `dpiStages` is populated only when every one of the six stages
     // answered — a partial table is never fabricated with a placeholder for
-    // the stage(s) that did not.
+    // the stage(s) that did not. It is then trimmed to the stages the cycle
+    // actually uses: the device keeps all six stored values, but the ones
+    // past `count` are not in the rotation and must not be offered as if
+    // they were.
     const dpiStages = dpiStageReads.every((value): value is number => value !== null)
-      ? dpiStageReads
+      ? dpiStageReads.slice(0, dpiCycle?.count ?? dpiStageReads.length)
       : null;
     const dpi = activeDpiStage === null ? null : dpiStageReads[activeDpiStage] ?? null;
     const pollingRateHz = dead
@@ -765,7 +779,11 @@ export class IncottHidClient {
       // PAW3395 unit is expected to have a write above 32000 refused by the
       // existing read-back verification in `setDpi`/`setDpiStageValue`
       // rather than this module guessing which sensor is present.
-      dpiStageEditor: { maxStages: INCOTT_DPI_STAGE_COUNT, countEditable: false, minDpi: INCOTT_DPI_MIN, maxDpi: INCOTT_DPI_MAX, stepDpi: INCOTT_DPI_STEP },
+      // `countEditable` only while the cycle actually read: the count picker
+      // writes through `setDpiStageCount`, which needs a real current count
+      // to preserve the active stage, and offering it against an unreadable
+      // one would write a guess.
+      dpiStageEditor: { maxStages: INCOTT_DPI_STAGE_COUNT, countEditable: dpiCycle !== null, minDpi: INCOTT_DPI_MIN, maxDpi: INCOTT_DPI_MAX, stepDpi: INCOTT_DPI_STEP },
     };
 
     return {
@@ -831,7 +849,7 @@ export class IncottHidClient {
    */
   async setDpi(dpi: number): Promise<number> {
     incottValidateDpi(dpi);
-    const stage = incottDecodeDpiStageIndex(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_DPI_STAGE));
+    const stage = (await this.readDpiCycle())?.active ?? null;
     if (stage === null) throw new Error("Could not read the active DPI stage to write.");
     await this.write(incottEncodeSetDpi(stage, dpi));
     const got = incottDecodeDpiStage(await this.query(INCOTT_CMD_QUERY_DPI_STAGE_VALUE, stage), stage);
@@ -839,22 +857,60 @@ export class IncottHidClient {
     return dpi;
   }
 
+  /** Reads the DPI cycle (stage count + active stage) in one query. */
+  private async readDpiCycle(): Promise<IncottDpiCycle | null> {
+    return incottDecodeDpiCycle(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_NONE));
+  }
+
   /**
-   * SELECTS which of the six DPI stages is active (`09 03 06 <idx>`) —
-   * distinct from `setDpi`/`setDpiStageValue`, which EDIT a stage's stored
-   * value. Confirmed on hardware 2026-09-08 that a select never touches any
-   * stage's stored value (see `INCOTT_CMD_SET_DPI_STAGE` in
-   * `src/incott/index.ts`), so unlike every value setter in this client this
-   * one reads back `0x83`/`0x06` — the active index — not a DPI value.
+   * SELECTS which DPI stage is active (`09 03 <count> <idx>`) — distinct from
+   * `setDpi`/`setDpiStageValue`, which EDIT a stage's stored value. Confirmed
+   * on hardware 2026-09-08 that a select never touches any stage's stored
+   * value (see `INCOTT_CMD_SET_DPI_STAGE` in `src/incott/index.ts`), so
+   * unlike every value setter in this client this one reads back the active
+   * index rather than a DPI value.
+   *
+   * The stage count is READ FIRST and written back unchanged. It shares the
+   * write with the index, so sending a constant here would silently resize a
+   * cycle that is not six stages long — see
+   * `INCOTT_DPI_STAGE_COUNT_DEFAULT`.
    */
   async setActiveDpiStage(stage: number): Promise<number> {
     if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
       throw new RangeError(`DPI stage out of range: ${stage}`);
     }
-    await this.write(incottEncodeSetActiveDpiStage(stage));
-    const got = incottDecodeDpiStageIndex(await this.query(INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_DPI_STAGE));
+    const cycle = await this.readDpiCycle();
+    if (cycle === null) throw new Error("Could not read the DPI stage cycle to write.");
+    if (stage >= cycle.count) {
+      throw new RangeError(`DPI stage ${stage} is outside this mouse's ${cycle.count}-stage cycle.`);
+    }
+    await this.write(incottEncodeSetDpiCycle(cycle.count, stage));
+    const got = (await this.readDpiCycle())?.active ?? null;
     if (got !== stage) throw new Error(`The mouse kept DPI stage ${got ?? "an unreadable"} instead of ${stage}.`);
     return stage;
+  }
+
+  /**
+   * Sets how many stages the DPI cycle rotates through (`09 03 <count>
+   * <idx>`). The stored value of every stage is left alone — stages above
+   * the new count keep their values and simply stop being visited.
+   *
+   * The active stage rides along in the same write, so it is clamped into
+   * the new cycle rather than left pointing past the end.
+   */
+  async setDpiStageCount(count: number): Promise<number> {
+    if (!Number.isInteger(count) || count < 1 || count > INCOTT_DPI_STAGE_COUNT) {
+      throw new RangeError(`DPI stage count out of range: ${count}`);
+    }
+    const cycle = await this.readDpiCycle();
+    if (cycle === null) throw new Error("Could not read the DPI stage cycle to write.");
+    const active = Math.min(cycle.active, count - 1);
+    await this.write(incottEncodeSetDpiCycle(count, active));
+    const got = await this.readDpiCycle();
+    if (got?.count !== count) {
+      throw new Error(`The mouse kept ${got?.count ?? "an unreadable"} DPI stages instead of ${count}.`);
+    }
+    return count;
   }
 
   /**

--- a/src/drivers/incott/hid.ts
+++ b/src/drivers/incott/hid.ts
@@ -561,14 +561,14 @@ export class IncottHidClient {
     // CONNECTION is wired, and charging is a consequence of that, not what
     // the id itself encodes. See `incottIsWiredProduct`.
     const wired = incottIsWiredProduct(this.device.productId);
-    // The real model name ("Esports G23V2Pro") lives only in the WIRED
-    // product string; wireless reports a generic "incott 8K wireless mouse"
-    // with no model in it, and there is no way to read a model over the air
-    // — see `incottNormalizeProductName`'s doc comment. `this.device` stays
-    // public, so `client.device.productName` remains available as the
+    // Fallback display name only — the model read from the device wins where
+    // one is available, and `name` is settled below once the identity query
+    // has answered. The product string names a model over the cable
+    // ("incott Esports G23V2Pro mouse") but is a generic "incott 8K wireless
+    // mouse" on the dongle, so it cannot be the primary source. `this.device`
+    // stays public, so `client.device.productName` remains available as the
     // untouched raw string for anything that wants it.
     const rawName = this.device.productName || "Incott wireless mouse";
-    const name = incottNormalizeProductName(rawName);
 
     // WIRED-MODE BUG, hardware-verified 2026-09-08 (see `open()`'s class
     // comment): when `open()`'s identity probe found this collection dead,
@@ -669,11 +669,24 @@ export class IncottHidClient {
     // right now, so it is used here instead of inferring the state from the
     // connection.
     const batteryCharging = this.lastInputStatus?.charging ?? null;
-    // Section 13 of the IncottHub spec: the identity byte layout is unknown,
-    // so the raw hex is shown rather than pretending to parse a version.
+    // The identity reply carries the model, the sensor and the receiver type
+    // — see `incottDecodeIdentity` for the byte map. The raw hex is still
+    // published under `firmware` below, because the remaining bytes (7-8) are
+    // genuinely undecoded and a capture of them is what a second model's
+    // owner would need to send.
     const identity = dead
       ? null
       : incottDecodeIdentity(await this.query(INCOTT_CMD_QUERY_IDENTITY, INCOTT_SUB_NONE));
+
+    // The model READ FROM THE DEVICE is preferred over the product string:
+    // it is the only source that works on the 2.4 GHz dongle, where the
+    // product string has no model in it. All six Incott models share the
+    // same two product ids, so this is the only thing that tells them apart
+    // at all. Falls back to the tidied product string whenever the identity
+    // query failed or returned a model code outside the known table — an
+    // unrecognised model reports whatever the device called itself rather
+    // than a guess.
+    const name = identity?.displayName ?? incottNormalizeProductName(rawName);
 
     // The owner confirmed on hardware that the mouse only reaches 1000 Hz
     // over the cable — 2000/4000/8000 Hz are wireless-only (see

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -215,6 +215,21 @@ export interface MouseStatus {
   finalmouseDongleLedMode?: number | null;
   finalmouseTournamentScrollMode?: number | null;
   finalmouseTournamentScrollTimeoutMs?: number | null;
+  /**
+   * Incott's 2.4 GHz receiver LED: 0 connect & polling rate, 1 battery
+   * status, 2 battery warning. A property of the dongle, so it is omitted
+   * entirely over the cable rather than reported as a value the user cannot
+   * act on. Does not fit `dongleLedEnabled`, which is a boolean.
+   */
+  incottReceiverLedMode?: number | null;
+  /**
+   * Incott's "Fire Key" rapid-fire settings: how many clicks a press sends
+   * (1-3) and the gap between them in milliseconds (0-255). Global to the
+   * device — the command carries no button index, so these apply to whichever
+   * button is bound to the rapid-fire action.
+   */
+  incottFireKeyTimes?: number | null;
+  incottFireKeyIntervalMs?: number | null;
   signalStrength?: number | null;
   motionSync?: boolean | null;
   /** On-device DPI stages, where supported (Teevolution, Ninjutso, …). */

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import {
   incottDecodeBattery,
+  incottButtonActionCode,
+  incottButtonActionLabel,
   incottDecodeButtonBinding,
   incottDecodeDebounce,
   incottDecodeDpiStage,
@@ -36,6 +38,9 @@ import {
   incottPerformanceModeFromWire,
   incottPerformanceModeToWire,
   incottValidateDpi,
+  INCOTT_BUTTON_ACTIONS,
+  INCOTT_BUTTON_NAMES,
+  INCOTT_BUTTON_WIRE_INDEX,
   INCOTT_PERFORMANCE_MODE_FROM_WIRE,
   INCOTT_PERFORMANCE_MODE_NAMES,
   INCOTT_PERFORMANCE_MODE_TO_WIRE,
@@ -463,34 +468,87 @@ test("input-report decode rejects out-of-byte-range inputs", () => {
   assert.equal(incottDecodeInputStatus(0x00, 256), null);
 });
 
-test("button binding encodes the raw three-byte payload under command 0x06", () => {
+test("button binding encodes the 32-bit action little-endian under command 0x06", () => {
   // Captured 2026-09-08: the vendor tool wrote `09 06 00 01 00 f0` to button
-  // 0. This is a codec for the raw bytes only — see incottEncodeSetButtonBinding.
-  assert.deepEqual(bytes(incottEncodeSetButtonBinding(0, [0x01, 0x00, 0xf0])).slice(0, 5), [0x06, 0x00, 0x01, 0x00, 0xf0]);
+  // 0, which is 0x00F00001 (left click) little-endian.
+  assert.deepEqual(
+    bytes(incottEncodeSetButtonBinding(0, 0x00f00001)).slice(0, 6),
+    [0x06, 0x00, 0x01, 0x00, 0xf0, 0x00],
+  );
+  // A code needing all four bytes: rapid fire. The old three-byte codec
+  // dropped the 0x02 here.
+  assert.deepEqual(
+    bytes(incottEncodeSetButtonBinding(5, 0x0218f00a)).slice(0, 6),
+    [0x06, 0x05, 0x0a, 0xf0, 0x18, 0x02],
+  );
 });
 
 test("button binding rejects a button index outside 0-5", () => {
-  assert.throws(() => incottEncodeSetButtonBinding(6, [0, 0, 0]), RangeError);
-  assert.throws(() => incottEncodeSetButtonBinding(-1, [0, 0, 0]), RangeError);
+  assert.throws(() => incottEncodeSetButtonBinding(6, 0), RangeError);
+  assert.throws(() => incottEncodeSetButtonBinding(-1, 0), RangeError);
 });
 
-test("button binding decodes all six buttons, pinned to the real capture", () => {
-  // Captured on real hardware 2026-09-08, reading each of the six buttons
-  // (left, right, middle, forward, back, DPI, in some physical order):
-  //   09 86 00 -> bytes 3-5 = 01 00 f0
-  //   09 86 01 -> bytes 3-5 = 01 00 f1
-  //   09 86 02 -> bytes 3-5 = 01 00 f2
-  //   09 86 03 -> bytes 3-5 = 01 00 f3
-  //   09 86 04 -> bytes 3-5 = 01 00 f4
-  //   09 86 05 -> bytes 3-5 = 07 00 03
-  // Button 0's read-back matches byte-for-byte what the vendor tool wrote
-  // (`09 06 00 01 00 f0`) — the round-trip proof this codec is correct.
-  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x00, 0x01, 0x00, 0xf0), 0), { button: 0, b0: 0x01, b1: 0x00, b2: 0xf0 });
-  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x01, 0x01, 0x00, 0xf1), 1), { button: 1, b0: 0x01, b1: 0x00, b2: 0xf1 });
-  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x02, 0x01, 0x00, 0xf2), 2), { button: 2, b0: 0x01, b1: 0x00, b2: 0xf2 });
-  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x03, 0x01, 0x00, 0xf3), 3), { button: 3, b0: 0x01, b1: 0x00, b2: 0xf3 });
-  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x04, 0x01, 0x00, 0xf4), 4), { button: 4, b0: 0x01, b1: 0x00, b2: 0xf4 });
-  assert.deepEqual(incottDecodeButtonBinding(frame(0x86, 0x05, 0x07, 0x00, 0x03), 5), { button: 5, b0: 0x07, b1: 0x00, b2: 0x03 });
+test("every factory binding read from hardware decodes to the vendor's own action code", () => {
+  // Captured on real hardware 2026-09-08, reading each of the six buttons.
+  // Every one matches the code the vendor bundle's `kf_hw()` encoder returns
+  // for that function — an independent confirmation of the whole mouse
+  // action table, not just one row.
+  //
+  // Note buttons 3 and 4: wire index 3 answers 0xF3 (fmsBACK) and wire index
+  // 4 answers 0xF4 (fmsFORWARD). That is the `matrix` transposition in
+  // INCOTT_BUTTON_WIRE_INDEX, confirmed on hardware.
+  const expected: ReadonlyArray<readonly [number, number, number, string]> = [
+    [0, 0xf0, 0x00f00001, "Left click"],
+    [1, 0xf1, 0x00f10001, "Right click"],
+    [2, 0xf2, 0x00f20001, "Middle click"],
+    [3, 0xf3, 0x00f30001, "Back"],
+    [4, 0xf4, 0x00f40001, "Forward"],
+  ];
+  for (const [index, high, code, label] of expected) {
+    assert.deepEqual(
+      incottDecodeButtonBinding(frame(0x86, index, 0x01, 0x00, high), index),
+      { button: index, code, label },
+    );
+  }
+  // The DPI button: `07 00 03` -> 0x00030007, kf_hw's favDPI.
+  assert.deepEqual(
+    incottDecodeButtonBinding(frame(0x86, 0x05, 0x07, 0x00, 0x03), 5),
+    { button: 5, code: 0x00030007, label: "DPI cycle" },
+  );
+});
+
+test("button binding decodes the top byte instead of truncating it", () => {
+  // Regression: the decoder used to read only frame bytes 3-5, so rapid fire
+  // (0x0218F00A) came back as 0x0018F00A and matched no action at all.
+  assert.deepEqual(
+    incottDecodeButtonBinding(frame(0x86, 0x03, 0x0a, 0xf0, 0x18, 0x02), 3),
+    { button: 3, code: 0x0218f00a, label: "Rapid fire" },
+  );
+});
+
+test("button binding reports an unknown action's raw code rather than a label", () => {
+  // A keyboard binding: 'A' (HID 0x04) with no modifier is 0x0480 by the
+  // vendor's parametric rule, which no entry in the action table covers.
+  const binding = incottDecodeButtonBinding(frame(0x86, 0x00, 0x80, 0x04, 0x00, 0x00), 0);
+  assert.equal(binding?.code, 0x00000480);
+  assert.equal(binding?.label, null);
+});
+
+test("button action labels and codes round-trip through the table", () => {
+  for (const [label, code] of INCOTT_BUTTON_ACTIONS) {
+    assert.equal(incottButtonActionCode(label), code, label);
+    assert.equal(incottButtonActionLabel(code), label, label);
+  }
+  assert.equal(incottButtonActionCode("Not a real action"), null);
+  assert.equal(incottButtonActionLabel(0x12345678), null);
+});
+
+test("Forward and Back are transposed between display order and the wire", () => {
+  // The vendor addresses buttons by a `matrix` field, not array position.
+  // Getting this wrong swaps two buttons silently.
+  assert.equal(INCOTT_BUTTON_WIRE_INDEX.Forward, 4);
+  assert.equal(INCOTT_BUTTON_WIRE_INDEX.Back, 3);
+  assert.deepEqual(INCOTT_BUTTON_NAMES.map((n) => INCOTT_BUTTON_WIRE_INDEX[n]), [0, 1, 2, 4, 3, 5]);
 });
 
 test("button binding rejects a frame answering a different button (sub-command echo)", () => {

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -8,7 +8,7 @@ import {
   incottDecodeButtonBinding,
   incottDecodeDebounce,
   incottDecodeDpiStage,
-  incottDecodeDpiStageIndex,
+  incottDecodeDpiCycle,
   incottDecodeIdentity,
   incottDecodeInputStatus,
   incottDecodeLiftOff,
@@ -20,7 +20,7 @@ import {
   incottDecodeSleep,
   incottDecodeToggle,
   incottEncodeQuery,
-  incottEncodeSetActiveDpiStage,
+  incottEncodeSetDpiCycle,
   incottEncodeSetButtonBinding,
   incottEncodeSetDebounce,
   incottEncodeSetDpi,
@@ -184,34 +184,51 @@ test("incottFrameMatches rejects a frame carrying the wrong report ID", () => {
   assert.equal(incottFrameMatches(wrong, 0x85, 0x03), false);
 });
 
-test("0x83/0x06 decodes the active DPI STAGE INDEX, not a DPI value", () => {
-  // Captured 2026-09-07 against the vendor tool: 09 83 06 01 -> stage 1 of 6.
-  // Decoding byte 3 as an index into the six default presets used to yield
-  // 800 DPI here, which matched the vendor UI only by coincidence.
-  assert.equal(incottDecodeDpiStageIndex(frame(0x83, 0x06, 0x01)), 1);
-  assert.equal(incottDecodeDpiStageIndex(frame(0x83, 0x06, 0x00)), 0);
-  assert.equal(incottDecodeDpiStageIndex(frame(0x83, 0x06, 0x05)), 5);
+test("0x83 decodes the stage COUNT and the active index, not a DPI value", () => {
+  // Captured 2026-09-07 against the vendor tool: 09 83 06 01 -> a six-stage
+  // cycle sitting on stage 1. Decoding byte 3 as an index into the six
+  // default presets used to yield 800 DPI here, which matched the vendor UI
+  // only by coincidence.
+  assert.deepEqual(incottDecodeDpiCycle(frame(0x83, 0x06, 0x01)), { count: 6, active: 1 });
+  assert.deepEqual(incottDecodeDpiCycle(frame(0x83, 0x06, 0x00)), { count: 6, active: 0 });
+  assert.deepEqual(incottDecodeDpiCycle(frame(0x83, 0x06, 0x05)), { count: 6, active: 5 });
 });
 
-test("DPI stage index returns null outside 0-5", () => {
-  assert.equal(incottDecodeDpiStageIndex(frame(0x83, 0x06, 0x06)), null);
+test("REGRESSION: 0x83 byte 2 is data, so a cycle shorter than six still decodes", () => {
+  // This is what the old decoder got wrong. It required byte 2 to equal the
+  // 0x06 the driver had sent, treating it as a sub-command echo — which only
+  // held because the count on the device under test happened to be six. A
+  // four-stage mouse would have failed every DPI read.
+  assert.deepEqual(incottDecodeDpiCycle(frame(0x83, 0x04, 0x03)), { count: 4, active: 3 });
+  assert.deepEqual(incottDecodeDpiCycle(frame(0x83, 0x01, 0x00)), { count: 1, active: 0 });
 });
 
-test("incottEncodeSetActiveDpiStage encodes 09 03 06 <idx> for every stage 0-5", () => {
-  // Command 0x03, sub-command INCOTT_SUB_DPI_STAGE (0x06), then the stage
-  // index — verified on hardware 2026-09-08 by selecting stages 0, 3, 5, then
-  // 1 and reading each back correctly via 0x83/0x06.
-  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(0)).slice(0, 3), [0x03, 0x06, 0x00]);
-  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(1)).slice(0, 3), [0x03, 0x06, 0x01]);
-  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(2)).slice(0, 3), [0x03, 0x06, 0x02]);
-  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(3)).slice(0, 3), [0x03, 0x06, 0x03]);
-  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(4)).slice(0, 3), [0x03, 0x06, 0x04]);
-  assert.deepEqual(bytes(incottEncodeSetActiveDpiStage(5)).slice(0, 3), [0x03, 0x06, 0x05]);
+test("DPI cycle rejects a count out of range or an active stage outside it", () => {
+  assert.equal(incottDecodeDpiCycle(frame(0x83, 0x07, 0x00)), null, "count above the table size");
+  assert.equal(incottDecodeDpiCycle(frame(0x83, 0x00, 0x00)), null, "zero-length cycle");
+  assert.equal(incottDecodeDpiCycle(frame(0x83, 0x04, 0x04)), null, "active stage past the cycle");
+  assert.equal(incottDecodeDpiCycle(frame(0x83, 0x06, 0x06)), null);
 });
 
-test("incottEncodeSetActiveDpiStage rejects a stage index outside 0-5", () => {
-  assert.throws(() => incottEncodeSetActiveDpiStage(6), RangeError);
-  assert.throws(() => incottEncodeSetActiveDpiStage(-1), RangeError);
+test("incottEncodeSetDpiCycle encodes 09 03 <count> <idx> for every stage 0-5", () => {
+  // Verified on hardware 2026-09-08 by selecting stages 0, 3, 5, then 1 and
+  // reading each back correctly.
+  for (let stage = 0; stage < 6; stage += 1) {
+    assert.deepEqual(bytes(incottEncodeSetDpiCycle(6, stage)).slice(0, 3), [0x03, 0x06, stage]);
+  }
+  // A shorter cycle writes its own count, not a hardcoded six.
+  assert.deepEqual(bytes(incottEncodeSetDpiCycle(3, 2)).slice(0, 3), [0x03, 0x03, 0x02]);
+});
+
+test("incottEncodeSetDpiCycle rejects a stage outside the cycle it is given", () => {
+  assert.throws(() => incottEncodeSetDpiCycle(3, 3), RangeError);
+  assert.throws(() => incottEncodeSetDpiCycle(0, 0), RangeError);
+  assert.throws(() => incottEncodeSetDpiCycle(7, 0), RangeError);
+});
+
+test("incottEncodeSetDpiCycle rejects a stage index outside 0-5", () => {
+  assert.throws(() => incottEncodeSetDpiCycle(6, 6), RangeError);
+  assert.throws(() => incottEncodeSetDpiCycle(6, -1), RangeError);
 });
 
 test("selecting the active stage (0x03) is byte-for-byte distinct from editing a stage's value (0x02) — the bug this driver used to have", () => {
@@ -221,7 +238,7 @@ test("selecting the active stage (0x03) is byte-for-byte distinct from editing a
   // commands with different opcodes and different payload shapes: the select
   // carries only a stage index (no DPI value at all), the edit carries a
   // 2-byte DPI wire value and no fixed sub-command byte.
-  const select = incottEncodeSetActiveDpiStage(4);
+  const select = incottEncodeSetDpiCycle(6, 4);
   const edit = incottEncodeSetDpi(4, 3200);
   assert.notEqual(select[0], edit[0], "different command bytes (0x03 vs 0x02)");
   assert.deepEqual(bytes(select).slice(0, 3), [0x03, 0x06, 0x04]);

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -11,6 +11,7 @@ import {
   incottDecodeDpiCycle,
   incottDecodeFireKey,
   incottDecodeIdentity,
+  incottDpiMaxForSensor,
   incottDecodeInputStatus,
   incottDecodeLiftOff,
   incottDecodeLiftOffDirect,
@@ -935,4 +936,22 @@ test("a macro button binding reads back as its slot", () => {
   assert.equal(binding?.label, "Macro 4");
   // Not offered as a writable option: there is no UI to author one.
   assert.equal(incottButtonActionCode("Macro 4"), null);
+});
+
+test("the offered DPI ceiling follows the fitted sensor", () => {
+  // The vendor builds its DPI table from the sensor: PAW3395 stops at 32000,
+  // PAW3950 reaches 45000. Every Incott model shares one protocol and one
+  // device definition, so this is the only thing that varies between them.
+  assert.equal(incottDpiMaxForSensor(INCOTT_SENSOR_PAW3395), 32000);
+  assert.equal(incottDpiMaxForSensor(INCOTT_SENSOR_PAW3950), 45000);
+  // Unknown or unreadable falls back to the higher ceiling: narrowing on a
+  // guess would hide DPI the mouse can actually reach.
+  assert.equal(incottDpiMaxForSensor(null), 45000);
+  assert.equal(incottDpiMaxForSensor(0x1234), 45000);
+});
+
+test("the encoder still accepts the full range regardless of sensor", () => {
+  // Same split as the polling rate: readStatus narrows what is OFFERED, the
+  // codec keeps accepting anything the protocol can express.
+  assert.doesNotThrow(() => incottEncodeSetDpi(0, 45000));
 });

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -628,18 +628,25 @@ test("identity decodes the model, sensor and receiver from the G23V2 capture", (
   assert.equal(identity?.is8KReceiver, true);
 });
 
-test("identity reads the fitted sensor from byte 6, so the name is the same wired and wireless", () => {
-  // Bytes 5 and 6 disagree (f0/f1) on this device. The vendor picks between
-  // them by connection and so renames the same physical mouse when a cable
-  // goes in; byte 6 is the full-capability slot and is used unconditionally
-  // here. See `incottDecodeIdentity` for why, and for how to falsify it.
-  const identity = incottDecodeIdentity(IDENTITY_G23V2);
-  assert.equal(identity?.sensorId, INCOTT_SENSOR_PAW3950);
-  assert.equal(identity?.isPro, true);
-  assert.equal(identity?.displayName, "G23V2 Pro");
+test("identity finds the PAW3950 whichever slot the receiver puts it in", () => {
+  // The sensor slot MOVES with the receiver. Both of these are the same
+  // physical mouse on the cable, captured with and without the dongle
+  // plugged in — see `incottDecodeIdentity`.
+  const withDongle = incottDecodeIdentity(IDENTITY_G23V2);
+  assert.equal(withDongle?.sensorId, INCOTT_SENSOR_PAW3950);
+  assert.equal(withDongle?.displayName, "G23V2 Pro");
+  assert.equal(withDongle?.is8KReceiver, true);
+
+  // Cable only, captured 2026-09-11: 0xF1 has moved to byte 5 and byte 6 is
+  // empty. Reading byte 6 alone reported a PAW3395 here and dropped the
+  // "Pro" — the bug this replaced.
+  const cableOnly = incottDecodeIdentity(frame(0x8f, 0x01, 0x0e, 0x00, 0xf1, 0x00, 0x00, 0x00));
+  assert.equal(cableOnly?.sensorId, INCOTT_SENSOR_PAW3950);
+  assert.equal(cableOnly?.displayName, "G23V2 Pro");
+  assert.equal(cableOnly?.is8KReceiver, false, "no dongle, so no 8K receiver");
 });
 
-test("identity reports the PAW3395 and drops the Pro suffix when byte 6 is 0xf0", () => {
+test("identity reports the PAW3395 only when no slot carries 0xf1", () => {
   const identity = incottDecodeIdentity(frame(0x8f, 0x01, 0x0e, 0x02, 0xf0, 0xf0, 0x00, 0xff));
   assert.equal(identity?.sensorId, INCOTT_SENSOR_PAW3395);
   assert.equal(identity?.isPro, false);

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -9,6 +9,7 @@ import {
   incottDecodeDebounce,
   incottDecodeDpiStage,
   incottDecodeDpiCycle,
+  incottDecodeFireKey,
   incottDecodeIdentity,
   incottDecodeInputStatus,
   incottDecodeLiftOff,
@@ -26,6 +27,7 @@ import {
   incottEncodeSetDebounce,
   incottEncodeSetDpi,
   incottEncodeSetDpiCycle,
+  incottEncodeSetFireKey,
   incottEncodeSetLiftOff,
   incottEncodeSetPerformanceMode,
   incottEncodeSetPollingRate,
@@ -874,4 +876,33 @@ test("macro chunking covers the whole buffer without the vendor's slice bug", ()
   assert.ok(chunks.every((chunk) => chunk.length === 32));
   assert.deepEqual([...chunks.flatMap((chunk) => [...chunk])], [...buffer], "chunks rejoin to the original");
   assert.throws(() => incottMacroChunks(new Uint8Array(319)), RangeError);
+});
+
+test("fire key encodes times and interval under 0x05/0x02", () => {
+  // The last unidentified command in the protocol. The vendor's setFKeyPm
+  // clamps its two arguments to 3 and 255, and its UI labels them "times"
+  // and "interval" ("Keep left-clicking according to the interval and
+  // times").
+  assert.deepEqual(bytes(incottEncodeSetFireKey(3, 10)).slice(0, 4), [0x05, 0x02, 0x03, 0x0a]);
+  assert.deepEqual(bytes(incottEncodeSetFireKey(1, 255)).slice(0, 4), [0x05, 0x02, 0x01, 0xff]);
+});
+
+test("fire key rejects a times or interval the device cannot hold", () => {
+  assert.throws(() => incottEncodeSetFireKey(4, 10), RangeError);
+  assert.throws(() => incottEncodeSetFireKey(-1, 10), RangeError);
+  assert.throws(() => incottEncodeSetFireKey(3, 256), RangeError);
+  assert.throws(() => incottEncodeSetFireKey(3, -1), RangeError);
+});
+
+test("fire key decodes the live hardware reading", () => {
+  // Read from the device 2026-09-11: 09 85 02 03 0a.
+  assert.deepEqual(incottDecodeFireKey(frame(0x85, 0x02, 0x03, 0x0a)), { times: 3, intervalMs: 10 });
+  assert.deepEqual(incottDecodeFireKey(frame(0x85, 0x02, 0x01, 0x32)), { times: 1, intervalMs: 50 });
+});
+
+test("fire key rejects a frame from another sub-command or one too short", () => {
+  assert.equal(incottDecodeFireKey(frame(0x85, 0x01, 0x04)), null, "debounce, not fire key");
+  assert.equal(incottDecodeFireKey(frame(0x85, 0x03, 0x3c, 0x00)), null, "sleep, not fire key");
+  assert.equal(incottDecodeFireKey(new Uint8Array([0x09, 0x85, 0x02, 0x03])), null, "no interval byte");
+  assert.equal(incottDecodeFireKey(frame(0x85, 0x02, 0x09, 0x0a)), null, "times above the maximum");
 });

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -20,10 +20,12 @@ import {
   incottDecodeSleep,
   incottDecodeToggle,
   incottEncodeQuery,
-  incottEncodeSetDpiCycle,
+  incottEncodeMacroBuffer,
+  incottEncodeMacroChunkHeader,
   incottEncodeSetButtonBinding,
   incottEncodeSetDebounce,
   incottEncodeSetDpi,
+  incottEncodeSetDpiCycle,
   incottEncodeSetLiftOff,
   incottEncodeSetPerformanceMode,
   incottEncodeSetPollingRate,
@@ -33,6 +35,7 @@ import {
   incottFrameMatches,
   incottIsWiredProduct,
   incottKeyboardActionCode,
+  incottMacroChunks,
   incottLiftOffLabel,
   incottLiftOffTenths,
   incottNormalizeProductName,
@@ -51,6 +54,7 @@ import {
   INCOTT_PRODUCT_ID_WIRED,
   INCOTT_SENSOR_PAW3395,
   INCOTT_SENSOR_PAW3950,
+  type IncottMacroLoop,
 } from "./index.ts";
 
 const bytes = (frame: Uint8Array): number[] => Array.from(frame);
@@ -800,4 +804,74 @@ test("REGRESSION: the performance-mode mapping is NOT the vendor UI's left-to-ri
   assert.notEqual(incottPerformanceModeToWire("HP"), INCOTT_PERFORMANCE_MODE_NAMES.indexOf("HP"));
   assert.deepEqual(INCOTT_PERFORMANCE_MODE_TO_WIRE, { HP: 2, Corded: 1, LP: 0 });
   assert.deepEqual(INCOTT_PERFORMANCE_MODE_FROM_WIRE, { 2: "HP", 1: "Corded", 0: "LP" });
+});
+
+test("macro buffer encodes the header, steps and trailer from the vendor's juji_to_hw", () => {
+  const buffer = incottEncodeMacroBuffer({
+    bufferId: 2,
+    loop: "cycle",
+    cycles: 300,
+    uid: 0x12345678,
+    steps: [
+      { key: 0x04, press: true, delayMs: 50 },   // 'A' down
+      { key: 0x04, press: false, delayMs: 1000 }, // 'A' up
+    ],
+  });
+  assert.equal(buffer.length, 320);
+  assert.equal(buffer[0], 2, "buffer id");
+  assert.equal(buffer[1], 2, "loop mode: cycle");
+  assert.deepEqual([buffer[2], buffer[3]], [0x2c, 0x01], "cycles 300 LE16");
+
+  // A press sets bit 0 only; a release also sets bit 7.
+  assert.deepEqual([...buffer.slice(4, 8)], [0x01, 0x04, 50, 0]);
+  assert.deepEqual([...buffer.slice(8, 12)], [0x81, 0x04, 0xe8, 0x03]);
+
+  // "Macro3" — the name is 1-based where the buffer id is 0-based.
+  assert.equal(String.fromCharCode(...buffer.slice(288, 294)), "Macro3");
+
+  const size = (2 + 1) * 132;
+  assert.deepEqual([...buffer.slice(304, 308)], [size & 0xff, (size >> 8) & 0xff, 0, 0]);
+  assert.deepEqual([...buffer.slice(308, 312)], [16, 0, 232, 232]);
+  assert.deepEqual([...buffer.slice(312, 316)], [0x78, 0x56, 0x34, 0x12], "uid LE32");
+  assert.deepEqual([...buffer.slice(316, 319)], [4, 0, 2], "steps*2 LE16, then the step count");
+});
+
+test("macro loop modes map to their wire values in order", () => {
+  const at = (loop: IncottMacroLoop): number =>
+    incottEncodeMacroBuffer({ bufferId: 0, loop, cycles: 0, uid: 0, steps: [] })[1]!;
+  assert.equal(at("untilKeyRelease"), 0);
+  assert.equal(at("untilAnyKey"), 1);
+  assert.equal(at("cycle"), 2);
+});
+
+test("macro encoders reject an out-of-range buffer, chunk or step count", () => {
+  const base = { bufferId: 0, loop: "cycle" as const, cycles: 0, uid: 0, steps: [] };
+  assert.throws(() => incottEncodeMacroBuffer({ ...base, bufferId: 10 }), RangeError);
+  assert.throws(
+    () => incottEncodeMacroBuffer({
+      ...base,
+      steps: Array.from({ length: 72 }, () => ({ key: 4, press: true, delayMs: 0 })),
+    }),
+    RangeError,
+  );
+  assert.throws(() => incottEncodeMacroChunkHeader(10, 0), RangeError);
+  assert.throws(() => incottEncodeMacroChunkHeader(0, 10), RangeError);
+});
+
+test("macro chunk headers announce ten 32-byte chunks under command 0x07", () => {
+  assert.deepEqual(bytes(incottEncodeMacroChunkHeader(0, 3)).slice(0, 5), [0x07, 0x0a, 0x00, 0x20, 0x03]);
+  assert.deepEqual(bytes(incottEncodeMacroChunkHeader(9, 0)).slice(0, 5), [0x07, 0x0a, 0x09, 0x20, 0x00]);
+});
+
+test("macro chunking covers the whole buffer without the vendor's slice bug", () => {
+  // The vendor slices `mda.slice(i * 32, i * 64)`, which is EMPTY for i = 0.
+  const buffer = incottEncodeMacroBuffer({
+    bufferId: 0, loop: "cycle", cycles: 1, uid: 0,
+    steps: [{ key: 0x04, press: true, delayMs: 1 }],
+  });
+  const chunks = incottMacroChunks(buffer);
+  assert.equal(chunks.length, 10);
+  assert.ok(chunks.every((chunk) => chunk.length === 32));
+  assert.deepEqual([...chunks.flatMap((chunk) => [...chunk])], [...buffer], "chunks rejoin to the original");
+  assert.throws(() => incottMacroChunks(new Uint8Array(319)), RangeError);
 });

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -551,10 +551,10 @@ test("button binding decodes the top byte instead of truncating it", () => {
 });
 
 test("button binding reports an unknown action's raw code rather than a label", () => {
-  // A macro binding (slot 1): `slot << 16 | 9`, which the action table
-  // deliberately does not cover — macros need the 0x07 upload command.
-  const binding = incottDecodeButtonBinding(frame(0x86, 0x00, 0x09, 0x00, 0x01, 0x00), 0);
-  assert.equal(binding?.code, 0x00010009);
+  // Not a mouse, media, keyboard or macro encoding — nothing this driver can
+  // name, so it must round-trip as a raw value rather than be mislabelled.
+  const binding = incottDecodeButtonBinding(frame(0x86, 0x00, 0x78, 0x56, 0x34, 0x12), 0);
+  assert.equal(binding?.code, 0x12345678);
   assert.equal(binding?.label, null);
 });
 
@@ -808,36 +808,6 @@ test("REGRESSION: the performance-mode mapping is NOT the vendor UI's left-to-ri
   assert.deepEqual(INCOTT_PERFORMANCE_MODE_FROM_WIRE, { 2: "HP", 1: "Corded", 0: "LP" });
 });
 
-test("macro buffer encodes the header, steps and trailer from the vendor's juji_to_hw", () => {
-  const buffer = incottEncodeMacroBuffer({
-    bufferId: 2,
-    loop: "cycle",
-    cycles: 300,
-    uid: 0x12345678,
-    steps: [
-      { key: 0x04, press: true, delayMs: 50 },   // 'A' down
-      { key: 0x04, press: false, delayMs: 1000 }, // 'A' up
-    ],
-  });
-  assert.equal(buffer.length, 320);
-  assert.equal(buffer[0], 2, "buffer id");
-  assert.equal(buffer[1], 2, "loop mode: cycle");
-  assert.deepEqual([buffer[2], buffer[3]], [0x2c, 0x01], "cycles 300 LE16");
-
-  // A press sets bit 0 only; a release also sets bit 7.
-  assert.deepEqual([...buffer.slice(4, 8)], [0x01, 0x04, 50, 0]);
-  assert.deepEqual([...buffer.slice(8, 12)], [0x81, 0x04, 0xe8, 0x03]);
-
-  // "Macro3" — the name is 1-based where the buffer id is 0-based.
-  assert.equal(String.fromCharCode(...buffer.slice(288, 294)), "Macro3");
-
-  const size = (2 + 1) * 132;
-  assert.deepEqual([...buffer.slice(304, 308)], [size & 0xff, (size >> 8) & 0xff, 0, 0]);
-  assert.deepEqual([...buffer.slice(308, 312)], [16, 0, 232, 232]);
-  assert.deepEqual([...buffer.slice(312, 316)], [0x78, 0x56, 0x34, 0x12], "uid LE32");
-  assert.deepEqual([...buffer.slice(316, 319)], [4, 0, 2], "steps*2 LE16, then the step count");
-});
-
 test("macro loop modes map to their wire values in order", () => {
   const at = (loop: IncottMacroLoop): number =>
     incottEncodeMacroBuffer({ bufferId: 0, loop, cycles: 0, uid: 0, steps: [] })[1]!;
@@ -905,4 +875,64 @@ test("fire key rejects a frame from another sub-command or one too short", () =>
   assert.equal(incottDecodeFireKey(frame(0x85, 0x03, 0x3c, 0x00)), null, "sleep, not fire key");
   assert.equal(incottDecodeFireKey(new Uint8Array([0x09, 0x85, 0x02, 0x03])), null, "no interval byte");
   assert.equal(incottDecodeFireKey(frame(0x85, 0x02, 0x09, 0x0a)), null, "times above the maximum");
+});
+
+test("the macro buffer reproduces a real capture byte for byte", () => {
+  // Captured from Incott's own configurator 2026-09-11 saving "first macro"
+  // to buffer 3: L/K/F/Y pressed and released with the delays shown in the
+  // vendor UI, looping until any key is pressed, one cycle.
+  const buffer = incottEncodeMacroBuffer({
+    bufferId: 3,
+    loop: "untilAnyKey",
+    cycles: 1,
+    uid: 0x8fba0e90,
+    steps: [
+      { key: 0x0f, press: true, delayMs: 124 },   // L down
+      { key: 0x0f, press: false, delayMs: 1510 }, // L up
+      { key: 0x0e, press: true, delayMs: 157 },   // K down
+      { key: 0x0e, press: false, delayMs: 1104 }, // K up
+      { key: 0x09, press: true, delayMs: 135 },   // F down
+      { key: 0x09, press: false, delayMs: 1713 }, // F up
+      { key: 0x1c, press: true, delayMs: 140 },   // Y down
+      { key: 0x1c, press: false, delayMs: 0 },    // Y up
+    ],
+  });
+  const hex = (from: number, to: number): string =>
+    [...buffer.slice(from, to)].map((b) => b.toString(16).padStart(2, "0")).join(" ");
+
+  // Chunk 0 exactly as the vendor sent it.
+  assert.equal(
+    hex(0, 32),
+    "03 01 01 00 01 0f 7c 00 81 0f e6 05 01 0e 9d 00 81 0e 50 04 01 09 87 00 81 09 b1 06 01 1c 8c 00",
+  );
+  // Chunk 1: the final release, then the step area runs out into zeros.
+  assert.equal(hex(32, 36), "81 1c 00 00");
+  assert.ok(buffer.slice(36, 288).every((byte) => byte === 0), "nothing between the steps and the trailer");
+  // Chunk 9, the trailer. 0xa4 = 164 = (8 + 1) * 4 + 128 — the constant an
+  // earlier transcription had as 132.
+  assert.equal(
+    hex(288, 320),
+    "4d 61 63 72 6f 34 00 00 00 00 00 00 00 00 00 00 a4 00 00 00 10 00 e8 e8 90 0e ba 8f 10 00 08 00",
+  );
+});
+
+test("macro chunk headers match the captured upload", () => {
+  // TX feature  07 0a 00 20 03  ... through  07 0a 09 20 03
+  for (let index = 0; index < 10; index += 1) {
+    assert.deepEqual(
+      bytes(incottEncodeMacroChunkHeader(index, 3)).slice(0, 5),
+      [0x07, 0x0a, index, 0x20, 0x03],
+    );
+  }
+});
+
+test("a macro button binding reads back as its slot", () => {
+  // The capture ended with `06 04 09 00 03 00` — button wire index 4 bound to
+  // macro slot 3, encoded as slot << 16 | 9.
+  assert.equal(incottButtonActionLabel(0x00030009), "Macro 4");
+  assert.equal(incottButtonActionLabel(0x00000009), "Macro 1");
+  const binding = incottDecodeButtonBinding(frame(0x86, 0x04, 0x09, 0x00, 0x03, 0x00), 4);
+  assert.equal(binding?.label, "Macro 4");
+  // Not offered as a writable option: there is no UI to author one.
+  assert.equal(incottButtonActionCode("Macro 4"), null);
 });

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -43,6 +43,8 @@ import {
   INCOTT_POLLING_STEPS_HZ_WIRED,
   INCOTT_PRODUCT_ID,
   INCOTT_PRODUCT_ID_WIRED,
+  INCOTT_SENSOR_PAW3395,
+  INCOTT_SENSOR_PAW3950,
 } from "./index.ts";
 
 const bytes = (frame: Uint8Array): number[] => Array.from(frame);
@@ -511,6 +513,82 @@ test("identity returns the raw payload for display", () => {
 
 test("identity returns null when the frame is not an identity response", () => {
   assert.equal(incottDecodeIdentity(frame(0x84, 0x00)), null);
+});
+
+// The capture this contributor's hardware produced, wired and wireless
+// alike: 09 8f 01 0e 02 f0 f1 00 ff. Byte 3 (0x0e) is the model, byte 4
+// (0x02) the receiver, bytes 5/6 (f0/f1) the wired/wireless sensor.
+const IDENTITY_G23V2 = frame(0x8f, 0x01, 0x0e, 0x02, 0xf0, 0xf1, 0x00, 0xff);
+
+test("identity decodes the model, sensor and receiver from the G23V2 capture", () => {
+  const identity = incottDecodeIdentity(IDENTITY_G23V2);
+  assert.equal(identity?.model, "G23V2");
+  assert.equal(identity?.modelCode, 0x0e);
+  assert.equal(identity?.is8KReceiver, true);
+});
+
+test("identity reads the fitted sensor from byte 6, so the name is the same wired and wireless", () => {
+  // Bytes 5 and 6 disagree (f0/f1) on this device. The vendor picks between
+  // them by connection and so renames the same physical mouse when a cable
+  // goes in; byte 6 is the full-capability slot and is used unconditionally
+  // here. See `incottDecodeIdentity` for why, and for how to falsify it.
+  const identity = incottDecodeIdentity(IDENTITY_G23V2);
+  assert.equal(identity?.sensorId, INCOTT_SENSOR_PAW3950);
+  assert.equal(identity?.isPro, true);
+  assert.equal(identity?.displayName, "G23V2 Pro");
+});
+
+test("identity reports the PAW3395 and drops the Pro suffix when byte 6 is 0xf0", () => {
+  const identity = incottDecodeIdentity(frame(0x8f, 0x01, 0x0e, 0x02, 0xf0, 0xf0, 0x00, 0xff));
+  assert.equal(identity?.sensorId, INCOTT_SENSOR_PAW3395);
+  assert.equal(identity?.isPro, false);
+  assert.equal(identity?.displayName, "G23V2");
+});
+
+test("identity maps every model code the vendor's own dispatch knows", () => {
+  const codeToModel: ReadonlyArray<readonly [number, string]> = [
+    [0x01, "Ghero"],
+    [0x02, "G23"],
+    [0x03, "G24"],
+    [0x06, "Zero 29"],
+    [0x08, "G23V2"],
+    [0x09, "Zero 39"],
+    [0x0e, "G23V2"],
+  ];
+  for (const [code, model] of codeToModel) {
+    const identity = incottDecodeIdentity(frame(0x8f, 0x01, code, 0x02, 0xf0, 0xf0, 0x00, 0xff));
+    assert.equal(identity?.model, model, `model code 0x${code.toString(16)}`);
+    // byte 6 is 0xf0 here, so the PAW3395 profile and no "Pro" suffix.
+    assert.equal(identity?.displayName, model);
+  }
+});
+
+test("identity reports an unknown model code rather than guessing one", () => {
+  const identity = incottDecodeIdentity(frame(0x8f, 0x01, 0x7f, 0x02, 0xf0, 0xf1, 0x00, 0xff));
+  assert.notEqual(identity, null);
+  assert.equal(identity?.model, null);
+  assert.equal(identity?.displayName, null);
+  // The raw code is still surfaced, so an unrecognised device can be reported.
+  assert.equal(identity?.modelCode, 0x7f);
+});
+
+test("identity decodes no model when the guard byte is not 0x01", () => {
+  // The vendor abandons the device entirely on this; here it degrades to
+  // raw-only rather than decoding whatever happens to sit at byte 3.
+  const identity = incottDecodeIdentity(frame(0x8f, 0x00, 0x0e, 0x02, 0xf0, 0xf1, 0x00, 0xff));
+  assert.notEqual(identity, null);
+  assert.equal(identity?.model, null);
+  assert.equal(identity?.modelCode, null);
+  assert.equal(identity?.sensorId, null);
+});
+
+test("identity decodes no model from a frame too short to carry one", () => {
+  // Built directly rather than through `frame`, which always pads to 64.
+  const identity = incottDecodeIdentity(new Uint8Array([0x09, 0x8f, 0x01, 0x0e]));
+  assert.notEqual(identity, null);
+  assert.equal(identity?.model, null);
+  assert.equal(identity?.sensorId, null);
+  assert.equal(identity?.isPro, false);
 });
 
 test("incottIsWiredProduct is true only for the wired product id (0x622C), hardware-verified 2026-09-08", () => {

--- a/src/incott/index.test.ts
+++ b/src/incott/index.test.ts
@@ -32,6 +32,7 @@ import {
   incottEncodeSetToggle,
   incottFrameMatches,
   incottIsWiredProduct,
+  incottKeyboardActionCode,
   incottLiftOffLabel,
   incottLiftOffTenths,
   incottNormalizeProductName,
@@ -544,11 +545,36 @@ test("button binding decodes the top byte instead of truncating it", () => {
 });
 
 test("button binding reports an unknown action's raw code rather than a label", () => {
-  // A keyboard binding: 'A' (HID 0x04) with no modifier is 0x0480 by the
-  // vendor's parametric rule, which no entry in the action table covers.
-  const binding = incottDecodeButtonBinding(frame(0x86, 0x00, 0x80, 0x04, 0x00, 0x00), 0);
-  assert.equal(binding?.code, 0x00000480);
+  // A macro binding (slot 1): `slot << 16 | 9`, which the action table
+  // deliberately does not cover — macros need the 0x07 upload command.
+  const binding = incottDecodeButtonBinding(frame(0x86, 0x00, 0x09, 0x00, 0x01, 0x00), 0);
+  assert.equal(binding?.code, 0x00010009);
   assert.equal(binding?.label, null);
+});
+
+test("keyboard actions use a different shape with and without modifiers", () => {
+  // From the vendor's kf_hw() keyboard branch. An unmodified key sets the
+  // 0x80 marker in the low byte and sits one byte lower than a chord does —
+  // they are not the same form with a zero modifier.
+  assert.equal(incottKeyboardActionCode(0x04), 0x00000480, "'A' alone");
+  assert.equal(incottKeyboardActionCode(0x04, 0x01), 0x00040100, "Ctrl + A");
+  assert.equal(incottKeyboardActionCode(0x29, 0x01 | 0x02), 0x00290300, "Ctrl + Shift + Escape");
+});
+
+test("the action table offers keyboard keys and chords, and every label is unique", () => {
+  // The picker keys on the label, so a duplicate would make one action
+  // unreachable and silently write the other.
+  const labels = INCOTT_BUTTON_ACTIONS.map(([label]) => label);
+  assert.equal(new Set(labels).size, labels.length);
+
+  assert.equal(incottButtonActionCode("A"), 0x00000480);
+  assert.equal(incottButtonActionCode("F1"), 0x00003a80);
+  assert.equal(incottButtonActionCode("Ctrl + C"), 0x00060100);
+  assert.equal(incottButtonActionCode("Alt + Tab"), 0x002b0400);
+  // Still round-trips back to a label, so a key binding read from the mouse
+  // is not reported as unknown.
+  assert.equal(incottButtonActionLabel(0x00000480), "A");
+  assert.equal(incottButtonActionLabel(0x00060100), "Ctrl + C");
 });
 
 test("button action labels and codes round-trip through the table", () => {

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -650,8 +650,23 @@ export const INCOTT_SUB_DEBOUNCE = 0x01;
  * clicks, 10 ms apart.
  */
 export const INCOTT_SUB_FIRE_KEY = 0x02;
-/** Clicks per press. The vendor clamps to this; 0 is accepted but untested. */
+/**
+ * Clicks per press, 1-3 — the ceiling the vendor clamps to.
+ *
+ * `INCOTT_FIRE_KEY_TIMES_HOLD` (0) is a real fourth setting, not an absence
+ * of one: it switches the button from a fixed burst to firing continuously
+ * while held. Confirmed against the vendor software 2026-09-11 by the device
+ * owner, which is the only way it could have been established — the value is
+ * in range for the write either way, so a round-trip proves nothing about
+ * what it MEANS.
+ */
 export const INCOTT_FIRE_KEY_MAX_TIMES = 3;
+/**
+ * Fire key "times" value that means hold-to-fire: the button keeps clicking
+ * at the configured interval for as long as it is held, and stops on
+ * release. See `INCOTT_FIRE_KEY_MAX_TIMES`.
+ */
+export const INCOTT_FIRE_KEY_TIMES_HOLD = 0;
 /** Milliseconds between clicks in a burst, one byte. */
 export const INCOTT_FIRE_KEY_MAX_INTERVAL_MS = 255;
 export const INCOTT_SUB_SLEEP = 0x03;

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -149,7 +149,8 @@ export const INCOTT_CMD_SET_BUTTON = 0x06;
  * Announces one 32-byte chunk of a macro buffer:
  * `09 07 <chunks> <chunk index> <bytes per chunk> <buffer id>`.
  *
- * CODEC ONLY, AND NOT SENDABLE YET — see `incottEncodeMacroChunkHeader`.
+ * Each header is followed by the chunk itself as a 32-byte OUTPUT report on
+ * the same id — see `IncottHidClient.uploadMacro`.
  */
 export const INCOTT_CMD_MACRO_CHUNK = 0x07;
 export const INCOTT_CMD_SET_RECEIVER_LED = 0x08;
@@ -261,24 +262,28 @@ export const INCOTT_INPUT_REPORT_ID = INCOTT_REPORT_ID;
  *   1 -> 01 00 f1    4 -> 01 00 f4
  *   2 -> 01 00 f2    5 -> 07 00 03
  * (left, right, middle, forward, back, DPI — physically, in some order).
- * This was previously `INCOTT_CMD_UNKNOWN_86`, decoded only for the vendor
- * tool's own `09 86 09` query (still unexplained, kept as
- * `INCOTT_SUB_UNKNOWN_86_VENDOR_QUERY`). See `incottDecodeButtonBinding` —
- * only the raw three bytes are exposed; what `type`/`code` mean inside them
- * is NOT established and is not guessed at here.
+ * This was previously `INCOTT_CMD_UNKNOWN_86`. Sub-command `0x09` on the
+ * same command reads the onboard profile index instead — see
+ * `INCOTT_SUB_PROFILE_INDEX`. The binding itself is a 32-bit little-endian
+ * action word; see `incottDecodeButtonBinding`.
  */
 export const INCOTT_CMD_QUERY_BUTTON = 0x86;
 /** Button count: left, right, middle, forward, back, DPI. */
 export const INCOTT_BUTTON_COUNT = 6;
 /**
- * The vendor tool's own query, `09 86 09`. NOT a button index — buttons only
- * go up to 5. It reads the onboard profile index, the counterpart of the
- * `09 06 09 <index>` write (`setProfileIndex` in the vendor bundle). Neither
- * is implemented here: switching profiles in the vendor tool still replays
- * every setting individually, so what the device stores against the index is
- * unknown.
+ * Reads the onboard profile INDEX, `09 86 09` — not a button index, since
+ * buttons only go up to 5. Counterpart of the `09 06 09 <index>` write.
+ *
+ * Neither is implemented, and that is a finding rather than an omission: the
+ * index is real and sticks (0-3), but it gates nothing. Writing a setting
+ * while on one slot changes what every other slot reports, so there is a
+ * single settings store and the vendor replays every setting on a switch
+ * because the mouse holds none of them. Publishing OpenMouse's
+ * `profileCount`/`setProfile` contract — which describes ONBOARD profiles —
+ * would hand the user a selector that appears to work and does not. See
+ * `captures/incott-8k-wireless/profile-index-2026-09-11.hex`.
  */
-export const INCOTT_SUB_UNKNOWN_86_VENDOR_QUERY = 0x09;
+export const INCOTT_SUB_PROFILE_INDEX = 0x09;
 
 /**
  * Physical buttons, in left-to-right display order.
@@ -472,24 +477,18 @@ export const INCOTT_MACRO_MAX_STEPS = 71;
  *     [316..317] steps * 2, LE16
  *     [318]      step count
  *
- * NOT SENDABLE YET, and this is the reason no client method exists: the
- * buffer goes out as ten 32-byte chunks, each announced by
- * `incottEncodeMacroChunkHeader` and then followed by the chunk itself — and
- * the call that carries the chunk (`document.elsDevice` in the vendor bundle)
- * is never defined in any file the page loads. Its transport cannot be
- * recovered by reading the bundle: no `sendFeatureReport` or
- * `receiveFeatureReport` appears literally anywhere in it, because the method
- * names are resolved through variables at runtime.
+ * The buffer goes out as ten 32-byte chunks, each announced by
+ * `incottEncodeMacroChunkHeader` and then carried by a 32-byte OUTPUT report
+ * on the same report id — the only place this protocol uses an output report
+ * at all. That transport is not recoverable from the vendor bundle (the call
+ * carrying each chunk is defined in none of the files its page loads, and the
+ * HID method names resolve through variables at runtime), so it was captured
+ * from the running tool instead: see
+ * `captures/incott-8k-wireless/macro-upload-2026-09-11.hex`, and
+ * `IncottHidClient.uploadMacro` for the sender.
  *
- * It cannot be the ordinary path either. Every command in this protocol is an
- * 8-byte feature report on id `0x09`, which a 32-byte chunk does not fit, and
- * a read-only sweep of the other vendor collections (2026-09-11) found
- * `0xFF00` answering nothing at all.
- *
- * So this encoder exists to preserve a format that took real work to recover,
- * with tests pinning it. Wiring it up needs the transport identified first —
- * most likely by instrumenting the vendor tool while it saves a macro, the
- * same way `vendor-tool-session.hex` was captured.
+ * Pinned byte-for-byte to that capture. There is no macro READ command, so
+ * nothing here can be verified against the device after the fact.
  */
 export function incottEncodeMacroBuffer(macro: IncottMacro): Uint8Array {
   if (!Number.isInteger(macro.bufferId) || macro.bufferId < 0 || macro.bufferId >= INCOTT_MACRO_BUFFER_COUNT) {
@@ -913,13 +912,10 @@ export function incottValidateDpi(dpi: number): void {
  * PAYLOAD INDEX 7 IS AN AXIS BYTE, discovered 2026-09-10: the full write is
  * `02 <stage> <lo> <hi> 00 00 00 <axis>`, where `axis` 0 = both axes, 1 = X
  * only, 2 = Y only. This encoder always emits trailing zeros (see `payload`),
- * so it has only ever written axis 0 (both) — correct, but now for a known
- * reason rather than by accident. Independent X/Y is deliberately NOT
- * implemented: probing `0x82` with the axis byte set to 0, 1 and 2 returned
- * the identical value every time, i.e. there is no per-axis READ yet, and
- * this driver never ships a write it cannot verify. See
- * `docs/incott-testing.md` for the open question (find the read the vendor
- * tool uses to display separate X and Y DPI values) that would unblock this.
+ * and the `axis` argument selects it. Independent X/Y IS implemented and
+ * hardware-verified — the matching per-axis read is `incottEncodeQueryDpiAxis`,
+ * which an earlier probe concluded did not exist because X and Y happened to
+ * be equal at the time.
  */
 /**
  * Which axis a DPI write targets, and which one a read asks for.

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -614,9 +614,65 @@ export function incottEncodeQuery(cmd: number, sub: number = INCOTT_SUB_NONE): U
   return payload(cmd, sub);
 }
 
+/**
+ * The models that share `093A:522C`/`093A:622C`. All six enumerate under the
+ * same two product ids, so the USB descriptor cannot tell them apart — the
+ * model is carried in the identity reply instead (`incottDecodeIdentity`).
+ *
+ * "Zero 29"/"Zero 39" are the English series names the vendor's own
+ * `text_en` bundle uses (`msg94`/`msg95`); its code calls the same two models
+ * `G29` and `FM23` internally and renders them as 零29/零39.
+ */
+export type IncottModel = "Ghero" | "G23" | "G24" | "G23V2" | "Zero 29" | "Zero 39";
+
+/**
+ * Identity byte 3 -> model, transcribed from the vendor configurator's own
+ * `readDps()` dispatch. That dispatch is authoritative for all six models in
+ * a way one owner's device can never be; only the `0x0e` row is confirmed
+ * against hardware here, since this contributor has only a G23V2.
+ *
+ * `0x08` and `0x0e` BOTH mean G23V2 — the vendor tests them in a single
+ * branch (`8 == rData[2] || 14 == rData[2]`). Two hardware revisions of one
+ * model is the obvious reading, but that is an inference; what is certain is
+ * that the vendor maps both to the same name.
+ */
+const INCOTT_MODEL_BY_CODE: ReadonlyMap<number, IncottModel> = new Map<number, IncottModel>([
+  [0x01, "Ghero"],
+  [0x02, "G23"],
+  [0x03, "G24"],
+  [0x06, "Zero 29"],
+  [0x08, "G23V2"],
+  [0x09, "Zero 39"],
+  [0x0e, "G23V2"],
+]);
+
+/** PixArt PAW3395 — capped at 32000 DPI in the vendor's own DPI table. */
+export const INCOTT_SENSOR_PAW3395 = 0x3395;
+/** PixArt PAW3950 — capped at 45000 DPI, and what the "Pro" suffix means. */
+export const INCOTT_SENSOR_PAW3950 = 0x3950;
+
+/** Identity byte 2 is a fixed `0x01` guard; the vendor rejects the device otherwise. */
+const INCOTT_IDENTITY_GUARD = 0x01;
+/** Identity sensor byte: `0xF1` selects the PAW3950 profile, anything else the PAW3395. */
+const INCOTT_IDENTITY_SENSOR_PAW3950 = 0xf1;
+/** Identity byte 4 — `0x02` is the 8 KHz receiver. */
+const INCOTT_IDENTITY_8K_RECEIVER = 0x02;
+
 export interface IncottDeviceIdentity {
   /** Space-separated hex of the identity payload, for the details panel. */
   raw: string;
+  /** Decoded model, or null when byte 3 carries a code this table does not know. */
+  model: IncottModel | null;
+  /** Raw byte 3, kept even when unrecognised so an unknown model can still be reported. */
+  modelCode: number | null;
+  /** Model plus a " Pro" suffix when the PAW3950 is fitted, e.g. "G23V2 Pro". */
+  displayName: string | null;
+  /** The FITTED sensor, from byte 6: `INCOTT_SENSOR_PAW3395` or `INCOTT_SENSOR_PAW3950`. */
+  sensorId: number | null;
+  /** True when the PAW3950 is fitted — what the vendor's "Pro" suffix means. */
+  isPro: boolean;
+  /** True when byte 4 reports the 8 KHz receiver. */
+  is8KReceiver: boolean;
 }
 
 /**
@@ -899,12 +955,79 @@ export function incottDecodeButtonBinding(frame: Uint8Array, button: number): In
   return { button, b0: frame[3]!, b1: frame[4]!, b2: frame[5]! };
 }
 
+/**
+ * Decodes the identity reply (`09 8f 00` -> `09 8f 01 0e 02 f0 f1 00 ff`).
+ *
+ * Byte map, transcribed from the vendor configurator's `readDps()` and
+ * confirmed byte-for-byte against this contributor's G23V2 (capture
+ * 2026-09-07, `captures/incott-8k-wireless/query-sweep-0x80-0x8f.hex`):
+ *
+ *     byte 2  guard, always 0x01   -- the vendor abandons the device otherwise
+ *     byte 3  model code           -- 0x0e = G23V2, see INCOTT_MODEL_BY_CODE
+ *     byte 4  receiver type        -- 0x02 = 8 KHz receiver
+ *     byte 5  sensor profile, WIRED link    -- 0xF0 -> PAW3395, 0xF1 -> PAW3950
+ *     byte 6  sensor profile, WIRELESS link
+ *
+ * WHY BYTE 6 AND NOT BYTE 5: the vendor picks its sensor byte by connection
+ * (`let i = this.iswireless ? 5 : 4` over its own report-id-less buffer), and
+ * on this G23V2 the two bytes DISAGREE — `f0 f1`. Taken as hardware identity
+ * that is a contradiction: a mouse does not swap sensors when a cable goes
+ * in. Taken as a per-link CAPABILITY profile it is consistent, because the
+ * vendor feeds this value straight into `getStDPI(sensor)` to pick a DPI
+ * ceiling (PAW3395 -> 32000, PAW3950 -> 45000) — and the cable is already
+ * known to be the reduced-capability path on this device, capping polling at
+ * 1000 Hz (see `INCOTT_POLLING_STEPS_HZ_WIRED`).
+ *
+ * So the FITTED sensor is read from byte 6, the full-capability slot, and the
+ * decoded name is therefore stable across wired and wireless. The vendor's
+ * own tool is not: because it re-reads the byte by connection, it labels this
+ * one physical mouse "G23V2Pro" on the dongle and "G23V2" on the cable. That
+ * cosmetic flip is deliberately NOT mirrored — a model name that changes when
+ * you plug in a cable is a worse answer than the hardware's own.
+ *
+ * This is the one inference in this decoder rather than a transcription, and
+ * it is falsifiable: if the vendor tool ever shows "G23V2Pro" while WIRED,
+ * byte 5 is not a wired-capability profile and this reading is wrong. Byte 5
+ * is otherwise unused here — a per-link DPI ceiling is not implemented,
+ * because nothing has yet confirmed the cable actually caps DPI at 32000.
+ *
+ * Returns `null` ONLY when the report id or command echo is wrong — `open()`
+ * uses that as its collection-liveness probe. A frame that is well-formed
+ * but too short, or whose guard byte is not `0x01`, still yields an identity
+ * carrying `raw` with every decoded field left null: an unreadable model is
+ * reported as unknown, never guessed.
+ */
 export function incottDecodeIdentity(frame: Uint8Array): IncottDeviceIdentity | null {
   if (frame[0] !== INCOTT_REPORT_ID || frame[1] !== INCOTT_CMD_QUERY_IDENTITY) return null;
   const raw = Array.from(frame.slice(2, 9))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join(" ");
-  return { raw };
+  const unknown: IncottDeviceIdentity = {
+    raw,
+    model: null,
+    modelCode: null,
+    displayName: null,
+    sensorId: null,
+    isPro: false,
+    is8KReceiver: false,
+  };
+  if (frame.length < 7) return unknown;
+  if (frame[2] !== INCOTT_IDENTITY_GUARD) return unknown;
+  const modelCode = frame[3]!;
+  const model = INCOTT_MODEL_BY_CODE.get(modelCode) ?? null;
+  const sensorId = frame[6] === INCOTT_IDENTITY_SENSOR_PAW3950
+    ? INCOTT_SENSOR_PAW3950
+    : INCOTT_SENSOR_PAW3395;
+  const isPro = sensorId === INCOTT_SENSOR_PAW3950;
+  return {
+    raw,
+    model,
+    modelCode,
+    displayName: model === null ? null : isPro ? `${model} Pro` : model,
+    sensorId,
+    isPro,
+    is8KReceiver: frame[4] === INCOTT_IDENTITY_8K_RECEIVER,
+  };
 }
 
 /**
@@ -931,20 +1054,17 @@ export function incottIsWiredProduct(productId: number): boolean {
  * "incott Esports G23V2Pro mouse" -> "Esports G23V2Pro"
  * "incott 8K wireless mouse"      -> "8K wireless"
  *
- * WHY THIS EXISTS: the real model name ("Esports G23V2Pro") is only present
- * in the WIRED product string — hardware-verified 2026-09-08. The wireless
- * dongle's product string ("incott 8K wireless mouse") is a generic name
- * with no model in it at all, and there is no way to read the model while
- * connected wirelessly: this driver does NOT infer or guess a model in that
- * case, since doing so would be a fabricated value. This function only
- * TIDIES whatever raw string the device actually reported; it never invents
- * one.
+ * WHY THIS EXISTS: the product string names a model only over the CABLE
+ * ("incott Esports G23V2Pro mouse", hardware-verified 2026-09-08); the
+ * wireless dongle reports a generic "incott 8K wireless mouse" with no model
+ * in it at all. This function only TIDIES whatever raw string the device
+ * actually reported; it never invents one.
  *
- * The identity query's reply (`09 8f 00` -> `01 0e 02 f0 f1 00 ff`, see
- * `incottDecodeIdentity`) has NOT been decoded — its byte layout is unknown
- * — so it is not currently a source for the model name either, wired or
- * wireless. If a future capture decodes it, this comment is the place to
- * update.
+ * This is now the FALLBACK, not the primary source. The identity reply's
+ * byte layout has since been decoded (`incottDecodeIdentity`), so
+ * `IncottHidClient.readStatus` prefers the model read from the device —
+ * which works wirelessly too — and drops back to this function only when the
+ * identity query fails or reports a model code the table does not know.
  */
 export function incottNormalizeProductName(raw: string): string {
   const words = raw.trim().split(/\s+/).filter((word) => word.length > 0);

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -363,8 +363,25 @@ export function incottButtonActionCode(label: string): number | null {
   return null;
 }
 
-/** Sub-command for the DPI *active stage index* query (`0x83`). */
-export const INCOTT_SUB_DPI_STAGE = 0x06;
+/**
+ * How many DPI stages the cycle uses by default — and the value this driver
+ * spent two sessions mistaking for a sub-command.
+ *
+ * `0x83`'s reply byte 2 is the stage COUNT, not an echo. Proven by the
+ * captures: the vendor sends `09 83 00` and gets `09 83 06 01` back, and a
+ * bare `09 83` sweep with no sub-command gets the same `06` — a byte the
+ * request never contained cannot be an echo. Byte 3 is the active index,
+ * which varies (`00`/`01`/`03`/`05`) while byte 2 stays `06`.
+ *
+ * This matters twice over:
+ *   - `0x83` must NOT be treated as sub-echoing when matching responses. It
+ *     belongs with `0x81`/`0x88`/`0x89`/`0x8f`, where byte 2 is data.
+ *   - the `0x03` write carries the count alongside the index
+ *     (`09 03 <count> <stage>`), so writing a hardcoded `06` while selecting
+ *     a stage would reset a four-stage cycle back to six — the same shape of
+ *     bug as the old `INCOTT_SUB_SET_DPI` constant below.
+ */
+export const INCOTT_DPI_STAGE_COUNT_DEFAULT = 6;
 /**
  * Number of DPI stages the table holds. Both the `0x02` write and the `0x82`
  * read take a stage index in this range as their second payload byte — see
@@ -622,17 +639,27 @@ export function incottEncodeSetDpi(stage: number, dpi: number): Uint8Array {
 }
 
 /**
- * Selects which of the six DPI stages is active — `09 03 06 <idx>`. Does NOT
- * write a DPI value and does NOT alter any stage's stored value; see
- * `INCOTT_CMD_SET_DPI_STAGE` for the hardware proof (select 0/3/5/1, table
- * unchanged) and for why this is a distinct operation from
- * `incottEncodeSetDpi`, which edits a stage's stored value.
+ * Writes the DPI cycle: `09 03 <count> <stage>` — how many stages the cycle
+ * uses, and which one is active. Does NOT write a DPI value and does NOT
+ * alter any stage's stored value; see `INCOTT_CMD_SET_DPI_STAGE` for the
+ * hardware proof (select 0/3/5/1, table unchanged) and for why this is a
+ * distinct operation from `incottEncodeSetDpi`, which edits a stage's stored
+ * value.
+ *
+ * `count` IS REQUIRED, and callers must pass what the device currently
+ * reports rather than a constant — the byte used to be hardcoded `0x06` in
+ * the belief that it was a sub-command, which would silently reset a
+ * four-stage cycle to six every time a stage was selected. See
+ * `INCOTT_DPI_STAGE_COUNT_DEFAULT`.
  */
-export function incottEncodeSetActiveDpiStage(stage: number): Uint8Array {
-  if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
-    throw new RangeError(`DPI stage out of range: ${stage}`);
+export function incottEncodeSetDpiCycle(count: number, stage: number): Uint8Array {
+  if (!Number.isInteger(count) || count < 1 || count > INCOTT_DPI_STAGE_COUNT) {
+    throw new RangeError(`DPI stage count out of range: ${count}`);
   }
-  return payload(INCOTT_CMD_SET_DPI_STAGE, INCOTT_SUB_DPI_STAGE, stage);
+  if (!Number.isInteger(stage) || stage < 0 || stage >= count) {
+    throw new RangeError(`DPI stage ${stage} out of range for a ${count}-stage cycle`);
+  }
+  return payload(INCOTT_CMD_SET_DPI_STAGE, count, stage);
 }
 
 export function incottEncodeSetPollingRate(hz: number): Uint8Array {
@@ -795,19 +822,41 @@ export function incottFrameMatches(frame: Uint8Array, cmd: number, sub: number |
   return true;
 }
 
+/** The DPI cycle as the device reports it: how many stages, and which is live. */
+export interface IncottDpiCycle {
+  /** Stages in the cycle, 1..`INCOTT_DPI_STAGE_COUNT`. */
+  count: number;
+  /** Active stage, 0-based and always below `count`. */
+  active: number;
+}
+
 /**
- * `0x83`/`0x06` returns which of the six DPI stages is currently active
- * (0-5) at response byte 3 — proven wrong to be a DPI-value index on
- * hardware 2026-09-07: decoding byte 3 through `INCOTT_DPI_DEFAULT_STAGE_PRESETS`
- * used to yield 800 DPI, which matched the vendor UI only by coincidence (the
- * device happened to be on stage 1 of 6). Combine with
- * `incottDecodeDpiStage` at this index to get the actual DPI value — see
- * `IncottHidClient.readStatus`.
+ * `09 83` -> `<count> <active>` at response bytes 2 and 3.
+ *
+ * Byte 3 was proven not to be a DPI-value index on hardware 2026-09-07:
+ * decoding it through `INCOTT_DPI_DEFAULT_STAGE_PRESETS` used to yield 800
+ * DPI, matching the vendor UI only by coincidence (the device happened to be
+ * on stage 1 of 6). Combine with `incottDecodeDpiStage` at `active` to get
+ * the actual DPI value — see `IncottHidClient.readStatus`.
+ *
+ * Byte 2 was then mistaken for a sub-command echo, because the count on the
+ * only device available is 6 and the driver happened to send `06`. It is
+ * data: `09 83 00` and a bare `09 83` both answer `06`. Matching it as an
+ * echo would reject every reply from a mouse whose cycle is not six stages
+ * long, so this decoder matches on the COMMAND ONLY — see
+ * `INCOTT_DPI_STAGE_COUNT_DEFAULT`.
  */
-export function incottDecodeDpiStageIndex(frame: Uint8Array): number | null {
-  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_DPI_STAGE, INCOTT_SUB_DPI_STAGE)) return null;
-  const index = frame[3];
-  return index !== undefined && index >= 0 && index <= 5 ? index : null;
+export function incottDecodeDpiCycle(frame: Uint8Array): IncottDpiCycle | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_DPI_STAGE, null)) return null;
+  const count = frame[2];
+  const active = frame[3];
+  if (count === undefined || active === undefined) return null;
+  if (count < 1 || count > INCOTT_DPI_STAGE_COUNT) return null;
+  // An active index outside the cycle is not a reading this driver can make
+  // sense of, and guessing a fallback would put the DPI panel on the wrong
+  // stage. Report nothing instead.
+  if (active >= count) return null;
+  return { count, active };
 }
 
 /**

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -145,6 +145,13 @@ export const INCOTT_CMD_SET_TIMING = 0x05;
  * nothing here interprets them.
  */
 export const INCOTT_CMD_SET_BUTTON = 0x06;
+/**
+ * Announces one 32-byte chunk of a macro buffer:
+ * `09 07 <chunks> <chunk index> <bytes per chunk> <buffer id>`.
+ *
+ * CODEC ONLY, AND NOT SENDABLE YET — see `incottEncodeMacroChunkHeader`.
+ */
+export const INCOTT_CMD_MACRO_CHUNK = 0x07;
 export const INCOTT_CMD_SET_RECEIVER_LED = 0x08;
 
 /**
@@ -414,6 +421,149 @@ export const INCOTT_BUTTON_ACTIONS: ReadonlyArray<readonly [string, number]> = [
     ([label, modifiers, usage]) => [label, incottKeyboardActionCode(usage, modifiers)] as const,
   ),
 ];
+
+/** Macro loop modes, in wire order. */
+export const INCOTT_MACRO_LOOP_MODES = ["untilKeyRelease", "untilAnyKey", "cycle"] as const;
+export type IncottMacroLoop = (typeof INCOTT_MACRO_LOOP_MODES)[number];
+
+/** One key event in a macro: a press or a release, then a delay. */
+export interface IncottMacroStep {
+  /** HID keyboard usage code. */
+  key: number;
+  /** True for a key-down event, false for key-up. */
+  press: boolean;
+  /** Delay after this event, milliseconds, 16-bit. */
+  delayMs: number;
+}
+
+export interface IncottMacro {
+  /** Which of the ten on-device macro buffers this occupies, 0-9. */
+  bufferId: number;
+  loop: IncottMacroLoop;
+  /** Repeat count, used by the `cycle` loop mode. */
+  cycles: number;
+  steps: readonly IncottMacroStep[];
+  /** The vendor's own identifier for the macro; echoed back in the buffer. */
+  uid: number;
+}
+
+/** A macro buffer is always this long, in ten 32-byte chunks. */
+export const INCOTT_MACRO_BUFFER_BYTES = 320;
+export const INCOTT_MACRO_CHUNK_BYTES = 32;
+export const INCOTT_MACRO_CHUNK_COUNT = INCOTT_MACRO_BUFFER_BYTES / INCOTT_MACRO_CHUNK_BYTES;
+export const INCOTT_MACRO_BUFFER_COUNT = 10;
+/** Steps occupy bytes 4..287 at four bytes each, so 71 fit. */
+export const INCOTT_MACRO_MAX_STEPS = 71;
+
+/**
+ * Builds the 320-byte macro buffer, transcribed from the vendor bundle's
+ * `juji_to_hw()`.
+ *
+ *     [0]        buffer id
+ *     [1]        loop mode (0 until key release, 1 until any key, 2 cycle)
+ *     [2..3]     cycle count, LE16
+ *     [4+4n]     event flags: bit 0 always set, bit 7 set for a RELEASE
+ *     [5+4n]     HID keyboard usage code
+ *     [6..7+4n]  delay after the event, LE16 milliseconds
+ *     [288..293] the ASCII name "Macro" followed by '1' + buffer id
+ *     [304..307] (steps + 1) * 132, LE32
+ *     [308..311] 16, 0, 232, 232 — constant in every buffer the vendor builds
+ *     [312..315] uid, LE32
+ *     [316..317] steps * 2, LE16
+ *     [318]      step count
+ *
+ * NOT SENDABLE YET, and this is the reason no client method exists: the
+ * buffer goes out as ten 32-byte chunks, each announced by
+ * `incottEncodeMacroChunkHeader` and then followed by the chunk itself — and
+ * the call that carries the chunk (`document.elsDevice` in the vendor bundle)
+ * is never defined in any file the page loads. Its transport cannot be
+ * recovered by reading the bundle: no `sendFeatureReport` or
+ * `receiveFeatureReport` appears literally anywhere in it, because the method
+ * names are resolved through variables at runtime.
+ *
+ * It cannot be the ordinary path either. Every command in this protocol is an
+ * 8-byte feature report on id `0x09`, which a 32-byte chunk does not fit, and
+ * a read-only sweep of the other vendor collections (2026-09-11) found
+ * `0xFF00` answering nothing at all.
+ *
+ * So this encoder exists to preserve a format that took real work to recover,
+ * with tests pinning it. Wiring it up needs the transport identified first —
+ * most likely by instrumenting the vendor tool while it saves a macro, the
+ * same way `vendor-tool-session.hex` was captured.
+ */
+export function incottEncodeMacroBuffer(macro: IncottMacro): Uint8Array {
+  if (!Number.isInteger(macro.bufferId) || macro.bufferId < 0 || macro.bufferId >= INCOTT_MACRO_BUFFER_COUNT) {
+    throw new RangeError(`Macro buffer id out of range: ${macro.bufferId}`);
+  }
+  if (macro.steps.length > INCOTT_MACRO_MAX_STEPS) {
+    throw new RangeError(`Macro has ${macro.steps.length} steps; the buffer holds ${INCOTT_MACRO_MAX_STEPS}`);
+  }
+  const out = new Uint8Array(INCOTT_MACRO_BUFFER_BYTES);
+  out[0] = macro.bufferId & 0xff;
+  out[1] = INCOTT_MACRO_LOOP_MODES.indexOf(macro.loop);
+  out[2] = macro.cycles & 0xff;
+  out[3] = (macro.cycles >> 8) & 0xff;
+
+  macro.steps.forEach((step, index) => {
+    const at = 4 + index * 4;
+    // Bit 0 is set on every event; bit 7 marks a release. A press is 0x01.
+    out[at] = (step.press ? 0x00 : 0x80) | 0x01;
+    out[at + 1] = step.key & 0xff;
+    out[at + 2] = step.delayMs & 0xff;
+    out[at + 3] = (step.delayMs >> 8) & 0xff;
+  });
+
+  // "Macro" + the 1-based buffer number, as the vendor names its slots.
+  out.set([0x4d, 0x61, 0x63, 0x72, 0x6f], 288);
+  out[293] = 0x31 + macro.bufferId;
+
+  const size = (macro.steps.length + 1) * 132;
+  out[304] = size & 0xff;
+  out[305] = (size >> 8) & 0xff;
+  out[306] = (size >> 16) & 0xff;
+  out[307] = (size >> 24) & 0xff;
+  out[308] = 16;
+  out[310] = 232;
+  out[311] = 232;
+  out[312] = macro.uid & 0xff;
+  out[313] = (macro.uid >>> 8) & 0xff;
+  out[314] = (macro.uid >>> 16) & 0xff;
+  out[315] = (macro.uid >>> 24) & 0xff;
+  const len = macro.steps.length * 2;
+  out[316] = len & 0xff;
+  out[317] = (len >> 8) & 0xff;
+  out[318] = macro.steps.length;
+  return out;
+}
+
+/**
+ * The 8-byte header announcing one chunk of a macro buffer:
+ * `09 07 0a <chunk index> 20 <buffer id>`.
+ *
+ * See `incottEncodeMacroBuffer` for why nothing sends this yet. Note the
+ * vendor slices its own payload as `mda.slice(i * 32, i * 64)`, which yields
+ * an EMPTY chunk for `i = 0` and over-long ones after — visibly a bug in its
+ * own uploader, and not reproduced here.
+ */
+export function incottEncodeMacroChunkHeader(chunkIndex: number, bufferId: number): Uint8Array {
+  if (!Number.isInteger(chunkIndex) || chunkIndex < 0 || chunkIndex >= INCOTT_MACRO_CHUNK_COUNT) {
+    throw new RangeError(`Macro chunk index out of range: ${chunkIndex}`);
+  }
+  if (!Number.isInteger(bufferId) || bufferId < 0 || bufferId >= INCOTT_MACRO_BUFFER_COUNT) {
+    throw new RangeError(`Macro buffer id out of range: ${bufferId}`);
+  }
+  return payload(INCOTT_CMD_MACRO_CHUNK, INCOTT_MACRO_CHUNK_COUNT, chunkIndex, INCOTT_MACRO_CHUNK_BYTES, bufferId);
+}
+
+/** Splits a macro buffer into the ten chunks the upload sends. */
+export function incottMacroChunks(buffer: Uint8Array): Uint8Array[] {
+  if (buffer.length !== INCOTT_MACRO_BUFFER_BYTES) {
+    throw new RangeError(`Macro buffer must be ${INCOTT_MACRO_BUFFER_BYTES} bytes, got ${buffer.length}`);
+  }
+  return Array.from({ length: INCOTT_MACRO_CHUNK_COUNT }, (_, index) =>
+    buffer.slice(index * INCOTT_MACRO_CHUNK_BYTES, (index + 1) * INCOTT_MACRO_CHUNK_BYTES),
+  );
+}
 
 /** Label for a 32-bit action word, or null when it is not one this driver knows. */
 export function incottButtonActionLabel(code: number): string | null {

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -868,7 +868,7 @@ export interface IncottDeviceIdentity {
   modelCode: number | null;
   /** Model plus a " Pro" suffix when the PAW3950 is fitted, e.g. "G23V2 Pro". */
   displayName: string | null;
-  /** The FITTED sensor, from byte 6: `INCOTT_SENSOR_PAW3395` or `INCOTT_SENSOR_PAW3950`. */
+  /** The FITTED sensor: `INCOTT_SENSOR_PAW3395` or `INCOTT_SENSOR_PAW3950`. */
   sensorId: number | null;
   /** True when the PAW3950 is fitted — what the vendor's "Pro" suffix means. */
   isPro: boolean;
@@ -1196,31 +1196,34 @@ export function incottDecodeButtonBinding(frame: Uint8Array, button: number): In
  *     byte 2  guard, always 0x01   -- the vendor abandons the device otherwise
  *     byte 3  model code           -- 0x0e = G23V2, see INCOTT_MODEL_BY_CODE
  *     byte 4  receiver type        -- 0x02 = 8 KHz receiver
- *     byte 5  sensor profile, WIRED link    -- 0xF0 -> PAW3395, 0xF1 -> PAW3950
- *     byte 6  sensor profile, WIRELESS link
+ *     byte 5  sensor slot A          -- 0xF0 -> PAW3395, 0xF1 -> PAW3950
+ *     byte 6  sensor slot B          -- same encoding, 0x00 when unpopulated
  *
- * WHY BYTE 6 AND NOT BYTE 5: the vendor picks its sensor byte by connection
- * (`let i = this.iswireless ? 5 : 4` over its own report-id-less buffer), and
- * on this G23V2 the two bytes DISAGREE — `f0 f1`. Taken as hardware identity
- * that is a contradiction: a mouse does not swap sensors when a cable goes
- * in. Taken as a per-link CAPABILITY profile it is consistent, because the
- * vendor feeds this value straight into `getStDPI(sensor)` to pick a DPI
- * ceiling (PAW3395 -> 32000, PAW3950 -> 45000) — and the cable is already
- * known to be the reduced-capability path on this device, capping polling at
- * 1000 Hz (see `INCOTT_POLLING_STEPS_HZ_WIRED`).
+ * THE SENSOR SLOT MOVES WITH THE RECEIVER, so neither byte alone is "the"
+ * sensor. Two wired captures of the same mouse:
  *
- * So the FITTED sensor is read from byte 6, the full-capability slot, and the
- * decoded name is therefore stable across wired and wireless. The vendor's
- * own tool is not: because it re-reads the byte by connection, it labels this
- * one physical mouse "G23V2Pro" on the dongle and "G23V2" on the cable. That
- * cosmetic flip is deliberately NOT mirrored — a model name that changes when
- * you plug in a cable is a worse answer than the hardware's own.
+ *     cable + dongle (2026-09-08):  09 8f 01 0e 02 f0 f1 00 ff
+ *     cable only     (2026-09-11):  09 8f 01 0e 00 f1 00 00 00
  *
- * This is the one inference in this decoder rather than a transcription, and
- * it is falsifiable: if the vendor tool ever shows "G23V2Pro" while WIRED,
- * byte 5 is not a wired-capability profile and this reading is wrong. Byte 5
- * is otherwise unused here — a per-link DPI ceiling is not implemented,
- * because nothing has yet confirmed the cable actually caps DPI at 32000.
+ * With the dongle present, byte 4 reports the receiver and the `0xF1` sits at
+ * byte 6; with the dongle gone, byte 4 is `0x00` and the same `0xF1` sits at
+ * byte 5. This is why the vendor indexes by connection
+ * (`let i = this.iswireless ? 5 : 4` over its report-id-less buffer, i.e.
+ * frame bytes 6:5) — that is correct behaviour, not the cosmetic bug an
+ * earlier version of this comment claimed.
+ *
+ * WHY ANY SLOT, NOT THE CONNECTION-INDEXED ONE: the fitted sensor is settled
+ * independently of this frame. A PAW3395 stops at 32000 DPI in the vendor's
+ * own table, and this mouse stored and read back 45000 over the CABLE
+ * (`captures/incott-8k-wireless/wired-dpi-ceiling-2026-09-11.hex`). It is a
+ * PAW3950 on every link, so the answer is whichever slot carries `0xF1`. The
+ * vendor's index disagrees in exactly one configuration — cable AND dongle
+ * attached, where it reads byte 5's `0xF0` and drops the "Pro" — and that is
+ * the one case where a capability byte cannot be describing this mouse.
+ *
+ * The same capture also shows there is NO wired DPI ceiling to model: 45000
+ * is accepted over the cable, so `INCOTT_DPI_MAX` stays flat across links,
+ * unlike the polling rate (`INCOTT_POLLING_STEPS_HZ_WIRED`).
  *
  * Returns `null` ONLY when the report id or command echo is wrong — `open()`
  * uses that as its collection-liveness probe. A frame that is well-formed
@@ -1246,7 +1249,7 @@ export function incottDecodeIdentity(frame: Uint8Array): IncottDeviceIdentity | 
   if (frame[2] !== INCOTT_IDENTITY_GUARD) return unknown;
   const modelCode = frame[3]!;
   const model = INCOTT_MODEL_BY_CODE.get(modelCode) ?? null;
-  const sensorId = frame[6] === INCOTT_IDENTITY_SENSOR_PAW3950
+  const sensorId = frame[5] === INCOTT_IDENTITY_SENSOR_PAW3950 || frame[6] === INCOTT_IDENTITY_SENSOR_PAW3950
     ? INCOTT_SENSOR_PAW3950
     : INCOTT_SENSOR_PAW3395;
   const isPro = sensorId === INCOTT_SENSOR_PAW3950;

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -637,6 +637,23 @@ export const INCOTT_SUB_MOTION_SYNC = 0x04;
  */
 export const INCOTT_SUB_PERFORMANCE = 0x05;
 export const INCOTT_SUB_DEBOUNCE = 0x01;
+/**
+ * Fire Key (rapid-fire) parameters, `09 05 02 <times> <interval ms>`.
+ *
+ * The last unidentified command in this protocol, settled 2026-09-11. The
+ * vendor calls it `setFKeyPm(lp, ir)` and only ever calls it for a button
+ * bound to `favFIRE`, deriving both values from that button's `itemdata` and
+ * clamping them to 3 and 255 respectively. Its own UI names the two fields:
+ * "Fire Key" / "Keep left-clicking according to the interval and times".
+ *
+ * Read back at `0x85`/`0x02`. On this hardware: `09 85 02 03 0a` — three
+ * clicks, 10 ms apart.
+ */
+export const INCOTT_SUB_FIRE_KEY = 0x02;
+/** Clicks per press. The vendor clamps to this; 0 is accepted but untested. */
+export const INCOTT_FIRE_KEY_MAX_TIMES = 3;
+/** Milliseconds between clicks in a burst, one byte. */
+export const INCOTT_FIRE_KEY_MAX_INTERVAL_MS = 255;
 export const INCOTT_SUB_SLEEP = 0x03;
 export const INCOTT_SUB_NONE = 0x00;
 
@@ -1191,6 +1208,41 @@ export function incottDecodeSleep(frame: Uint8Array): number | null {
   if (frame.length < 5) return null;
   const value = frame[3] | (frame[4] << 8);
   return value >= INCOTT_SLEEP_MIN_S && value <= INCOTT_SLEEP_MAX_S ? value : null;
+}
+
+/** How a Fire Key button behaves: how many clicks it sends, and how fast. */
+export interface IncottFireKey {
+  /** Clicks sent per press, 0-3. */
+  times: number;
+  /** Milliseconds between those clicks, 0-255. */
+  intervalMs: number;
+}
+
+/**
+ * `09 05 02 <times> <interval ms>` — see `INCOTT_SUB_FIRE_KEY`.
+ *
+ * These are the settings for whichever button is bound to "Rapid fire"; they
+ * are global to the device rather than per-button, since the command carries
+ * no button index.
+ */
+export function incottEncodeSetFireKey(times: number, intervalMs: number): Uint8Array {
+  if (!Number.isInteger(times) || times < 0 || times > INCOTT_FIRE_KEY_MAX_TIMES) {
+    throw new RangeError(`Fire key times out of range: ${times}`);
+  }
+  if (!Number.isInteger(intervalMs) || intervalMs < 0 || intervalMs > INCOTT_FIRE_KEY_MAX_INTERVAL_MS) {
+    throw new RangeError(`Fire key interval out of range: ${intervalMs} ms`);
+  }
+  return payload(INCOTT_CMD_SET_TIMING, INCOTT_SUB_FIRE_KEY, times, intervalMs);
+}
+
+/** `09 85 02` -> times at byte 3, interval at byte 4. */
+export function incottDecodeFireKey(frame: Uint8Array): IncottFireKey | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_TIMING, INCOTT_SUB_FIRE_KEY)) return null;
+  if (frame.length < 5) return null;
+  const times = frame[3]!;
+  const intervalMs = frame[4]!;
+  if (times > INCOTT_FIRE_KEY_MAX_TIMES) return null;
+  return { times, intervalMs };
 }
 
 export function incottDecodeReceiverLed(frame: Uint8Array): number | null {

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -712,15 +712,36 @@ export const INCOTT_SUB_NONE = 0x00;
  * of 50:
  *   sensor 0x3395 (PAW3395): 32000
  *   sensor 0x3950 (PAW3950): 45000
- * There is no known way to read which sensor variant is fitted to a given
- * unit, so `INCOTT_DPI_MAX` uses the higher of the two known ceilings. A
- * PAW3395 unit is expected to refuse anything above 32000; the existing
- * write-cache/read-back verification in `IncottHidClient.setDpi` is relied on
- * to report that honestly rather than this module guessing which sensor is
- * present.
+ * The fitted sensor IS readable — the identity reply carries it (see
+ * `incottDecodeIdentity`) — so `readStatus` narrows the ceiling it OFFERS to
+ * whichever sensor answered, via `incottDpiMaxForSensor`. This constant stays
+ * the higher of the two: it is the bound on what the protocol can express,
+ * and the encoder must keep accepting a value the app is entitled to send.
+ * That mirrors the polling rate, where `supportedPollingRates` narrows by
+ * connection while `incottEncodeSetPollingRate` still accepts the full
+ * ladder.
  */
 export const INCOTT_DPI_MIN = 50;
 export const INCOTT_DPI_MAX = 45000;
+/** The PAW3395's ceiling in the vendor's own DPI table. */
+export const INCOTT_DPI_MAX_PAW3395 = 32000;
+
+/**
+ * The DPI ceiling to OFFER for a fitted sensor, matching the table the vendor
+ * builds in `getStDPI`.
+ *
+ * Worth being precise about what this is and is not. It is the vendor's UI
+ * limit, not a proven firmware limit: this contributor's PAW3950 accepted
+ * 45000 over the cable even though the connection-indexed sensor byte read
+ * PAW3395 there (see `captures/incott-8k-wireless/wired-dpi-ceiling-2026-09-11.hex`),
+ * so a real PAW3395 unit has never been tested and may well accept more. It
+ * is used because offering exactly what the vendor offers cannot surprise
+ * anyone, and because the alternative — advertising 45000 to a Ghero — risks
+ * a silent refusal on a model nobody here can test.
+ */
+export function incottDpiMaxForSensor(sensorId: number | null): number {
+  return sensorId === INCOTT_SENSOR_PAW3395 ? INCOTT_DPI_MAX_PAW3395 : INCOTT_DPI_MAX;
+}
 export const INCOTT_DPI_STEP = 50;
 
 /**

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -306,18 +306,11 @@ export const INCOTT_BUTTON_WIRE_INDEX: Readonly<Record<IncottButtonName, number>
  * back `07 00 03`, which is `0x00030007` little-endian — the value `kf_hw`
  * returns for that function.
  *
- * NOT covered here, deliberately:
- *   - keyboard bindings, which are parametric rather than a fixed list
- *     (`(keycode & 255) << 16 | (modifiers & 255) << 8`, or
- *     `(keycode & 255) << 8 | 128` with no modifier). The shared
- *     `buttonOptions` contract is a flat list of labels, which cannot express
- *     "any key plus any modifier combination"; wiring that up needs a UI
- *     contract that does not exist yet.
- *   - macros (`slot << 16 | 9`), which need the `0x07` upload command.
- *   - `fmeFAVOR`, which the vendor defines as a constant but has no case for
- *     in its own encoder, so it has no code to send.
+ * NOT covered here: macros (`slot << 16 | 9`), which need the `0x07` upload
+ * command, and `fmeFAVOR`, which the vendor defines as a constant but has no
+ * case for in its own encoder, so there is no code to send.
  */
-export const INCOTT_BUTTON_ACTIONS: ReadonlyArray<readonly [string, number]> = [
+const MOUSE_AND_MEDIA_ACTIONS: ReadonlyArray<readonly [string, number]> = [
   ["Left click", 0x00f00001],
   ["Right click", 0x00f10001],
   ["Middle click", 0x00f20001],
@@ -345,6 +338,81 @@ export const INCOTT_BUTTON_ACTIONS: ReadonlyArray<readonly [string, number]> = [
   ["Browser back", 0x02240003],
   ["Browser search", 0x02210003],
   ["Disabled", 0x00000000],
+];
+
+/** HID keyboard modifier bits, as the vendor's encoder packs them at byte 1. */
+const MODIFIER_CTRL = 0x01;
+const MODIFIER_SHIFT = 0x02;
+const MODIFIER_ALT = 0x04;
+const MODIFIER_GUI = 0x08;
+
+/**
+ * Standard HID keyboard usage codes. Labels are display names, not key-cap
+ * legends, so they stay readable in a flat picker.
+ */
+const KEY_USAGES: ReadonlyArray<readonly [string, number]> = [
+  ...Array.from({ length: 26 }, (_, i) => [String.fromCharCode(65 + i), 0x04 + i] as const),
+  ...Array.from({ length: 9 }, (_, i) => [String(i + 1), 0x1e + i] as const),
+  ["0", 0x27],
+  ...Array.from({ length: 12 }, (_, i) => [`F${i + 1}`, 0x3a + i] as const),
+  ["Enter", 0x28], ["Escape", 0x29], ["Backspace", 0x2a], ["Tab", 0x2b], ["Space", 0x2c],
+  ["Insert", 0x49], ["Delete", 0x4c], ["Home", 0x4a], ["End", 0x4d],
+  ["Page Up", 0x4b], ["Page Down", 0x4e],
+  ["Up", 0x52], ["Down", 0x51], ["Left", 0x50], ["Right", 0x4f],
+  ["Caps Lock", 0x39], ["Num Lock", 0x53], ["Scroll Lock", 0x47],
+  ["Print Screen", 0x46], ["Pause", 0x48], ["Context Menu", 0x65],
+  ["Left Ctrl", 0xe0], ["Left Shift", 0xe1], ["Left Alt", 0xe2], ["Left Windows", 0xe3],
+  ["Right Ctrl", 0xe4], ["Right Shift", 0xe5], ["Right Alt", 0xe6], ["Right Windows", 0xe7],
+];
+
+/** Common chords, since the flat picker cannot express "any key + any modifier". */
+const KEY_SHORTCUTS: ReadonlyArray<readonly [string, number, number]> = [
+  ["Ctrl + A", MODIFIER_CTRL, 0x04], ["Ctrl + C", MODIFIER_CTRL, 0x06],
+  ["Ctrl + V", MODIFIER_CTRL, 0x19], ["Ctrl + X", MODIFIER_CTRL, 0x1b],
+  ["Ctrl + Z", MODIFIER_CTRL, 0x1d], ["Ctrl + Y", MODIFIER_CTRL, 0x1c],
+  ["Ctrl + S", MODIFIER_CTRL, 0x16], ["Ctrl + O", MODIFIER_CTRL, 0x12],
+  ["Ctrl + N", MODIFIER_CTRL, 0x11], ["Ctrl + T", MODIFIER_CTRL, 0x17],
+  ["Ctrl + W", MODIFIER_CTRL, 0x1a], ["Ctrl + F", MODIFIER_CTRL, 0x09],
+  ["Ctrl + Shift + Escape", MODIFIER_CTRL | MODIFIER_SHIFT, 0x29],
+  ["Alt + Tab", MODIFIER_ALT, 0x2b], ["Alt + F4", MODIFIER_ALT, 0x3d],
+  ["Alt + Left", MODIFIER_ALT, 0x50], ["Alt + Right", MODIFIER_ALT, 0x4f],
+  ["Win + D", MODIFIER_GUI, 0x07], ["Win + E", MODIFIER_GUI, 0x08],
+  ["Win + L", MODIFIER_GUI, 0x0f], ["Win + R", MODIFIER_GUI, 0x15],
+  ["Win + S", MODIFIER_GUI, 0x16], ["Win + Tab", MODIFIER_GUI, 0x2b],
+];
+
+/**
+ * A keyboard action word, from the vendor's `kf_hw()` keyboard branch:
+ *
+ *     no modifier:   (keycode & 255) << 8  | 128
+ *     with modifier: (keycode & 255) << 16 | (modifiers & 255) << 8
+ *
+ * The two forms are genuinely different shapes, not one with a zero
+ * modifier — an unmodified key sets the `0x80` marker in the low byte and
+ * puts the keycode one byte lower than a chord does.
+ */
+export function incottKeyboardActionCode(keycode: number, modifiers = 0): number {
+  return modifiers === 0
+    ? (((keycode & 0xff) << 8) | 0x80) >>> 0
+    : (((keycode & 0xff) << 16) | ((modifiers & 0xff) << 8)) >>> 0;
+}
+
+/**
+ * Everything a button can be set to, in display order: the mouse, DPI and
+ * media actions above, then individual keys, then common chords.
+ *
+ * Keyboard bindings are enumerated rather than left out. The encoding is
+ * parametric (any of 256 keycodes against any of 256 modifier masks) and the
+ * shared `buttonOptions` contract is a flat list of labels, so the full space
+ * cannot be offered — but a curated list covers what people actually bind,
+ * and it is the same approach the MCHOSE driver in this repo already takes.
+ */
+export const INCOTT_BUTTON_ACTIONS: ReadonlyArray<readonly [string, number]> = [
+  ...MOUSE_AND_MEDIA_ACTIONS,
+  ...KEY_USAGES.map(([label, usage]) => [label, incottKeyboardActionCode(usage)] as const),
+  ...KEY_SHORTCUTS.map(
+    ([label, modifiers, usage]) => [label, incottKeyboardActionCode(usage, modifiers)] as const,
+  ),
 ];
 
 /** Label for a 32-bit action word, or null when it is not one this driver knows. */

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -264,10 +264,104 @@ export const INCOTT_CMD_QUERY_BUTTON = 0x86;
 /** Button count: left, right, middle, forward, back, DPI. */
 export const INCOTT_BUTTON_COUNT = 6;
 /**
- * The vendor tool's own query, `09 86 09` — not a button index (buttons only
- * go up to 5). Its payload is still undecoded.
+ * The vendor tool's own query, `09 86 09`. NOT a button index — buttons only
+ * go up to 5. It reads the onboard profile index, the counterpart of the
+ * `09 06 09 <index>` write (`setProfileIndex` in the vendor bundle). Neither
+ * is implemented here: switching profiles in the vendor tool still replays
+ * every setting individually, so what the device stores against the index is
+ * unknown.
  */
 export const INCOTT_SUB_UNKNOWN_86_VENDOR_QUERY = 0x09;
+
+/**
+ * Physical buttons, in left-to-right display order.
+ */
+export const INCOTT_BUTTON_NAMES = ["Left", "Right", "Middle", "Forward", "Back", "DPI"] as const;
+export type IncottButtonName = (typeof INCOTT_BUTTON_NAMES)[number];
+
+/**
+ * Display order -> WIRE index. **These are not the same**, and assuming they
+ * were would silently swap two buttons.
+ *
+ * The vendor's per-model key table carries an explicit `matrix` field and
+ * addresses the device with it (`setMsK(dvar.key[i].matrix, code)`), not with
+ * the array position. For this family Forward sits at array index 3 with
+ * `matrix = 4`, and Back at array index 4 with `matrix = 3` — the two are
+ * transposed. Every other button's matrix equals its position.
+ */
+export const INCOTT_BUTTON_WIRE_INDEX: Readonly<Record<IncottButtonName, number>> = {
+  Left: 0,
+  Right: 1,
+  Middle: 2,
+  Forward: 4,
+  Back: 3,
+  DPI: 5,
+};
+
+/**
+ * Button actions, label -> 32-bit action word, in display order.
+ *
+ * Transcribed from the vendor bundle's `kf_hw()` encoder. One row is
+ * confirmed against this contributor's hardware: the factory DPI button reads
+ * back `07 00 03`, which is `0x00030007` little-endian — the value `kf_hw`
+ * returns for that function.
+ *
+ * NOT covered here, deliberately:
+ *   - keyboard bindings, which are parametric rather than a fixed list
+ *     (`(keycode & 255) << 16 | (modifiers & 255) << 8`, or
+ *     `(keycode & 255) << 8 | 128` with no modifier). The shared
+ *     `buttonOptions` contract is a flat list of labels, which cannot express
+ *     "any key plus any modifier combination"; wiring that up needs a UI
+ *     contract that does not exist yet.
+ *   - macros (`slot << 16 | 9`), which need the `0x07` upload command.
+ *   - `fmeFAVOR`, which the vendor defines as a constant but has no case for
+ *     in its own encoder, so it has no code to send.
+ */
+export const INCOTT_BUTTON_ACTIONS: ReadonlyArray<readonly [string, number]> = [
+  ["Left click", 0x00f00001],
+  ["Right click", 0x00f10001],
+  ["Middle click", 0x00f20001],
+  ["Forward", 0x00f40001],
+  ["Back", 0x00f30001],
+  ["DPI cycle", 0x00030007],
+  ["DPI +", 0x00010007],
+  ["DPI -", 0x00020007],
+  ["Rapid fire", 0x0218f00a],
+  ["Profile switch", 0x0000f10a],
+  ["Media player", 0x01830003],
+  ["Play/Pause", 0x00cd0003],
+  ["Stop", 0x00b70003],
+  ["Previous track", 0x00b60003],
+  ["Next track", 0x00b50003],
+  ["Volume up", 0x00e90003],
+  ["Volume down", 0x00ea0003],
+  ["Mute", 0x00e20003],
+  ["Email", 0x018a0003],
+  ["Calculator", 0x01920003],
+  ["File explorer", 0x01940003],
+  ["Browser home", 0x02230003],
+  ["Browser refresh", 0x02270003],
+  ["Browser forward", 0x02250003],
+  ["Browser back", 0x02240003],
+  ["Browser search", 0x02210003],
+  ["Disabled", 0x00000000],
+];
+
+/** Label for a 32-bit action word, or null when it is not one this driver knows. */
+export function incottButtonActionLabel(code: number): string | null {
+  for (const [label, value] of INCOTT_BUTTON_ACTIONS) {
+    if (value === code) return label;
+  }
+  return null;
+}
+
+/** 32-bit action word for a label, or null when the label is not in the table. */
+export function incottButtonActionCode(label: string): number | null {
+  for (const [name, value] of INCOTT_BUTTON_ACTIONS) {
+    if (name === label) return value;
+  }
+  return null;
+}
 
 /** Sub-command for the DPI *active stage index* query (`0x83`). */
 export const INCOTT_SUB_DPI_STAGE = 0x06;
@@ -559,19 +653,31 @@ export function incottEncodeSetToggle(kind: IncottToggleKind, on: boolean): Uint
 }
 
 /**
- * Encodes a raw three-byte button binding write, `09 06 <button 0..5>
- * <b0> <b1> <b2>`. Codec only, by design (see `INCOTT_CMD_SET_BUTTON`): the
- * meaning of the three bytes (key code, macro reference, remap target — the
- * fields are unnamed here on purpose) is NOT established, so this neither
- * interprets nor validates them beyond fitting in a byte. Round-trip
- * confirmed on hardware 2026-09-08: writing `01 00 f0` to button 0 read back
- * byte for byte via `incottDecodeButtonBinding`.
+ * Encodes a button binding write, `09 06 <button 0..5> <32-bit action, LE>`.
+ *
+ * The action is a 32-bit little-endian word — see `INCOTT_BUTTON_ACTIONS`
+ * for the labelled codes. Confirmed against hardware: this unit's factory
+ * binding for the DPI button reads back `07 00 03`, and the vendor's own
+ * encoder returns `0x00030007` for that function, which is the same word.
+ *
+ * `button` is the WIRE index, which is not the physical left-to-right order
+ * — see `INCOTT_BUTTON_WIRE_INDEX`.
  */
-export function incottEncodeSetButtonBinding(button: number, raw: readonly [number, number, number]): Uint8Array {
+export function incottEncodeSetButtonBinding(button: number, code: number): Uint8Array {
   if (!Number.isInteger(button) || button < 0 || button >= INCOTT_BUTTON_COUNT) {
     throw new RangeError(`Button index out of range: ${button}`);
   }
-  return payload(INCOTT_CMD_SET_BUTTON, button, raw[0], raw[1], raw[2]);
+  if (!Number.isInteger(code) || code < 0 || code > 0xffffffff) {
+    throw new RangeError(`Button action code out of range: ${code}`);
+  }
+  return payload(
+    INCOTT_CMD_SET_BUTTON,
+    button,
+    code & 0xff,
+    (code >>> 8) & 0xff,
+    (code >>> 16) & 0xff,
+    (code >>> 24) & 0xff,
+  );
 }
 
 /**
@@ -931,28 +1037,36 @@ export function incottDecodeInputStatus(byte0: number, byte1: number): IncottInp
 }
 
 /**
- * Raw three-byte binding read back from a button. Field names are
- * deliberately generic (`b0`/`b1`/`b2`), not `type`/`code`: what each byte
- * means (key code, macro reference, remap target) is NOT established. This
- * is a codec for the wire bytes only — see `INCOTT_CMD_QUERY_BUTTON`.
+ * A button's current binding: the raw 32-bit action word, plus the label
+ * when it is one this driver knows.
+ *
+ * `label` is null for a binding the action table does not cover — a keyboard
+ * key, a macro, or an action from a model this contributor cannot test. The
+ * `code` is always reported so an unrecognised binding round-trips
+ * unchanged rather than being flattened to a default.
  */
 export interface IncottButtonBinding {
   button: number;
-  b0: number;
-  b1: number;
-  b2: number;
+  code: number;
+  label: string | null;
 }
 
 /**
- * `09 86 <button 0..5>` -> response bytes 3-5 = the raw binding. Round-trip
- * confirmed on hardware 2026-09-08 (see `INCOTT_CMD_QUERY_BUTTON`). Codec
- * only: nothing here interprets `b0`/`b1`/`b2` as a key, macro, or action —
- * that mapping is unverified and out of scope for this driver.
+ * `09 86 <button 0..5>` -> response bytes 3-6 = the binding, 32-bit
+ * little-endian.
+ *
+ * PREVIOUSLY A BUG: this read only bytes 3-5 and reported them as three
+ * unnamed bytes, silently truncating the top byte. Every action in
+ * `INCOTT_BUTTON_ACTIONS` whose code exceeds 24 bits — "Rapid fire"
+ * (`0x0218F00A`) among them — decoded to a different value than was
+ * written. The vendor reads the same four bytes
+ * (`rData[5]<<24|rData[4]<<16|rData[3]<<8|rData[2]`).
  */
 export function incottDecodeButtonBinding(frame: Uint8Array, button: number): IncottButtonBinding | null {
   if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_BUTTON, button)) return null;
-  if (frame.length < 6) return null;
-  return { button, b0: frame[3]!, b1: frame[4]!, b2: frame[5]! };
+  if (frame.length < 7) return null;
+  const code = ((frame[6]! << 24) | (frame[5]! << 16) | (frame[4]! << 8) | frame[3]!) >>> 0;
+  return { button, code, label: incottButtonActionLabel(code) };
 }
 
 /**

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -864,13 +864,53 @@ export function incottValidateDpi(dpi: number): void {
  * `docs/incott-testing.md` for the open question (find the read the vendor
  * tool uses to display separate X and Y DPI values) that would unblock this.
  */
-export function incottEncodeSetDpi(stage: number, dpi: number): Uint8Array {
+/**
+ * Which axis a DPI write targets, and which one a read asks for.
+ *
+ * On the WRITE the value rides at payload byte 7; on the READ it is request
+ * byte 2 and the reply echoes it back at byte 8. Hardware-verified
+ * 2026-09-11: writing X=800/Y=1600, X=2400/Y=400 and X=1000/Y=1000 to one
+ * stage read back exactly, each axis independently.
+ *
+ * `both` is what a plain `incottEncodeSetDpi` sends, and what reading with no
+ * axis byte returns.
+ */
+export const INCOTT_DPI_AXIS = { both: 0, x: 1, y: 2 } as const;
+export type IncottDpiAxis = keyof typeof INCOTT_DPI_AXIS;
+
+export function incottEncodeSetDpi(stage: number, dpi: number, axis: IncottDpiAxis = "both"): Uint8Array {
   if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
     throw new RangeError(`DPI stage out of range: ${stage}`);
   }
   incottValidateDpi(dpi);
   const wire = dpi / INCOTT_DPI_STEP - 1;
-  return payload(INCOTT_CMD_SET_DPI, stage, wire & 0xff, (wire >> 8) & 0xff);
+  return payload(
+    INCOTT_CMD_SET_DPI,
+    stage,
+    wire & 0xff,
+    (wire >> 8) & 0xff,
+    0,
+    0,
+    0,
+    INCOTT_DPI_AXIS[axis],
+  );
+}
+
+/**
+ * `09 82 <stage> <axis>` — reads one axis of one stage.
+ *
+ * WHY THIS EXISTS, given a plain `09 82 <stage>` already reads a value: this
+ * driver previously recorded that no per-axis read existed, on the strength
+ * of a probe where all three axis values came back identical. They were
+ * identical because X and Y were BOTH at the factory 1600 at the time — the
+ * probe could not tell "no per-axis read" from "per-axis read whose axes
+ * happen to match". Confirmed 2026-09-11 by setting them apart first.
+ */
+export function incottEncodeQueryDpiAxis(stage: number, axis: IncottDpiAxis): Uint8Array {
+  if (!Number.isInteger(stage) || stage < 0 || stage >= INCOTT_DPI_STAGE_COUNT) {
+    throw new RangeError(`DPI stage out of range: ${stage}`);
+  }
+  return payload(INCOTT_CMD_QUERY_DPI_STAGE_VALUE, stage, INCOTT_DPI_AXIS[axis]);
 }
 
 /**
@@ -1049,11 +1089,23 @@ export interface IncottDeviceIdentity {
  * The device latches a single shared response buffer, so a frame left over
  * from an earlier query will otherwise be decoded as a real value.
  */
-export function incottFrameMatches(frame: Uint8Array, cmd: number, sub: number | null): boolean {
+export function incottFrameMatches(
+  frame: Uint8Array,
+  cmd: number,
+  sub: number | null,
+  axis: number | null = null,
+): boolean {
   if (frame.length < 3) return false;
   if (frame[0] !== INCOTT_REPORT_ID) return false;
   if (frame[1] !== cmd) return false;
   if (sub !== null && frame[2] !== sub) return false;
+  // The per-axis DPI read echoes the requested axis at byte 8. Reading X and
+  // then Y on the SAME stage sends two requests whose command and sub-command
+  // are identical, so without this the second read can be satisfied by the
+  // first one's latched reply and both axes report the same number — which
+  // is exactly the reading that made this driver conclude no per-axis read
+  // existed. See `incottEncodeQueryDpiAxis`.
+  if (axis !== null && frame[8] !== axis) return false;
   return true;
 }
 
@@ -1105,6 +1157,24 @@ export function incottDecodeDpiCycle(frame: Uint8Array): IncottDpiCycle | null {
  */
 export function incottDecodeDpiStage(frame: Uint8Array, stage: number): number | null {
   if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_DPI_STAGE_VALUE, stage)) return null;
+  if (frame.length < 5) return null;
+  const wire = frame[3]! | (frame[4]! << 8);
+  const dpi = (wire + 1) * INCOTT_DPI_STEP;
+  return dpi >= INCOTT_DPI_MIN && dpi <= INCOTT_DPI_MAX ? dpi : null;
+}
+
+/**
+ * One axis of one stage, from a reply to `incottEncodeQueryDpiAxis`. The
+ * requested axis MUST be matched at byte 8 — see `incottFrameMatches`.
+ */
+export function incottDecodeDpiStageAxis(
+  frame: Uint8Array,
+  stage: number,
+  axis: IncottDpiAxis,
+): number | null {
+  if (!incottFrameMatches(frame, INCOTT_CMD_QUERY_DPI_STAGE_VALUE, stage, INCOTT_DPI_AXIS[axis])) {
+    return null;
+  }
   if (frame.length < 5) return null;
   const wire = frame[3]! | (frame[4]! << 8);
   const dpi = (wire + 1) * INCOTT_DPI_STEP;

--- a/src/incott/index.ts
+++ b/src/incott/index.ts
@@ -466,7 +466,7 @@ export const INCOTT_MACRO_MAX_STEPS = 71;
  *     [5+4n]     HID keyboard usage code
  *     [6..7+4n]  delay after the event, LE16 milliseconds
  *     [288..293] the ASCII name "Macro" followed by '1' + buffer id
- *     [304..307] (steps + 1) * 132, LE32
+ *     [304..307] (steps + 1) * 4 + 128, LE32
  *     [308..311] 16, 0, 232, 232 — constant in every buffer the vendor builds
  *     [312..315] uid, LE32
  *     [316..317] steps * 2, LE16
@@ -517,7 +517,11 @@ export function incottEncodeMacroBuffer(macro: IncottMacro): Uint8Array {
   out.set([0x4d, 0x61, 0x63, 0x72, 0x6f], 288);
   out[293] = 0x31 + macro.bufferId;
 
-  const size = (macro.steps.length + 1) * 132;
+  // (steps + 1) * 4 + 128. An earlier transcription of this read
+  // `(steps + 1) * 132`, because the deobfuscation pass used to recover the
+  // vendor's source folded the constant `4 + 128` into `132` before anyone
+  // read it. Pinned to a real captured buffer now (2026-09-11).
+  const size = (macro.steps.length + 1) * 4 + 128;
   out[304] = size & 0xff;
   out[305] = (size >> 8) & 0xff;
   out[306] = (size >> 16) & 0xff;
@@ -565,13 +569,30 @@ export function incottMacroChunks(buffer: Uint8Array): Uint8Array[] {
   );
 }
 
-/** Label for a 32-bit action word, or null when it is not one this driver knows. */
+/**
+ * Label for a 32-bit action word, or null when it is not one this driver
+ * knows.
+ *
+ * Macro bindings are named rather than listed: the vendor encodes them as
+ * `slot << 16 | 9` (confirmed 2026-09-11, where binding a button to macro
+ * slot 3 wrote `0x00030009`), so a label can be derived for any slot without
+ * putting ten entries in the picker. `incottButtonActionCode` deliberately
+ * does NOT reverse these — nothing can assign a macro until there is a UI to
+ * author one — so a macro binding reads back correctly and is left alone.
+ */
 export function incottButtonActionLabel(code: number): string | null {
   for (const [label, value] of INCOTT_BUTTON_ACTIONS) {
     if (value === code) return label;
   }
+  if ((code & 0xffff) === INCOTT_BUTTON_MACRO_MARKER) {
+    const slot = code >>> 16;
+    if (slot < INCOTT_MACRO_BUFFER_COUNT) return `Macro ${slot + 1}`;
+  }
   return null;
 }
+
+/** Low half of a macro button binding: `slot << 16 | 9`. */
+export const INCOTT_BUTTON_MACRO_MARKER = 0x0009;
 
 /** 32-bit action word for a label, or null when the label is not in the table. */
 export function incottButtonActionCode(label: string): number | null {


### PR DESCRIPTION
Follows up #87 with the rest of the Incott protocol. Every command is now identified; what isn't implemented is explained rather than left open.

Everything below was verified against a G23V2 Pro unless marked otherwise. Raw captures are in captures/incott-8k-wireless/.

Features
Model detection. All six Incott models share 093a:522c/093a:622c, so the product string can't identify them — it names a model over the cable and not on the dongle. The identity reply (0x8F) carries a model code and the fitted sensor, so MouseStatus.name is now read from the device and is stable across connections.
Button remapping. 32-bit little-endian action words: mouse, media, DPI, rapid fire, plus keyboard keys and ~24 chords (127 actions). Publishes buttonMappings/buttonOptions, so the shared remapper renders with no app change.
Independent X/Y DPI. Per-axis read and write, with dpiY and supportsSeparateDpiAxes.
DPI stage count. setDpiStageCount plus countEditable.
Fire Key (rapid fire). 0x05/0x02 — the last unidentified command. 0 clicks means hold-to-fire.
Receiver LED and rapid fire published as incott* fields, following the finalmouseDongleLedMode pattern. Companion app PR adds the card.
Macros. 320-byte buffer uploaded as ten 32-byte output reports — the only place this protocol uses one. Encoder pinned byte-for-byte to a captured buffer.
Corrections to shipped behaviour
Four of these were bugs in the driver merged in #87:

0x83 byte 2 is the DPI stage count, not a sub-command echo. It was in SUB_ECHOING_QUERIES, so on a mouse with a cycle shorter than six every DPI read failed and the settings grid hid itself. Selecting a stage also wrote a hardcoded 6, silently resizing the cycle.
Button bindings were truncated to three bytes of a four-byte value, so any action above 24 bits decoded to something never written.
The identity sensor slot moves with the receiver — reading a fixed byte dropped the "Pro" suffix on a cable-only connection.
The DPI ceiling now follows the fitted sensor (PAW3395 32000, PAW3950 45000) instead of always offering 45000.
Not included, deliberately
Onboard profiles. The index is real and sticks (0–3) but gates nothing — writing a setting on one slot changes what every slot reports. Publishing profileCount/setProfile would give users a selector that appears to work and doesn't.
A macro authoring UI, pending a contract. uploadMacro is the one writer here with no read-back, because there's no macro read command; the comment says so rather than implying confirmation.
Verification
1602/1602 tests pass, build clean, rebased on current main.

Five of the six model codes are transcribed from the vendor's own dispatch table rather than tested — I only own a G23V2 Pro. That's the one place a second device would help.