### PR TITLE
Add ASUS ROG Gladius II support

### DIFF
--- a/docs/asus-gladius-ii-testing.md
+++ b/docs/asus-gladius-ii-testing.md
@@ -1,0 +1,37 @@
+# ASUS ROG Gladius II P502 Hardware Testing
+
+## Device
+
+- Model: ASUS ROG Gladius II P502
+- Vendor ID: `0x0B05`
+- Product ID: `0x1845`
+- Usage Page: `0xFF01`
+- Usage: `0x0001`
+- Connection: Wired USB
+
+## Verified HID interface
+
+The configuration interface was verified through WebHID.
+
+Observed collections included:
+
+- Consumer Control
+- Keyboard
+- Vendor-defined configuration interface
+
+The configuration interface used by OpenMouse is:
+
+- Usage Page: `0xFF01`
+- Usage: `0x0001`
+- Input Report ID: `0`
+- Output Report ID: `0`
+- Report payload size: `64` bytes
+
+## Verified read commands
+
+### Settings
+
+Request:
+
+```text
+12 04 00

--- a/src/asus/index.ts
+++ b/src/asus/index.ts
@@ -1,0 +1,223 @@
+export const ASUS_VENDOR_ID = 0x0b05;
+
+export const ROG_GLADIUS_II_PRODUCT_ID = 0x1845;
+
+export const ASUS_GLADIUS_II_USAGE_PAGE = 0xff01;
+export const ASUS_GLADIUS_II_USAGE = 0x0001;
+
+export const ASUS_REPORT_ID = 0;
+export const ASUS_REPORT_SIZE = 64;
+
+export const GLADIUS_II_MIN_DPI = 100;
+export const GLADIUS_II_MAX_DPI = 12000;
+export const GLADIUS_II_DPI_STEP = 100;
+
+export const GLADIUS_II_POLLING_RATES = [
+  125,
+  250,
+  500,
+  1000,
+] as const;
+
+export interface GladiusIISettings {
+  dpiStages: [number, number];
+  pollingRateHz: number;
+  debounceMs: number | null;
+  angleSnapping: boolean;
+}
+
+export interface GladiusIIProfile {
+  onboardProfile: number;
+  activeDpiStage: number;
+}
+
+function requirePrefix(
+  data: Uint8Array,
+  expected: readonly number[],
+  name: string,
+): void {
+  if (data.length < expected.length) {
+    throw new Error(`${name} reply is too short.`);
+  }
+
+  for (let i = 0; i < expected.length; i++) {
+    if (data[i] !== expected[i]) {
+      throw new Error(
+        `${name} reply has unexpected byte ${i}: ` +
+        `0x${data[i]?.toString(16).padStart(2, "0")}`,
+      );
+    }
+  }
+}
+
+function readUint16LE(data: Uint8Array, offset: number): number {
+  return data[offset] | (data[offset + 1] << 8);
+}
+
+function decodeDpiWord(value: number): number {
+  return (value + 1) * GLADIUS_II_DPI_STEP;
+}
+
+/**
+ * WebHID payload:
+ *
+ * 12 04 00 00
+ * [DPI1 lo hi]
+ * [DPI2 lo hi]
+ * [poll]
+ * 00
+ * [debounce]
+ * 00
+ * [angle snap]
+ */
+export function decodeGladiusIISettings(
+  data: Uint8Array,
+): GladiusIISettings {
+  requirePrefix(data, [0x12, 0x04, 0x00], "Gladius II settings");
+
+  if (data.length < 13) {
+    throw new Error("Gladius II settings reply is incomplete.");
+  }
+
+  const dpi1 = decodeDpiWord(readUint16LE(data, 4));
+  const dpi2 = decodeDpiWord(readUint16LE(data, 6));
+
+  const pollingRaw = data[8];
+
+  const pollingRateHz = GLADIUS_II_POLLING_RATES[pollingRaw];
+
+  if (pollingRateHz === undefined) {
+    throw new Error(
+      `Unknown Gladius II polling value 0x${pollingRaw
+        .toString(16)
+        .padStart(2, "0")}.`,
+    );
+  }
+
+  const debounceRaw = data[10];
+
+  // ASUS values 0x02..0x07 map to:
+  // 12, 16, 20, 24, 28, 32 ms.
+  const debounceMs =
+    debounceRaw >= 0x02 && debounceRaw <= 0x07
+      ? debounceRaw * 4 + 4
+      : null;
+
+  return {
+    dpiStages: [dpi1, dpi2],
+    pollingRateHz,
+    debounceMs,
+    angleSnapping: data[12] === 0x01,
+  };
+}
+
+/**
+ * WebHID payload:
+ *
+ * 12 00 00 ...
+ *
+ * G-Helper's packet indices include the HID report-id byte.
+ * WebHID removes that byte, therefore:
+ *
+ * packet[11] -> data[10] = onboard profile
+ * packet[12] -> data[11] = active DPI stage (1-based)
+ */
+export function decodeGladiusIIProfile(
+  data: Uint8Array,
+): GladiusIIProfile {
+  requirePrefix(data, [0x12, 0x00, 0x00], "Gladius II profile");
+
+  if (data.length < 12) {
+    throw new Error("Gladius II profile reply is incomplete.");
+  }
+
+  const onboardProfileRaw = data[10];
+  const dpiStageRaw = data[11];
+
+  if (dpiStageRaw < 1 || dpiStageRaw > 2) {
+    throw new Error(
+      `Invalid Gladius II DPI stage ${dpiStageRaw}.`,
+    );
+  }
+
+  return {
+    // ASUS profile is zero-based.
+    onboardProfile: onboardProfileRaw + 1,
+
+    // OpenMouse DPI stage is zero-based.
+    activeDpiStage: dpiStageRaw - 1,
+  };
+}
+
+function request(...bytes: number[]): Uint8Array {
+  const data = new Uint8Array(ASUS_REPORT_SIZE);
+  data.set(bytes);
+  return data;
+}
+
+export function gladiusIISetDpiRequest(
+  stage: number,
+  dpi: number,
+): Uint8Array {
+  if (!Number.isInteger(stage) || stage < 0 || stage > 1) {
+    throw new Error("Gladius II DPI stage must be 0 or 1.");
+  }
+
+  if (
+    !Number.isInteger(dpi) ||
+    dpi < GLADIUS_II_MIN_DPI ||
+    dpi > GLADIUS_II_MAX_DPI ||
+    dpi % GLADIUS_II_DPI_STEP !== 0
+  ) {
+    throw new Error(
+      `Gladius II DPI must be ${GLADIUS_II_MIN_DPI}-${GLADIUS_II_MAX_DPI} in ${GLADIUS_II_DPI_STEP}-DPI steps.`,
+    );
+  }
+
+  const encoded =
+    (dpi - GLADIUS_II_DPI_STEP) /
+    GLADIUS_II_DPI_STEP;
+
+  return request(
+    0x51,
+    0x31,
+    stage,
+    0x00,
+    encoded & 0xff,
+    (encoded >> 8) & 0xff,
+  );
+}
+
+export function gladiusIISetPollingRateRequest(
+  pollingRateHz: number,
+): Uint8Array {
+  const rateIndex = GLADIUS_II_POLLING_RATES.findIndex(
+    (rate) => rate === pollingRateHz,
+  );
+
+  if (rateIndex === -1) {
+    throw new Error(
+      `Unsupported Gladius II polling rate: ${pollingRateHz} Hz.`,
+    );
+  }
+
+  return request(
+    0x51,
+    0x31,
+    0x02,
+    0x00,
+    rateIndex,
+  );
+}
+
+export function gladiusIISaveRequest(): Uint8Array {
+  return request(0x50, 0x03);
+}
+
+export function gladiusIIReadSettingsRequest(): Uint8Array {
+  return request(0x12, 0x04, 0x00);
+}
+
+export function gladiusIIReadProfileRequest(): Uint8Array {
+  return request(0x12, 0x00);
+}

--- a/src/asus/index.ts
+++ b/src/asus/index.ts
@@ -12,12 +12,27 @@ export const GLADIUS_II_MIN_DPI = 100;
 export const GLADIUS_II_MAX_DPI = 12000;
 export const GLADIUS_II_DPI_STEP = 100;
 
+export const GLADIUS_II_PROFILE_COUNT = 3;
+
 export const GLADIUS_II_POLLING_RATES = [
   125,
   250,
   500,
   1000,
 ] as const;
+
+export const GLADIUS_II_DEBOUNCE_MS = [
+  12,
+  16,
+  20,
+  24,
+  28,
+  32,
+] as const;
+
+export type GladiusIILiftOffDistance =
+  | "Low"
+  | "High";
 
 export interface GladiusIISettings {
   dpiStages: [number, number];
@@ -31,62 +46,113 @@ export interface GladiusIIProfile {
   activeDpiStage: number;
 }
 
+export interface GladiusIIRawLightingZone {
+  zone: number;
+  mode: number;
+  brightness: number;
+  red: number;
+  green: number;
+  blue: number;
+  direction: number;
+  randomColor: boolean;
+  speed: number;
+}
+
 function requirePrefix(
   data: Uint8Array,
   expected: readonly number[],
   name: string,
 ): void {
   if (data.length < expected.length) {
-    throw new Error(`${name} reply is too short.`);
+    throw new Error(
+      `${name} reply is too short.`,
+    );
   }
 
-  for (let i = 0; i < expected.length; i++) {
+  for (
+    let i = 0;
+    i < expected.length;
+    i++
+  ) {
     if (data[i] !== expected[i]) {
       throw new Error(
         `${name} reply has unexpected byte ${i}: ` +
-        `0x${data[i]?.toString(16).padStart(2, "0")}`,
+          `0x${data[i]
+            ?.toString(16)
+            .padStart(2, "0")}`,
       );
     }
   }
 }
 
-function readUint16LE(data: Uint8Array, offset: number): number {
-  return data[offset] | (data[offset + 1] << 8);
+function readUint16LE(
+  data: Uint8Array,
+  offset: number,
+): number {
+  return (
+    data[offset] |
+    (data[offset + 1] << 8)
+  );
 }
 
-function decodeDpiWord(value: number): number {
-  return (value + 1) * GLADIUS_II_DPI_STEP;
+function decodeDpiWord(
+  value: number,
+): number {
+  return (
+    (value + 1) *
+    GLADIUS_II_DPI_STEP
+  );
 }
 
-/**
- * WebHID payload:
- *
- * 12 04 00 00
- * [DPI1 lo hi]
- * [DPI2 lo hi]
- * [poll]
- * 00
- * [debounce]
- * 00
- * [angle snap]
- */
+function request(
+  ...bytes: number[]
+): Uint8Array {
+  const data = new Uint8Array(
+    ASUS_REPORT_SIZE,
+  );
+
+  data.set(bytes);
+
+  return data;
+}
+
+/* ---------------------------------
+ * READ DECODERS
+ * --------------------------------- */
+
 export function decodeGladiusIISettings(
   data: Uint8Array,
 ): GladiusIISettings {
-  requirePrefix(data, [0x12, 0x04, 0x00], "Gladius II settings");
+  requirePrefix(
+    data,
+    [0x12, 0x04, 0x00],
+    "Gladius II settings",
+  );
 
   if (data.length < 13) {
-    throw new Error("Gladius II settings reply is incomplete.");
+    throw new Error(
+      "Gladius II settings reply is incomplete.",
+    );
   }
 
-  const dpi1 = decodeDpiWord(readUint16LE(data, 4));
-  const dpi2 = decodeDpiWord(readUint16LE(data, 6));
+  const dpi1 = decodeDpiWord(
+    readUint16LE(data, 4),
+  );
+
+  const dpi2 = decodeDpiWord(
+    readUint16LE(data, 6),
+  );
 
   const pollingRaw = data[8];
 
-  const pollingRateHz = GLADIUS_II_POLLING_RATES[pollingRaw];
+  const pollingRateHz =
+    GLADIUS_II_POLLING_RATES[
+      pollingRaw
+    ];
 
-  if (pollingRateHz === undefined) {
+  if (
+    pollingRateHz === undefined
+  ) {
     throw new Error(
       `Unknown Gladius II polling value 0x${pollingRaw
         .toString(16)
@@ -94,12 +160,12 @@ export function decodeGladiusIISettings(
     );
   }
 
-  const debounceRaw = data[10];
+  const debounceRaw =
+    data[10];
 
-  // ASUS values 0x02..0x07 map to:
-  // 12, 16, 20, 24, 28, 32 ms.
   const debounceMs =
-    debounceRaw >= 0x02 && debounceRaw <= 0x07
+    debounceRaw >= 0x02 &&
+    debounceRaw <= 0x07
       ? debounceRaw * 4 + 4
       : null;
 
@@ -107,67 +173,183 @@ export function decodeGladiusIISettings(
     dpiStages: [dpi1, dpi2],
     pollingRateHz,
     debounceMs,
-    angleSnapping: data[12] === 0x01,
+    angleSnapping:
+      data[12] === 0x01,
   };
 }
 
-/**
- * WebHID payload:
- *
- * 12 00 00 ...
- *
- * G-Helper's packet indices include the HID report-id byte.
- * WebHID removes that byte, therefore:
- *
- * packet[11] -> data[10] = onboard profile
- * packet[12] -> data[11] = active DPI stage (1-based)
- */
 export function decodeGladiusIIProfile(
   data: Uint8Array,
 ): GladiusIIProfile {
-  requirePrefix(data, [0x12, 0x00, 0x00], "Gladius II profile");
+  requirePrefix(
+    data,
+    [0x12, 0x00, 0x00],
+    "Gladius II profile",
+  );
 
   if (data.length < 12) {
-    throw new Error("Gladius II profile reply is incomplete.");
+    throw new Error(
+      "Gladius II profile reply is incomplete.",
+    );
   }
 
-  const onboardProfileRaw = data[10];
-  const dpiStageRaw = data[11];
+  const onboardProfileRaw =
+    data[10];
 
-  if (dpiStageRaw < 1 || dpiStageRaw > 2) {
+  const dpiStageRaw =
+    data[11];
+
+  if (
+    dpiStageRaw < 1 ||
+    dpiStageRaw > 2
+  ) {
     throw new Error(
       `Invalid Gladius II DPI stage ${dpiStageRaw}.`,
     );
   }
 
   return {
-    // ASUS profile is zero-based.
-    onboardProfile: onboardProfileRaw + 1,
+    onboardProfile:
+      onboardProfileRaw + 1,
 
-    // OpenMouse DPI stage is zero-based.
-    activeDpiStage: dpiStageRaw - 1,
+    activeDpiStage:
+      dpiStageRaw - 1,
   };
 }
 
-function request(...bytes: number[]): Uint8Array {
-  const data = new Uint8Array(ASUS_REPORT_SIZE);
-  data.set(bytes);
-  return data;
+export function decodeGladiusIILiftOffDistance(
+  data: Uint8Array,
+): GladiusIILiftOffDistance {
+  requirePrefix(
+    data,
+    [0x12, 0x06],
+    "Gladius II lift-off",
+  );
+
+  if (data.length < 8) {
+    throw new Error(
+      "Gladius II lift-off reply is incomplete.",
+    );
+  }
+
+  const raw = data[7];
+
+  if (raw === 0) {
+    return "Low";
+  }
+
+  if (raw === 1) {
+    return "High";
+  }
+
+  throw new Error(
+    `Unknown Gladius II lift-off value ${raw}.`,
+  );
 }
+
+export function decodeGladiusIILighting(
+  data: Uint8Array,
+): GladiusIIRawLightingZone[] {
+  requirePrefix(
+    data,
+    [0x12, 0x03, 0x00],
+    "Gladius II lighting",
+  );
+
+  if (data.length < 23) {
+    throw new Error(
+      "Gladius II lighting reply is incomplete.",
+    );
+  }
+
+  const direction = data[20];
+  const randomColor =
+    data[21] === 0x01;
+  const speed = data[22];
+
+  const zones: GladiusIIRawLightingZone[] =
+    [];
+
+  for (let zone = 0; zone < 3; zone++) {
+    const offset =
+      4 + zone * 5;
+
+    zones.push({
+      zone,
+      mode: data[offset],
+      brightness:
+        data[offset + 1],
+      red: data[offset + 2],
+      green: data[offset + 3],
+      blue: data[offset + 4],
+      direction,
+      randomColor,
+      speed,
+    });
+  }
+
+  return zones;
+}
+
+/* ---------------------------------
+ * READ REQUESTS
+ * --------------------------------- */
+
+export function gladiusIIReadSettingsRequest(): Uint8Array {
+  return request(
+    0x12,
+    0x04,
+    0x00,
+  );
+}
+
+export function gladiusIIReadProfileRequest(): Uint8Array {
+  return request(
+    0x12,
+    0x00,
+  );
+}
+
+export function gladiusIIReadLiftOffRequest(): Uint8Array {
+  return request(
+    0x12,
+    0x06,
+  );
+}
+
+export function gladiusIIReadLightingRequest(): Uint8Array {
+  return request(
+    0x12,
+    0x03,
+    0x00,
+  );
+}
+
+/* ---------------------------------
+ * DPI
+ * --------------------------------- */
 
 export function gladiusIISetDpiRequest(
   stage: number,
   dpi: number,
 ): Uint8Array {
-  if (!Number.isInteger(stage) || stage < 0 || stage > 1) {
-    throw new Error("Gladius II DPI stage must be 0 or 1.");
+  if (
+    !Number.isInteger(stage) ||
+    stage < 0 ||
+    stage > 1
+  ) {
+    throw new Error(
+      "Gladius II DPI stage must be 0 or 1.",
+    );
   }
 
   if (
     !Number.isInteger(dpi) ||
     dpi < GLADIUS_II_MIN_DPI ||
     dpi > GLADIUS_II_MAX_DPI ||
-    dpi % GLADIUS_II_DPI_STEP !== 0
+    dpi %
+      GLADIUS_II_DPI_STEP !==
+      0
   ) {
     throw new Error(
       `Gladius II DPI must be ${GLADIUS_II_MIN_DPI}-${GLADIUS_II_MAX_DPI} in ${GLADIUS_II_DPI_STEP}-DPI steps.`,
@@ -175,7 +357,8 @@ export function gladiusIISetDpiRequest(
   }
 
   const encoded =
-    (dpi - GLADIUS_II_DPI_STEP) /
+    (dpi -
+      GLADIUS_II_DPI_STEP) /
     GLADIUS_II_DPI_STEP;
 
   return request(
@@ -188,12 +371,40 @@ export function gladiusIISetDpiRequest(
   );
 }
 
+export function gladiusIISetActiveDpiStageRequest(
+  stage: number,
+): Uint8Array {
+  if (
+    !Number.isInteger(stage) ||
+    stage < 0 ||
+    stage > 1
+  ) {
+    throw new Error(
+      "Gladius II DPI stage must be 0 or 1.",
+    );
+  }
+
+  return request(
+    0x51,
+    0x31,
+    0x09,
+    0x00,
+    stage + 1,
+  );
+}
+
+/* ---------------------------------
+ * POLLING
+ * --------------------------------- */
+
 export function gladiusIISetPollingRateRequest(
   pollingRateHz: number,
 ): Uint8Array {
-  const rateIndex = GLADIUS_II_POLLING_RATES.findIndex(
-    (rate) => rate === pollingRateHz,
-  );
+  const rateIndex =
+    GLADIUS_II_POLLING_RATES.findIndex(
+      (rate) =>
+        rate === pollingRateHz,
+    );
 
   if (rateIndex === -1) {
     throw new Error(
@@ -210,14 +421,156 @@ export function gladiusIISetPollingRateRequest(
   );
 }
 
+/* ---------------------------------
+ * ONBOARD PROFILE
+ * --------------------------------- */
+
+export function gladiusIISetProfileRequest(
+  profile: number,
+): Uint8Array {
+  if (
+    !Number.isInteger(profile) ||
+    profile < 1 ||
+    profile >
+      GLADIUS_II_PROFILE_COUNT
+  ) {
+    throw new Error(
+      `Gladius II profile must be 1-${GLADIUS_II_PROFILE_COUNT}.`,
+    );
+  }
+
+  return request(
+    0x50,
+    0x02,
+    profile - 1,
+  );
+}
+
+/* ---------------------------------
+ * ANGLE SNAPPING
+ * --------------------------------- */
+
+export function gladiusIISetAngleSnappingRequest(
+  enabled: boolean,
+): Uint8Array {
+  return request(
+    0x51,
+    0x31,
+    0x04,
+    0x00,
+    enabled ? 0x01 : 0x00,
+  );
+}
+
+/* ---------------------------------
+ * DEBOUNCE
+ * --------------------------------- */
+
+export function gladiusIISetDebounceRequest(
+  milliseconds: number,
+): Uint8Array {
+  if (
+    !GLADIUS_II_DEBOUNCE_MS.some(
+      (value) =>
+        value === milliseconds,
+    )
+  ) {
+    throw new Error(
+      `Gladius II debounce must be one of: ${GLADIUS_II_DEBOUNCE_MS.join(", ")} ms.`,
+    );
+  }
+
+  const raw =
+    milliseconds / 4 - 1;
+
+  return request(
+    0x51,
+    0x31,
+    0x03,
+    0x00,
+    raw,
+  );
+}
+
+/* ---------------------------------
+ * LIFT-OFF DISTANCE
+ * --------------------------------- */
+
+export function gladiusIISetLiftOffRequest(
+  value: GladiusIILiftOffDistance,
+): Uint8Array {
+  const raw =
+    value === "High"
+      ? 1
+      : 0;
+
+  return request(
+    0x51,
+    0x35,
+    0xff,
+    0x00,
+    0xff,
+    raw,
+  );
+}
+
+/* ---------------------------------
+ * RGB
+ * --------------------------------- */
+
+export function gladiusIISetLightingRequest(
+  zone: number,
+  mode: number,
+  brightness: number,
+  red: number,
+  green: number,
+  blue: number,
+  direction = 0,
+  randomColor = 0,
+  speed = 0,
+): Uint8Array {
+  if (
+    !Number.isInteger(zone) ||
+    zone < 0 ||
+    zone > 2
+  ) {
+    throw new Error(
+      "Gladius II RGB zone must be 0, 1, or 2.",
+    );
+  }
+
+  if (
+    brightness < 0 ||
+    brightness > 4
+  ) {
+    throw new Error(
+      "Gladius II RGB brightness must be 0-4.",
+    );
+  }
+
+  return request(
+    0x51,
+    0x28,
+    zone,
+    0x00,
+    mode,
+    brightness,
+    red,
+    green,
+    blue,
+    direction,
+    randomColor,
+    speed,
+  );
+}
+
+/* ---------------------------------
+ * SAVE
+ * --------------------------------- */
+
 export function gladiusIISaveRequest(): Uint8Array {
-  return request(0x50, 0x03);
-}
-
-export function gladiusIIReadSettingsRequest(): Uint8Array {
-  return request(0x12, 0x04, 0x00);
-}
-
-export function gladiusIIReadProfileRequest(): Uint8Array {
-  return request(0x12, 0x00);
+  return request(
+    0x50,
+    0x03,
+  );
 }

--- a/src/drivers/asus/hid.test.ts
+++ b/src/drivers/asus/hid.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decodeGladiusIIProfile,
+  decodeGladiusIISettings,
+} from "../../asus/index.ts";
+
+function packet(hex: string): Uint8Array {
+  return Uint8Array.from(
+    hex
+      .trim()
+      .split(/\s+/)
+      .map((value) => Number.parseInt(value, 16)),
+  );
+}
+
+test("decodes verified Gladius II settings capture", () => {
+  const response = packet(`
+    12 04 00 00
+    0E 00
+    0B 00
+    03
+    00
+    07
+    00
+    00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00
+  `);
+
+  const result =
+    decodeGladiusIISettings(response);
+
+  assert.deepEqual(result.dpiStages, [
+    1500,
+    1200,
+  ]);
+
+  assert.equal(result.pollingRateHz, 1000);
+  assert.equal(result.debounceMs, 32);
+  assert.equal(result.angleSnapping, false);
+});
+
+test("decodes verified Gladius II profile capture", () => {
+  const response = packet(`
+    12 00 00 00
+    30 31 39 35
+    03 06
+    00
+    01
+    0E 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00
+    00 00
+  `);
+
+  const result =
+    decodeGladiusIIProfile(response);
+
+  assert.equal(result.onboardProfile, 1);
+  assert.equal(result.activeDpiStage, 0);
+});

--- a/src/drivers/asus/hid.test.ts
+++ b/src/drivers/asus/hid.test.ts
@@ -2,8 +2,20 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  ASUS_REPORT_SIZE,
   decodeGladiusIIProfile,
   decodeGladiusIISettings,
+  gladiusIIReadProfileRequest,
+  gladiusIIReadSettingsRequest,
+  gladiusIISaveRequest,
+  gladiusIISetActiveDpiStageRequest,
+  gladiusIISetAngleSnappingRequest,
+  gladiusIISetDebounceRequest,
+  gladiusIISetDpiRequest,
+  gladiusIISetLiftOffRequest,
+  gladiusIISetLightingRequest,
+  gladiusIISetPollingRateRequest,
+  gladiusIISetProfileRequest,
 } from "../../asus/index.ts";
 
 function packet(hex: string): Uint8Array {
@@ -11,62 +23,618 @@ function packet(hex: string): Uint8Array {
     hex
       .trim()
       .split(/\s+/)
-      .map((value) => Number.parseInt(value, 16)),
+      .map((value) =>
+        Number.parseInt(value, 16),
+      ),
   );
 }
 
-test("decodes verified Gladius II settings capture", () => {
-  const response = packet(`
-    12 04 00 00
-    0E 00
-    0B 00
-    03
-    00
-    07
-    00
-    00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00
-  `);
+function expectPrefix(
+  actual: Uint8Array,
+  expected: number[],
+): void {
+  assert.equal(
+    actual.length,
+    ASUS_REPORT_SIZE,
+  );
 
-  const result =
-    decodeGladiusIISettings(response);
+  assert.deepEqual(
+    [...actual.slice(0, expected.length)],
+    expected,
+  );
 
-  assert.deepEqual(result.dpiStages, [
-    1500,
-    1200,
-  ]);
+  // Everything after the command should remain zero-filled.
+  assert.ok(
+    [...actual.slice(expected.length)].every(
+      (value) => value === 0,
+    ),
+  );
+}
 
-  assert.equal(result.pollingRateHz, 1000);
-  assert.equal(result.debounceMs, 32);
-  assert.equal(result.angleSnapping, false);
-});
+/* ---------------------------------------------------------
+ * VERIFIED HARDWARE READ CAPTURES
+ * --------------------------------------------------------- */
 
-test("decodes verified Gladius II profile capture", () => {
-  const response = packet(`
-    12 00 00 00
-    30 31 39 35
-    03 06
-    00
-    01
-    0E 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00
-    00 00
-  `);
+test(
+  "decodes verified Gladius II settings capture",
+  () => {
+    const response = packet(`
+      12 04 00 00
+      0E 00
+      0B 00
+      03
+      00
+      07
+      00
+      00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00
+    `);
 
-  const result =
-    decodeGladiusIIProfile(response);
+    const result =
+      decodeGladiusIISettings(
+        response,
+      );
 
-  assert.equal(result.onboardProfile, 1);
-  assert.equal(result.activeDpiStage, 0);
-});
+    assert.deepEqual(
+      result.dpiStages,
+      [1500, 1200],
+    );
+
+    assert.equal(
+      result.pollingRateHz,
+      1000,
+    );
+
+    assert.equal(
+      result.debounceMs,
+      32,
+    );
+
+    assert.equal(
+      result.angleSnapping,
+      false,
+    );
+  },
+);
+
+test(
+  "decodes verified Gladius II profile capture",
+  () => {
+    const response = packet(`
+      12 00 00 00
+      30 31 39 35
+      03 06
+      00
+      01
+      0E 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00
+      00 00
+    `);
+
+    const result =
+      decodeGladiusIIProfile(
+        response,
+      );
+
+    assert.equal(
+      result.onboardProfile,
+      1,
+    );
+
+    assert.equal(
+      result.activeDpiStage,
+      0,
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * READ REQUESTS
+ * --------------------------------------------------------- */
+
+test(
+  "builds Gladius II settings read request",
+  () => {
+    expectPrefix(
+      gladiusIIReadSettingsRequest(),
+      [
+        0x12,
+        0x04,
+        0x00,
+      ],
+    );
+  },
+);
+
+test(
+  "builds Gladius II profile read request",
+  () => {
+    expectPrefix(
+      gladiusIIReadProfileRequest(),
+      [
+        0x12,
+        0x00,
+      ],
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * DPI
+ * --------------------------------------------------------- */
+
+test(
+  "builds stage 1 1600 DPI request",
+  () => {
+    expectPrefix(
+      gladiusIISetDpiRequest(
+        0,
+        1600,
+      ),
+      [
+        0x51,
+        0x31,
+        0x00,
+        0x00,
+        0x0f,
+        0x00,
+      ],
+    );
+  },
+);
+
+test(
+  "builds stage 2 12000 DPI request",
+  () => {
+    /*
+     * (12000 - 100) / 100 = 119
+     * 119 = 0x0077
+     */
+    expectPrefix(
+      gladiusIISetDpiRequest(
+        1,
+        12000,
+      ),
+      [
+        0x51,
+        0x31,
+        0x01,
+        0x00,
+        0x77,
+        0x00,
+      ],
+    );
+  },
+);
+
+test(
+  "rejects invalid DPI value",
+  () => {
+    assert.throws(
+      () =>
+        gladiusIISetDpiRequest(
+          0,
+          1550,
+        ),
+      /DPI must be/,
+    );
+  },
+);
+
+test(
+  "rejects invalid DPI stage",
+  () => {
+    assert.throws(
+      () =>
+        gladiusIISetDpiRequest(
+          2,
+          1600,
+        ),
+      /stage must be 0 or 1/,
+    );
+  },
+);
+
+test(
+  "builds active DPI stage 2 request",
+  () => {
+    expectPrefix(
+      gladiusIISetActiveDpiStageRequest(
+        1,
+      ),
+      [
+        0x51,
+        0x31,
+        0x09,
+        0x00,
+        0x02,
+      ],
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * POLLING RATE
+ * --------------------------------------------------------- */
+
+test(
+  "builds 125 Hz polling request",
+  () => {
+    expectPrefix(
+      gladiusIISetPollingRateRequest(
+        125,
+      ),
+      [
+        0x51,
+        0x31,
+        0x02,
+        0x00,
+        0x00,
+      ],
+    );
+  },
+);
+
+test(
+  "builds 500 Hz polling request",
+  () => {
+    expectPrefix(
+      gladiusIISetPollingRateRequest(
+        500,
+      ),
+      [
+        0x51,
+        0x31,
+        0x02,
+        0x00,
+        0x02,
+      ],
+    );
+  },
+);
+
+test(
+  "builds 1000 Hz polling request",
+  () => {
+    expectPrefix(
+      gladiusIISetPollingRateRequest(
+        1000,
+      ),
+      [
+        0x51,
+        0x31,
+        0x02,
+        0x00,
+        0x03,
+      ],
+    );
+  },
+);
+
+test(
+  "rejects unsupported polling rate",
+  () => {
+    assert.throws(
+      () =>
+        gladiusIISetPollingRateRequest(
+          2000,
+        ),
+      /Unsupported Gladius II polling rate/,
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * ONBOARD PROFILES
+ * --------------------------------------------------------- */
+
+test(
+  "builds profile 1 request",
+  () => {
+    expectPrefix(
+      gladiusIISetProfileRequest(
+        1,
+      ),
+      [
+        0x50,
+        0x02,
+        0x00,
+      ],
+    );
+  },
+);
+
+test(
+  "builds profile 3 request",
+  () => {
+    expectPrefix(
+      gladiusIISetProfileRequest(
+        3,
+      ),
+      [
+        0x50,
+        0x02,
+        0x02,
+      ],
+    );
+  },
+);
+
+test(
+  "rejects invalid profile",
+  () => {
+    assert.throws(
+      () =>
+        gladiusIISetProfileRequest(
+          4,
+        ),
+      /profile must be 1-3/,
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * ANGLE SNAPPING
+ * --------------------------------------------------------- */
+
+test(
+  "builds angle snapping on request",
+  () => {
+    expectPrefix(
+      gladiusIISetAngleSnappingRequest(
+        true,
+      ),
+      [
+        0x51,
+        0x31,
+        0x04,
+        0x00,
+        0x01,
+      ],
+    );
+  },
+);
+
+test(
+  "builds angle snapping off request",
+  () => {
+    expectPrefix(
+      gladiusIISetAngleSnappingRequest(
+        false,
+      ),
+      [
+        0x51,
+        0x31,
+        0x04,
+        0x00,
+        0x00,
+      ],
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * DEBOUNCE
+ * --------------------------------------------------------- */
+
+test(
+  "builds 12 ms debounce request",
+  () => {
+    expectPrefix(
+      gladiusIISetDebounceRequest(
+        12,
+      ),
+      [
+        0x51,
+        0x31,
+        0x03,
+        0x00,
+        0x02,
+      ],
+    );
+  },
+);
+
+test(
+  "builds 32 ms debounce request",
+  () => {
+    expectPrefix(
+      gladiusIISetDebounceRequest(
+        32,
+      ),
+      [
+        0x51,
+        0x31,
+        0x03,
+        0x00,
+        0x07,
+      ],
+    );
+  },
+);
+
+test(
+  "rejects unsupported debounce value",
+  () => {
+    assert.throws(
+      () =>
+        gladiusIISetDebounceRequest(
+          10,
+        ),
+      /debounce must be one of/,
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * LIFT-OFF DISTANCE
+ * --------------------------------------------------------- */
+
+test(
+  "builds low lift-off distance request",
+  () => {
+    expectPrefix(
+      gladiusIISetLiftOffRequest(
+        "Low",
+      ),
+      [
+        0x51,
+        0x35,
+        0xff,
+        0x00,
+        0xff,
+        0x00,
+      ],
+    );
+  },
+);
+
+test(
+  "builds high lift-off distance request",
+  () => {
+    expectPrefix(
+      gladiusIISetLiftOffRequest(
+        "High",
+      ),
+      [
+        0x51,
+        0x35,
+        0xff,
+        0x00,
+        0xff,
+        0x01,
+      ],
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * RGB
+ * --------------------------------------------------------- */
+
+test(
+  "builds static red logo RGB request",
+  () => {
+    expectPrefix(
+      gladiusIISetLightingRequest(
+        0,
+        0x00,
+        4,
+        0xff,
+        0x00,
+        0x00,
+      ),
+      [
+        0x51,
+        0x28,
+        0x00,
+        0x00,
+        0x00,
+        0x04,
+        0xff,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+      ],
+    );
+  },
+);
+
+test(
+  "builds RGB request for underglow zone",
+  () => {
+    expectPrefix(
+      gladiusIISetLightingRequest(
+        2,
+        0x01,
+        3,
+        0x12,
+        0x34,
+        0x56,
+        1,
+        0,
+        0x64,
+      ),
+      [
+        0x51,
+        0x28,
+        0x02,
+        0x00,
+        0x01,
+        0x03,
+        0x12,
+        0x34,
+        0x56,
+        0x01,
+        0x00,
+        0x64,
+      ],
+    );
+  },
+);
+
+test(
+  "rejects invalid RGB zone",
+  () => {
+    assert.throws(
+      () =>
+        gladiusIISetLightingRequest(
+          3,
+          0,
+          4,
+          255,
+          0,
+          0,
+        ),
+      /RGB zone must be 0, 1, or 2/,
+    );
+  },
+);
+
+test(
+  "rejects invalid RGB brightness",
+  () => {
+    assert.throws(
+      () =>
+        gladiusIISetLightingRequest(
+          0,
+          0,
+          5,
+          255,
+          0,
+          0,
+        ),
+      /brightness must be 0-4/,
+    );
+  },
+);
+
+/* ---------------------------------------------------------
+ * SAVE
+ * --------------------------------------------------------- */
+
+test(
+  "builds ASUS save request",
+  () => {
+    expectPrefix(
+      gladiusIISaveRequest(),
+      [
+        0x50,
+        0x03,
+      ],
+    );
+  },
+);

--- a/src/drivers/asus/hid.ts
+++ b/src/drivers/asus/hid.ts
@@ -1,4 +1,8 @@
-import type { MouseStatus } from "../mouse-types.ts";
+import type {
+  MouseLighting,
+  MouseLightingMode,
+  MouseStatus,
+} from "../mouse-types.ts";
 
 import {
   ASUS_GLADIUS_II_USAGE,
@@ -6,27 +10,88 @@ import {
   ASUS_REPORT_ID,
   ASUS_REPORT_SIZE,
   ASUS_VENDOR_ID,
+  GLADIUS_II_DEBOUNCE_MS,
   GLADIUS_II_DPI_STEP,
   GLADIUS_II_MAX_DPI,
   GLADIUS_II_MIN_DPI,
   GLADIUS_II_POLLING_RATES,
+  GLADIUS_II_PROFILE_COUNT,
   ROG_GLADIUS_II_PRODUCT_ID,
+  decodeGladiusIILiftOffDistance,
+  decodeGladiusIILighting,
   decodeGladiusIIProfile,
   decodeGladiusIISettings,
+  gladiusIIReadLiftOffRequest,
+  gladiusIIReadLightingRequest,
   gladiusIIReadProfileRequest,
   gladiusIIReadSettingsRequest,
-  gladiusIISetDpiRequest,
-  gladiusIISetPollingRateRequest,
   gladiusIISaveRequest,
+  gladiusIISetActiveDpiStageRequest,
+  gladiusIISetAngleSnappingRequest,
+  gladiusIISetDebounceRequest,
+  gladiusIISetDpiRequest,
+  gladiusIISetLiftOffRequest,
+  gladiusIISetLightingRequest,
+  gladiusIISetPollingRateRequest,
+  gladiusIISetProfileRequest,
+  type GladiusIIRawLightingZone,
 } from "../../asus/index.ts";
 
 const RESPONSE_TIMEOUT_MS = 1000;
 
-function copyDataView(view: DataView): Uint8Array {
+const RGB_ZONE_NAMES = [
+  "Logo",
+  "Scroll wheel",
+  "Underglow",
+] as const;
+
+const LIGHTING_MODES: readonly MouseLightingMode[] = [
+  "Static",
+  "Breathing single",
+  "Cycling",
+  "Spectrum",
+  "Reactive",
+  "Wave",
+];
+
+const COLOR_MODES: readonly MouseLightingMode[] = [
+  "Static",
+  "Breathing single",
+  "Reactive",
+  "Wave",
+];
+
+const RAW_TO_LIGHTING_MODE: Record<
+  number,
+  MouseLightingMode
+> = {
+  0x00: "Static",
+  0x01: "Breathing single",
+  0x02: "Cycling",
+  0x03: "Spectrum",
+  0x04: "Reactive",
+  0x05: "Wave",
+};
+
+const LIGHTING_MODE_TO_RAW: Partial<
+  Record<MouseLightingMode, number>
+> = {
+  Static: 0x00,
+  "Breathing single": 0x01,
+  Cycling: 0x02,
+  Spectrum: 0x03,
+  Reactive: 0x04,
+  Wave: 0x05,
+};
+
+function copyDataView(
+  view: DataView,
+): Uint8Array {
   return new Uint8Array(
     view.buffer.slice(
       view.byteOffset,
-      view.byteOffset + view.byteLength,
+      view.byteOffset +
+        view.byteLength,
     ),
   );
 }
@@ -34,43 +99,159 @@ function copyDataView(view: DataView): Uint8Array {
 function hasConfigCollection(
   collections: readonly HIDCollectionInfo[],
 ): boolean {
-  return collections.some((collection) => {
-    const correctCollection =
-      collection.usagePage === ASUS_GLADIUS_II_USAGE_PAGE &&
-      collection.usage === ASUS_GLADIUS_II_USAGE;
+  return collections.some(
+    (collection) => {
+      const correctCollection =
+        collection.usagePage ===
+          ASUS_GLADIUS_II_USAGE_PAGE &&
+        collection.usage ===
+          ASUS_GLADIUS_II_USAGE;
 
-    if (correctCollection) {
-      const hasInput = collection.inputReports.some(
-        (report) => report.reportId === ASUS_REPORT_ID,
-      );
+      if (correctCollection) {
+        const hasInput =
+          collection.inputReports.some(
+            (report) =>
+              report.reportId ===
+              ASUS_REPORT_ID,
+          );
 
-      const hasOutput = collection.outputReports.some(
-        (report) => report.reportId === ASUS_REPORT_ID,
-      );
+        const hasOutput =
+          collection.outputReports.some(
+            (report) =>
+              report.reportId ===
+              ASUS_REPORT_ID,
+          );
 
-      if (hasInput && hasOutput) {
-        return true;
+        if (
+          hasInput &&
+          hasOutput
+        ) {
+          return true;
+        }
       }
-    }
 
-    return hasConfigCollection(collection.children);
-  });
+      return hasConfigCollection(
+        collection.children,
+      );
+    },
+  );
+}
+
+function hexByte(
+  value: number,
+): string {
+  return value
+    .toString(16)
+    .padStart(2, "0");
+}
+
+function rgbToHex(
+  red: number,
+  green: number,
+  blue: number,
+): string {
+  return `#${hexByte(red)}${hexByte(green)}${hexByte(blue)}`;
+}
+
+function parseHexColor(
+  color: string | null,
+): [number, number, number] {
+  const normalized =
+    color ?? "#ff0000";
+
+  const match =
+    /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(
+      normalized,
+    );
+
+  if (!match) {
+    throw new Error(
+      `Invalid RGB colour: ${normalized}`,
+    );
+  }
+
+  return [
+    Number.parseInt(match[1], 16),
+    Number.parseInt(match[2], 16),
+    Number.parseInt(match[3], 16),
+  ];
+}
+
+function rawLightingToStatus(
+  raw: GladiusIIRawLightingZone,
+): MouseLighting {
+  const mode =
+    RAW_TO_LIGHTING_MODE[
+      raw.mode
+    ] ?? "Static";
+
+  return {
+    zone:
+      RGB_ZONE_NAMES[raw.zone] ??
+      `Zone ${raw.zone + 1}`,
+
+    modes: LIGHTING_MODES,
+
+    mode,
+
+    color: rgbToHex(
+      raw.red,
+      raw.green,
+      raw.blue,
+    ),
+
+    color2: null,
+
+    colorModes: COLOR_MODES,
+
+    dualColorModes: [],
+
+    reactiveModes: [],
+
+    speeds: [],
+
+    speed: null,
+
+    brightness:
+      Math.max(
+        0,
+        Math.min(
+          100,
+          raw.brightness * 25,
+        ),
+      ),
+
+    brightnessLevels: [
+      0,
+      25,
+      50,
+      75,
+      100,
+    ],
+  };
 }
 
 export class AsusGladiusIIHidClient {
   readonly device: HIDDevice;
 
-  private queue: Promise<unknown> = Promise.resolve();
+  private queue: Promise<unknown> =
+    Promise.resolve();
 
   constructor(device: HIDDevice) {
     this.device = device;
   }
 
-  static isSupported(device: HIDDevice): boolean {
+  static isSupported(
+    device: HIDDevice,
+  ): boolean {
     return (
-      device.vendorId === ASUS_VENDOR_ID &&
-      device.productId === ROG_GLADIUS_II_PRODUCT_ID &&
-      hasConfigCollection(device.collections)
+      device.vendorId ===
+        ASUS_VENDOR_ID &&
+      device.productId ===
+        ROG_GLADIUS_II_PRODUCT_ID &&
+      hasConfigCollection(
+        device.collections,
+      )
     );
   }
 
@@ -90,9 +271,12 @@ export class AsusGladiusIIHidClient {
     const values: number[] = [];
 
     for (
-      let dpi = GLADIUS_II_MIN_DPI;
-      dpi <= GLADIUS_II_MAX_DPI;
-      dpi += GLADIUS_II_DPI_STEP
+      let dpi =
+        GLADIUS_II_MIN_DPI;
+      dpi <=
+      GLADIUS_II_MAX_DPI;
+      dpi +=
+        GLADIUS_II_DPI_STEP
     ) {
       values.push(dpi);
     }
@@ -101,57 +285,69 @@ export class AsusGladiusIIHidClient {
   }
 
   getSupportedPollingRates(): number[] {
-    return [...GLADIUS_II_POLLING_RATES];
+    return [
+      ...GLADIUS_II_POLLING_RATES,
+    ];
   }
 
   private async run<T>(
     task: () => Promise<T>,
   ): Promise<T> {
-    const started = this.queue.then(
-      task,
-      task,
-    );
+    const started =
+      this.queue.then(
+        task,
+        task,
+      );
 
-    this.queue = started.catch(
-      () => undefined,
-    );
+    this.queue =
+      started.catch(
+        () => undefined,
+      );
 
     return started;
   }
 
   private async exchange(
     request: Uint8Array,
-    matches: (reply: Uint8Array) => boolean,
+    matches: (
+      reply: Uint8Array,
+    ) => boolean,
   ): Promise<Uint8Array> {
     return this.run(async () => {
       await this.open();
 
       return new Promise<Uint8Array>(
         (resolve, reject) => {
-          const cleanup = (): void => {
-            clearTimeout(timer);
+          const cleanup =
+            (): void => {
+              clearTimeout(
+                timer,
+              );
 
-            this.device.removeEventListener(
-              "inputreport",
-              listener,
-            );
-          };
+              this.device.removeEventListener(
+                "inputreport",
+                listener,
+              );
+            };
 
           const listener = (
             event: HIDInputReportEvent,
           ): void => {
             if (
-              event.reportId !== ASUS_REPORT_ID
+              event.reportId !==
+              ASUS_REPORT_ID
             ) {
               return;
             }
 
-            const data = copyDataView(
-              event.data,
-            );
+            const data =
+              copyDataView(
+                event.data,
+              );
 
             if (
-              data.length < ASUS_REPORT_SIZE
+              data.length <
+              ASUS_REPORT_SIZE
             ) {
               return;
             }
@@ -170,37 +366,33 @@ export class AsusGladiusIIHidClient {
             );
           };
 
-          const timer = setTimeout(() => {
-            this.device.removeEventListener(
-              "inputreport",
-              listener,
-            );
+          const timer =
+            setTimeout(() => {
+              this.device.removeEventListener(
+                "inputreport",
+                listener,
+              );
 
-            reject(
-              new Error(
-                "ROG Gladius II did not answer the HID request.",
-              ),
-            );
-          }, RESPONSE_TIMEOUT_MS);
+              reject(
+                new Error(
+                  "ROG Gladius II did not answer the HID request.",
+                ),
+              );
+            }, RESPONSE_TIMEOUT_MS);
 
           this.device.addEventListener(
             "inputreport",
             listener,
           );
 
-          /*
-           * WebHID's BufferSource typing requires
-           * a real ArrayBuffer rather than the
-           * potentially SharedArrayBuffer-backed
-           * Uint8Array TypeScript allows here.
-           */
-          const payload = new ArrayBuffer(
-            request.byteLength,
-          );
+          const payload =
+            new ArrayBuffer(
+              request.byteLength,
+            );
 
-          new Uint8Array(payload).set(
-            request,
-          );
+          new Uint8Array(
+            payload,
+          ).set(request);
 
           this.device
             .sendReport(
@@ -208,7 +400,9 @@ export class AsusGladiusIIHidClient {
               payload,
             )
             .catch(
-              (error: unknown) => {
+              (
+                error: unknown,
+              ) => {
                 cleanup();
                 reject(error);
               },
@@ -216,6 +410,15 @@ export class AsusGladiusIIHidClient {
         },
       );
     });
+  }
+
+  private async save(): Promise<void> {
+    await this.exchange(
+      gladiusIISaveRequest(),
+      (data) =>
+        data[0] === 0x50 &&
+        data[1] === 0x03,
+    );
   }
 
   private async readSettings(): Promise<
@@ -256,28 +459,66 @@ export class AsusGladiusIIHidClient {
     );
   }
 
+  private async readLiftOffDistance(): Promise<
+    "Low" | "High"
+  > {
+    const response =
+      await this.exchange(
+        gladiusIIReadLiftOffRequest(),
+        (data) =>
+          data[0] === 0x12 &&
+          data[1] === 0x06,
+      );
+
+    return decodeGladiusIILiftOffDistance(
+      response,
+    );
+  }
+
+  private async readLighting(): Promise<
+    MouseLighting[]
+  > {
+    const response =
+      await this.exchange(
+        gladiusIIReadLightingRequest(),
+        (data) =>
+          data[0] === 0x12 &&
+          data[1] === 0x03 &&
+          data[2] === 0x00,
+      );
+
+    return decodeGladiusIILighting(
+      response,
+    ).map(
+      rawLightingToStatus,
+    );
+  }
+
   async setDpi(
     dpi: number,
   ): Promise<number> {
+    const profile =
+      await this.readProfile();
+
+    return this.setDpiStageValue(
+      profile.activeDpiStage,
+      dpi,
+    );
+  }
+
+  async setDpiStageValue(
+    stage: number,
+    dpi: number,
+  ): Promise<number> {
     if (
-      !this.getDpiOptions().includes(
-        dpi,
-      )
+      !this
+        .getDpiOptions()
+        .includes(dpi)
     ) {
       throw new Error(
         `${dpi} DPI is not supported by the ROG Gladius II.`,
       );
     }
-
-    /*
-     * The mouse has two DPI stages.
-     * Change whichever one is active now.
-     */
-    const profile =
-      await this.readProfile();
-
-    const stage =
-      profile.activeDpiStage;
 
     await this.exchange(
       gladiusIISetDpiRequest(
@@ -290,35 +531,63 @@ export class AsusGladiusIIHidClient {
         data[2] === stage,
     );
 
-    /*
-     * Commit the change to the mouse.
-     */
-    await this.exchange(
-      gladiusIISaveRequest(),
-      (data) =>
-        data[0] === 0x50 &&
-        data[1] === 0x03,
-    );
-
-    /*
-     * Read the mouse again so we know
-     * the requested DPI really stuck.
-     */
-    const confirmedSettings =
-      await this.readSettings();
+    await this.save();
 
     const confirmed =
-      confirmedSettings.dpiStages[
+      await this.readSettings();
+
+    const stored =
+      confirmed.dpiStages[
         stage
       ];
 
-    if (confirmed !== dpi) {
+    if (stored !== dpi) {
       throw new Error(
-        `ROG Gladius II kept ${confirmed} DPI instead of ${dpi} DPI.`,
+        `ROG Gladius II kept ${stored} DPI instead of ${dpi} DPI.`,
       );
     }
 
-    return confirmed;
+    return stored;
+  }
+
+  async setActiveDpiStage(
+    stage: number,
+  ): Promise<number> {
+    if (
+      !Number.isInteger(stage) ||
+      stage < 0 ||
+      stage > 1
+    ) {
+      throw new Error(
+        "DPI stage must be 0 or 1.",
+      );
+    }
+
+    await this.exchange(
+      gladiusIISetActiveDpiStageRequest(
+        stage,
+      ),
+      (data) =>
+        data[0] === 0x51 &&
+        data[1] === 0x31 &&
+        data[2] === 0x09,
+    );
+
+    await this.save();
+
+    const confirmed =
+      await this.readProfile();
+
+    if (
+      confirmed.activeDpiStage !==
+      stage
+    ) {
+      throw new Error(
+        `ROG Gladius II did not switch to DPI stage ${stage + 1}.`,
+      );
+    }
+
+    return stage;
   }
 
   async setPollingRate(
@@ -344,45 +613,278 @@ export class AsusGladiusIIHidClient {
         data[2] === 0x02,
     );
 
-    /*
-     * Commit the new polling rate.
-     */
-    await this.exchange(
-      gladiusIISaveRequest(),
-      (data) =>
-        data[0] === 0x50 &&
-        data[1] === 0x03,
-    );
+    await this.save();
 
-    /*
-     * Verify by reading the hardware.
-     */
-    const confirmedSettings =
+    const confirmed =
       await this.readSettings();
 
     if (
-      confirmedSettings.pollingRateHz !==
+      confirmed.pollingRateHz !==
       rate
     ) {
       throw new Error(
-        `ROG Gladius II kept ${confirmedSettings.pollingRateHz} Hz instead of ${rate} Hz.`,
+        `ROG Gladius II kept ${confirmed.pollingRateHz} Hz instead of ${rate} Hz.`,
       );
     }
 
-    return confirmedSettings.pollingRateHz;
+    return rate;
+  }
+
+  async setProfile(
+    profile: number,
+  ): Promise<number> {
+    await this.exchange(
+      gladiusIISetProfileRequest(
+        profile,
+      ),
+      (data) =>
+        data[0] === 0x50 &&
+        data[1] === 0x02 &&
+        data[2] ===
+          profile - 1,
+    );
+
+    await this.save();
+
+    const confirmed =
+      await this.readProfile();
+
+    if (
+      confirmed.onboardProfile !==
+      profile
+    ) {
+      throw new Error(
+        `ROG Gladius II did not switch to profile ${profile}.`,
+      );
+    }
+
+    return profile;
+  }
+
+  async setAngleSnapping(
+    enabled: boolean,
+  ): Promise<boolean> {
+    await this.exchange(
+      gladiusIISetAngleSnappingRequest(
+        enabled,
+      ),
+      (data) =>
+        data[0] === 0x51 &&
+        data[1] === 0x31 &&
+        data[2] === 0x04,
+    );
+
+    await this.save();
+
+    const confirmed =
+      await this.readSettings();
+
+    if (
+      confirmed.angleSnapping !==
+      enabled
+    ) {
+      throw new Error(
+        "ROG Gladius II did not retain the angle-snapping setting.",
+      );
+    }
+
+    return enabled;
+  }
+
+  async setDebounceTime(
+    milliseconds: number,
+  ): Promise<number> {
+    const normalized =
+      [...GLADIUS_II_DEBOUNCE_MS].reduce(
+        (best, value) =>
+          Math.abs(
+            value -
+              milliseconds,
+          ) <
+          Math.abs(
+            best -
+              milliseconds,
+          )
+            ? value
+            : best,
+      );
+
+    await this.exchange(
+      gladiusIISetDebounceRequest(
+        normalized,
+      ),
+      (data) =>
+        data[0] === 0x51 &&
+        data[1] === 0x31 &&
+        data[2] === 0x03,
+    );
+
+    await this.save();
+
+    const confirmed =
+      await this.readSettings();
+
+    if (
+      confirmed.debounceMs !==
+      normalized
+    ) {
+      throw new Error(
+        `ROG Gladius II kept ${confirmed.debounceMs} ms debounce instead of ${normalized} ms.`,
+      );
+    }
+
+    return normalized;
+  }
+
+  async setLiftOffDistance(
+    value:
+      | "Low"
+      | "Medium"
+      | "High",
+  ): Promise<"Low" | "High"> {
+    if (
+      value !== "Low" &&
+      value !== "High"
+    ) {
+      throw new Error(
+        "ROG Gladius II only supports Low or High lift-off distance.",
+      );
+    }
+
+    await this.exchange(
+      gladiusIISetLiftOffRequest(
+        value,
+      ),
+      (data) =>
+        data[0] === 0x51 &&
+        data[1] === 0x35,
+    );
+
+    await this.save();
+
+    const confirmed =
+      await this.readLiftOffDistance();
+
+    if (confirmed !== value) {
+      throw new Error(
+        `ROG Gladius II kept ${confirmed} lift-off instead of ${value}.`,
+      );
+    }
+
+    return confirmed;
+  }
+
+  async setLighting(
+    lighting: MouseLighting,
+  ): Promise<MouseLighting> {
+    const zone =
+      RGB_ZONE_NAMES.findIndex(
+        (name) =>
+          name === lighting.zone,
+      );
+
+    if (zone < 0) {
+      throw new Error(
+        `Unknown Gladius II lighting zone: ${lighting.zone}`,
+      );
+    }
+
+    if (!lighting.mode) {
+      throw new Error(
+        "Choose an RGB effect first.",
+      );
+    }
+
+    const rawMode =
+      LIGHTING_MODE_TO_RAW[
+        lighting.mode
+      ];
+
+    if (
+      rawMode === undefined
+    ) {
+      throw new Error(
+        `Unsupported Gladius II lighting mode: ${lighting.mode}`,
+      );
+    }
+
+    let [red, green, blue] =
+      parseHexColor(
+        lighting.color,
+      );
+
+    const brightnessPercent =
+      lighting.brightness ?? 100;
+
+    const brightness =
+      Math.max(
+        0,
+        Math.min(
+          4,
+          Math.round(
+            brightnessPercent /
+              25,
+          ),
+        ),
+      );
+
+    /*
+     * ASUS Rainbow/Spectrum uses
+     * fixed red bytes plus a special
+     * Gladius-II speed code.
+     */
+    let speed = 0;
+
+    if (
+      lighting.mode ===
+      "Spectrum"
+    ) {
+      red = 0xff;
+      green = 0x00;
+      blue = 0x00;
+
+      // Medium rainbow speed.
+      speed = 0x64;
+    }
+
+    await this.exchange(
+      gladiusIISetLightingRequest(
+        zone,
+        rawMode,
+        brightness,
+        red,
+        green,
+        blue,
+        0,
+        0,
+        speed,
+      ),
+      (data) =>
+        data[0] === 0x51 &&
+        data[1] === 0x28 &&
+        data[2] === zone,
+    );
+
+    await this.save();
+
+    const confirmed =
+      await this.readLighting();
+
+    return confirmed[zone];
   }
 
   async readStatus(): Promise<MouseStatus> {
-    /*
-     * These are sequential because both
-     * commands share the same HID input
-     * response channel.
-     */
     const settings =
       await this.readSettings();
 
     const profile =
       await this.readProfile();
+
+    const liftOffDistance =
+      await this.readLiftOffDistance();
+
+    const lightingZones =
+      await this.readLighting();
 
     const dpi =
       settings.dpiStages[
@@ -394,23 +896,49 @@ export class AsusGladiusIIHidClient {
       name: "ROG Gladius II",
 
       ui: {
-        family: "asus-gladius-ii",
+        family:
+          "asus-gladius-ii",
 
         settingsReady: true,
+
         valuesVerified: true,
 
         hideUnsupportedPollingRates:
           true,
 
+        showAdvancedSection:
+          true,
+
+        hideSignalCard: true,
+
+        hideSleepCard: true,
+
+        hideMotionSync: true,
+
+        hideRippleControl: true,
+
+        dpiStageEditor: {
+          maxStages: 2,
+          countEditable: false,
+          minDpi:
+            GLADIUS_II_MIN_DPI,
+          maxDpi:
+            GLADIUS_II_MAX_DPI,
+          stepDpi:
+            GLADIUS_II_DPI_STEP,
+        },
+
         statusNote:
-          "DPI and polling rate changes are supported.",
+          "ROG Gladius II hardware controls are enabled.",
 
         defaultDisplayName:
           "ROG Gladius II",
       },
 
       batteryPercent: null,
-      batteryState: "Unknown",
+
+      batteryState:
+        "Unknown",
 
       dpi,
 
@@ -430,8 +958,14 @@ export class AsusGladiusIIHidClient {
       activeProfile:
         profile.onboardProfile,
 
-      connectionType: "Wired",
-      connectionDetail: "Wired USB",
+      profileCount:
+        GLADIUS_II_PROFILE_COUNT,
+
+      connectionType:
+        "Wired",
+
+      connectionDetail:
+        "Wired USB",
 
       debounceMs:
         settings.debounceMs,
@@ -439,7 +973,17 @@ export class AsusGladiusIIHidClient {
       angleSnapping:
         settings.angleSnapping,
 
-      liftOffDistance: null,
+      liftOffDistance,
+
+      supportedLiftOffDistances: [
+        "Low",
+        "High",
+      ],
+
+      lighting:
+        lightingZones[0],
+
+      lightingZones,
 
       firmware: [],
     };

--- a/src/drivers/asus/hid.ts
+++ b/src/drivers/asus/hid.ts
@@ -1,0 +1,447 @@
+import type { MouseStatus } from "../mouse-types.ts";
+
+import {
+  ASUS_GLADIUS_II_USAGE,
+  ASUS_GLADIUS_II_USAGE_PAGE,
+  ASUS_REPORT_ID,
+  ASUS_REPORT_SIZE,
+  ASUS_VENDOR_ID,
+  GLADIUS_II_DPI_STEP,
+  GLADIUS_II_MAX_DPI,
+  GLADIUS_II_MIN_DPI,
+  GLADIUS_II_POLLING_RATES,
+  ROG_GLADIUS_II_PRODUCT_ID,
+  decodeGladiusIIProfile,
+  decodeGladiusIISettings,
+  gladiusIIReadProfileRequest,
+  gladiusIIReadSettingsRequest,
+  gladiusIISetDpiRequest,
+  gladiusIISetPollingRateRequest,
+  gladiusIISaveRequest,
+} from "../../asus/index.ts";
+
+const RESPONSE_TIMEOUT_MS = 1000;
+
+function copyDataView(view: DataView): Uint8Array {
+  return new Uint8Array(
+    view.buffer.slice(
+      view.byteOffset,
+      view.byteOffset + view.byteLength,
+    ),
+  );
+}
+
+function hasConfigCollection(
+  collections: readonly HIDCollectionInfo[],
+): boolean {
+  return collections.some((collection) => {
+    const correctCollection =
+      collection.usagePage === ASUS_GLADIUS_II_USAGE_PAGE &&
+      collection.usage === ASUS_GLADIUS_II_USAGE;
+
+    if (correctCollection) {
+      const hasInput = collection.inputReports.some(
+        (report) => report.reportId === ASUS_REPORT_ID,
+      );
+
+      const hasOutput = collection.outputReports.some(
+        (report) => report.reportId === ASUS_REPORT_ID,
+      );
+
+      if (hasInput && hasOutput) {
+        return true;
+      }
+    }
+
+    return hasConfigCollection(collection.children);
+  });
+}
+
+export class AsusGladiusIIHidClient {
+  readonly device: HIDDevice;
+
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(device: HIDDevice) {
+    this.device = device;
+  }
+
+  static isSupported(device: HIDDevice): boolean {
+    return (
+      device.vendorId === ASUS_VENDOR_ID &&
+      device.productId === ROG_GLADIUS_II_PRODUCT_ID &&
+      hasConfigCollection(device.collections)
+    );
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) {
+      await this.device.open();
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.device.opened) {
+      await this.device.close();
+    }
+  }
+
+  getDpiOptions(): number[] {
+    const values: number[] = [];
+
+    for (
+      let dpi = GLADIUS_II_MIN_DPI;
+      dpi <= GLADIUS_II_MAX_DPI;
+      dpi += GLADIUS_II_DPI_STEP
+    ) {
+      values.push(dpi);
+    }
+
+    return values;
+  }
+
+  getSupportedPollingRates(): number[] {
+    return [...GLADIUS_II_POLLING_RATES];
+  }
+
+  private async run<T>(
+    task: () => Promise<T>,
+  ): Promise<T> {
+    const started = this.queue.then(
+      task,
+      task,
+    );
+
+    this.queue = started.catch(
+      () => undefined,
+    );
+
+    return started;
+  }
+
+  private async exchange(
+    request: Uint8Array,
+    matches: (reply: Uint8Array) => boolean,
+  ): Promise<Uint8Array> {
+    return this.run(async () => {
+      await this.open();
+
+      return new Promise<Uint8Array>(
+        (resolve, reject) => {
+          const cleanup = (): void => {
+            clearTimeout(timer);
+
+            this.device.removeEventListener(
+              "inputreport",
+              listener,
+            );
+          };
+
+          const listener = (
+            event: HIDInputReportEvent,
+          ): void => {
+            if (
+              event.reportId !== ASUS_REPORT_ID
+            ) {
+              return;
+            }
+
+            const data = copyDataView(
+              event.data,
+            );
+
+            if (
+              data.length < ASUS_REPORT_SIZE
+            ) {
+              return;
+            }
+
+            if (!matches(data)) {
+              return;
+            }
+
+            cleanup();
+
+            resolve(
+              data.subarray(
+                0,
+                ASUS_REPORT_SIZE,
+              ),
+            );
+          };
+
+          const timer = setTimeout(() => {
+            this.device.removeEventListener(
+              "inputreport",
+              listener,
+            );
+
+            reject(
+              new Error(
+                "ROG Gladius II did not answer the HID request.",
+              ),
+            );
+          }, RESPONSE_TIMEOUT_MS);
+
+          this.device.addEventListener(
+            "inputreport",
+            listener,
+          );
+
+          /*
+           * WebHID's BufferSource typing requires
+           * a real ArrayBuffer rather than the
+           * potentially SharedArrayBuffer-backed
+           * Uint8Array TypeScript allows here.
+           */
+          const payload = new ArrayBuffer(
+            request.byteLength,
+          );
+
+          new Uint8Array(payload).set(
+            request,
+          );
+
+          this.device
+            .sendReport(
+              ASUS_REPORT_ID,
+              payload,
+            )
+            .catch(
+              (error: unknown) => {
+                cleanup();
+                reject(error);
+              },
+            );
+        },
+      );
+    });
+  }
+
+  private async readSettings(): Promise<
+    ReturnType<
+      typeof decodeGladiusIISettings
+    >
+  > {
+    const response =
+      await this.exchange(
+        gladiusIIReadSettingsRequest(),
+        (data) =>
+          data[0] === 0x12 &&
+          data[1] === 0x04 &&
+          data[2] === 0x00,
+      );
+
+    return decodeGladiusIISettings(
+      response,
+    );
+  }
+
+  private async readProfile(): Promise<
+    ReturnType<
+      typeof decodeGladiusIIProfile
+    >
+  > {
+    const response =
+      await this.exchange(
+        gladiusIIReadProfileRequest(),
+        (data) =>
+          data[0] === 0x12 &&
+          data[1] === 0x00 &&
+          data[2] === 0x00,
+      );
+
+    return decodeGladiusIIProfile(
+      response,
+    );
+  }
+
+  async setDpi(
+    dpi: number,
+  ): Promise<number> {
+    if (
+      !this.getDpiOptions().includes(
+        dpi,
+      )
+    ) {
+      throw new Error(
+        `${dpi} DPI is not supported by the ROG Gladius II.`,
+      );
+    }
+
+    /*
+     * The mouse has two DPI stages.
+     * Change whichever one is active now.
+     */
+    const profile =
+      await this.readProfile();
+
+    const stage =
+      profile.activeDpiStage;
+
+    await this.exchange(
+      gladiusIISetDpiRequest(
+        stage,
+        dpi,
+      ),
+      (data) =>
+        data[0] === 0x51 &&
+        data[1] === 0x31 &&
+        data[2] === stage,
+    );
+
+    /*
+     * Commit the change to the mouse.
+     */
+    await this.exchange(
+      gladiusIISaveRequest(),
+      (data) =>
+        data[0] === 0x50 &&
+        data[1] === 0x03,
+    );
+
+    /*
+     * Read the mouse again so we know
+     * the requested DPI really stuck.
+     */
+    const confirmedSettings =
+      await this.readSettings();
+
+    const confirmed =
+      confirmedSettings.dpiStages[
+        stage
+      ];
+
+    if (confirmed !== dpi) {
+      throw new Error(
+        `ROG Gladius II kept ${confirmed} DPI instead of ${dpi} DPI.`,
+      );
+    }
+
+    return confirmed;
+  }
+
+  async setPollingRate(
+    rate: number,
+  ): Promise<number> {
+    if (
+      !this
+        .getSupportedPollingRates()
+        .includes(rate)
+    ) {
+      throw new Error(
+        `${rate} Hz is not supported by the ROG Gladius II.`,
+      );
+    }
+
+    await this.exchange(
+      gladiusIISetPollingRateRequest(
+        rate,
+      ),
+      (data) =>
+        data[0] === 0x51 &&
+        data[1] === 0x31 &&
+        data[2] === 0x02,
+    );
+
+    /*
+     * Commit the new polling rate.
+     */
+    await this.exchange(
+      gladiusIISaveRequest(),
+      (data) =>
+        data[0] === 0x50 &&
+        data[1] === 0x03,
+    );
+
+    /*
+     * Verify by reading the hardware.
+     */
+    const confirmedSettings =
+      await this.readSettings();
+
+    if (
+      confirmedSettings.pollingRateHz !==
+      rate
+    ) {
+      throw new Error(
+        `ROG Gladius II kept ${confirmedSettings.pollingRateHz} Hz instead of ${rate} Hz.`,
+      );
+    }
+
+    return confirmedSettings.pollingRateHz;
+  }
+
+  async readStatus(): Promise<MouseStatus> {
+    /*
+     * These are sequential because both
+     * commands share the same HID input
+     * response channel.
+     */
+    const settings =
+      await this.readSettings();
+
+    const profile =
+      await this.readProfile();
+
+    const dpi =
+      settings.dpiStages[
+        profile.activeDpiStage
+      ];
+
+    return {
+      brand: "ASUS",
+      name: "ROG Gladius II",
+
+      ui: {
+        family: "asus-gladius-ii",
+
+        settingsReady: true,
+        valuesVerified: true,
+
+        hideUnsupportedPollingRates:
+          true,
+
+        statusNote:
+          "DPI and polling rate changes are supported.",
+
+        defaultDisplayName:
+          "ROG Gladius II",
+      },
+
+      batteryPercent: null,
+      batteryState: "Unknown",
+
+      dpi,
+
+      dpiStages: [
+        ...settings.dpiStages,
+      ],
+
+      activeDpiStage:
+        profile.activeDpiStage,
+
+      pollingRateHz:
+        settings.pollingRateHz,
+
+      supportedPollingRates:
+        this.getSupportedPollingRates(),
+
+      activeProfile:
+        profile.onboardProfile,
+
+      connectionType: "Wired",
+      connectionDetail: "Wired USB",
+
+      debounceMs:
+        settings.debounceMs,
+
+      angleSnapping:
+        settings.angleSnapping,
+
+      liftOffDistance: null,
+
+      firmware: [],
+    };
+  }
+}

--- a/src/drivers/mouse-types.ts
+++ b/src/drivers/mouse-types.ts
@@ -148,7 +148,7 @@ export interface AtkReceiverInfo {
 }
 
 export interface MouseStatus {
-  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "GearHub" | "Corsair" | "Microsoft" | "Dareu" | "Incott" | "HyperX";
+  brand: "Logitech" | "Pulsar" | "Endgame Gear" | "WLMouse" | "G-Wolves" | "Lamzu" | "CRDRAKO" | "Attack Shark" | "Orbital" | "Razer" | "Teevolution" | "ATK" | "VXE" | "VGN" | "Finalmouse" | "Keychron" | "moddoMOUSE" | "Ninjutso" | "Zaunkoenig" | "Fantech" | "Wooting" | "WALLHACK" | "SteelSeries" | "Glorious" | "MCHOSE" | "K-snake" | "Lingbao" | "GearHub" | "Corsair" | "Microsoft" | "Dareu" | "Incott" | "HyperX" | "ASUS";
   name: string;
   /** Driver-supplied UI policy (optional; keeps control.ts brand-agnostic). */
   ui?: MouseUiHints;
@@ -321,7 +321,7 @@ export interface MouseStatus {
   /** Logitech onboard profile format (HID++ 0x8100), which selects the layout. */
   onboardProfileFormat?: {
     id: number;
-    name: string;
+    name: string; 
     base: string;
     supported: boolean;
     /** False when the layout comes from vendor code but was never confirmed on hardware. */

--- a/src/drivers/registry.ts
+++ b/src/drivers/registry.ts
@@ -1,3 +1,4 @@
+import { AsusGladiusIIHidClient } from "./asus/hid.ts";
 import { AtkBitmouseHidClient } from "./atk/bitmouse-hid.ts";
 import { AtkHidClient } from "./atk/hid.ts";
 import { AttackSharkHidClient } from "./attackshark/hid.ts";
@@ -55,7 +56,7 @@ import { HyperXHidClient } from "./hyperx/hid.ts";
 import { MchoseV3HidClient } from "./mchose/v3-hid.ts";
 
 export type PulsarClient = PulsarHidClient | PulsarProHidClient | PulsarXs1HidClient;
-export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | LamzuAtlantisHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | MchoseA5ProMaxHidClient | KsnakeHidClient | MicrosoftHidClient | DareuHidClient | IncottHidClient | HyperXHidClient | MchoseV3HidClient;
+export type SupportedClient = LogitechHidppClient | PulsarClient | EggOp1HidClient | EggWeHidClient | FinalmouseHidClient | WLMouseHidClient | LamzuHidClient | LamzuAtlantisHidClient | OrbitalHidClient | RazerHidClient | RazerViperHidClient | RazerViperMiniHidClient | RazerViperV4ProHidClient | RazerCobraHidClient | TeevolutionHidClient | AtkHidClient | AtkBitmouseHidClient | VgnF2HidClient | KeychronM6HidClient | KeychronNapeHidClient | ModdoHidClient | NinjutsoHidClient | ZaunkoenigHidClient | CorsairHidClient | AttackSharkHidClient | FantechHidClient | GearHubHidClient | WootingHidClient | WallhackMouseHidClient | WallhackKeyboardHidClient | GWolvesHidClient | SteelSeriesRival3HidClient | SteelSeriesAerox3HidClient | SteelSeriesRival3WirelessHidClient | SteelSeriesAerox5HidClient | SteelSeriesAerox5WirelessHidClient | SteelSeriesRival650HidClient | SteelSeriesAerox9WirelessHidClient | SteelSeriesRival310HidClient | SteelSeriesPrimePlusHidClient | SteelSeriesPrimeMiniWirelessHidClient | SteelSeriesSenseiTenHidClient | GloriousHidClient | GloriousClassicHidClient | MchoseHidClient | MchoseDockHidClient | MchoseA5ProMaxHidClient | KsnakeHidClient | MicrosoftHidClient | DareuHidClient | IncottHidClient | HyperXHidClient | MchoseV3HidClient | AsusGladiusIIHidClient;
 
 export interface DeviceDriver {
   brand: string;
@@ -65,6 +66,7 @@ export interface DeviceDriver {
 }
 
 export const DEVICE_DRIVERS: readonly DeviceDriver[] = [
+  {brand: "ASUS",supports: (device) => AsusGladiusIIHidClient.isSupported(device), create: (device) => new AsusGladiusIIHidClient(device), score: () => 10,},
   { brand: "Dareu", supports: (device) => DareuHidClient.isSupported(device), create: (device) => new DareuHidClient(device), score: () => 9 },
   { brand: "Zaunkoenig", supports: (device) => ZaunkoenigHidClient.isSupported(device), create: (device) => new ZaunkoenigHidClient(device), score: () => 10 },
   { brand: "Corsair", supports: (device) => CorsairHidClient.isSupported(device), create: (device) => new CorsairHidClient(device), score: () => 8 },

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -1,3 +1,9 @@
+import {
+  ASUS_GLADIUS_II_USAGE,
+  ASUS_GLADIUS_II_USAGE_PAGE,
+  ASUS_VENDOR_ID,
+  ROG_GLADIUS_II_PRODUCT_ID,
+} from "../asus/index.ts";
 import { ATK_COMPX_PRODUCT_IDS } from "./atk/products.ts";
 import { MICROSOFT_PRODUCTS } from "../microsoft/index.ts";
 import { INCOTT_PRODUCT_IDS, INCOTT_USAGE_PAGE, INCOTT_VENDOR_ID } from "../incott/index.ts";
@@ -86,6 +92,7 @@ import {
 } from "@openmouse/protocol/hyperx";
 
 export const VENDOR_ID = {
+  asus: ASUS_VENDOR_ID,
   pulsar: 0x3710,
   endgameGear: 0x3367,
   wlmouse: 0x36a7,
@@ -133,6 +140,24 @@ export const VENDOR_ID = {
   hyperxKingston: HYPERX_VENDOR_ID_KINGSTON,
   hyperxHp: HYPERX_VENDOR_ID_HP,
 } as const;
+
+/**
+ * ROG Gladius II P502 configuration interface.
+ *
+ * Hardware verified:
+ * VID 0x0B05
+ * PID 0x1845
+ * Usage Page 0xFF01
+ * Usage 0x0001
+ */
+export const ASUS_GLADIUS_II_HID_FILTERS: HIDDeviceFilter[] = [
+  {
+    vendorId: ASUS_VENDOR_ID,
+    productId: ROG_GLADIUS_II_PRODUCT_ID,
+    usagePage: ASUS_GLADIUS_II_USAGE_PAGE,
+    usage: ASUS_GLADIUS_II_USAGE,
+  },
+];
 
 export const MCHOSE_A5_HID_FILTERS: HIDDeviceFilter[] = [
   ...[...MCHOSE_A5_GEN1_PRODUCTS.keys()].map((productId) => ({
@@ -539,6 +564,7 @@ export const HYPERX_HID_FILTERS: HIDDeviceFilter[] = [
 ];
 
 export const SUPPORTED_HID_FILTERS: HIDDeviceFilter[] = [
+  ...ASUS_GLADIUS_II_HID_FILTERS,
   ...DAREU_HID_FILTERS,
   ...ZAUNKOENIG_PRODUCT_IDS.map((productId) => ({
     vendorId: ZAUNKOENIG_VENDOR_ID,


### PR DESCRIPTION
Summary

Adds hardware-tested support for the ASUS ROG Gladius II P502 to mouse-protocol.

Hardware
Model: ASUS ROG Gladius II P502
VID: 0x0B05
PID: 0x1845
Configuration Usage Page: 0xFF01
Usage: 0x0001
Connection: Wired USB
Supported features

Verified on physical hardware:

Device detection
Current DPI reading
Two DPI stages
DPI stage read/write
Active DPI stage switching
Polling rate read/write
125 Hz
250 Hz
500 Hz
1000 Hz
Three onboard profiles
Debounce read/write
Angle snapping read/write
Low / High lift-off distance
RGB control
Logo
Scroll wheel
Underglow
Protocol

The driver uses the Gladius II vendor-defined HID configuration interface and 64-byte report-ID-0 packets.

Hardware reads and writes are verified by reading values back from the device after changes rather than assuming commands succeeded.

Testing
npm run build passes
npm test passes
1540 tests passing
Tested directly on an ASUS ROG Gladius II P502

Additional hardware test information is included in:

docs/asus-gladius-ii-testing.md

Notes

Lift-off distance changes use ASUS's surface/LOD command and may reset the device's surface calibration to its default state.
