### PR TITLE
razer: probe every granted collection as a fallback, widen HyperSpeed filter to match Synapse Web

### DIFF
--- a/src/drivers/razer/hid.ts
+++ b/src/drivers/razer/hid.ts
@@ -188,6 +188,26 @@ export class RazerHidClient {
     if (this.device.opened) await this.device.close();
   }
 
+  /**
+   * Whether this collection actually answers the Razer protocol, tried by
+   * sending the firmware-version read rather than inferred from the
+   * collection's declared shape. `isSupported()`'s shape check (single
+   * collection, Generic Desktop Mouse) is right for every model verified so
+   * far, but WebHID does not validate report ids against the descriptor (see
+   * the note atop codec.ts), so a collection that fails the shape check can
+   * still genuinely answer report 0 — used as a fallback in
+   * `razerProbeControlInterface` for exactly that case, not as the normal
+   * detection path.
+   */
+  async probeReachable(): Promise<boolean> {
+    try {
+      await this.request(RAZER_READ.firmware);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   displayName(): string {
     const known = this.profile();
     return known ? `Razer ${known.model}` : this.device.productName || "Razer";
@@ -800,4 +820,49 @@ export class RazerHidClient {
   private delay(milliseconds: number): Promise<void> {
     return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
   }
+}
+
+/**
+ * Last-resort device selection for when none of the granted collections
+ * matched `RazerHidClient.isSupported()`'s shape check. Rather than guess a
+ * new shape, this tries the protocol itself against every Razer-vendor
+ * collection Chrome granted and returns the client for whichever one
+ * actually answers.
+ *
+ * This exists because the shape check assumes every model's control channel
+ * is a single Generic Desktop Mouse collection (verified true so far for
+ * every model this driver has been confirmed against) — a real assumption a
+ * given browser/OS combination could break for a specific model without any
+ * code here changing, since what collections get exposed to WebHID at all is
+ * decided below this driver, by the platform. Kept off the normal detection
+ * path (`registry.ts`'s `DEVICE_DRIVERS` entry still uses `isSupported()`
+ * alone) because sending real protocol traffic to every candidate is real
+ * device I/O, not a cheap shape check, and only worth it once the cheap
+ * check has already failed to find anything.
+ *
+ * `sendFeatureReport`/`receiveFeatureReport` reject immediately for a
+ * collection with no feature-report capability at all, so a wrong candidate
+ * costs one failed call, not a hang — see `write()`'s try/catch above.
+ */
+export async function razerProbeControlInterface(
+  devices: readonly HIDDevice[],
+): Promise<RazerHidClient | null> {
+  const candidates = devices.filter((device) => device.vendorId === VENDOR_ID.razer);
+  for (const device of candidates) {
+    const client = new RazerHidClient(device);
+    const tag = `[razer-probe] 0x${device.productId.toString(16).padStart(4, "0")} `
+      + device.collections.map((c) => `${(c.usagePage ?? 0).toString(16)}:${c.usage ?? 0}`).join(",");
+    try {
+      await client.open();
+      if (await client.probeReachable()) {
+        console.info(`${tag} -> answered`);
+        return client;
+      }
+      console.info(`${tag} -> opened, no reply`);
+    } catch (error) {
+      console.info(`${tag} -> ${error instanceof Error ? error.message : String(error)}`);
+    }
+    await client.close().catch(() => undefined);
+  }
+  return null;
 }

--- a/src/drivers/vendors.ts
+++ b/src/drivers/vendors.ts
@@ -330,6 +330,17 @@ export const RAZER_VIPER_V3_CONTROL_FILTERS: HIDDeviceFilter[] = [0x00c0, 0x00c1
  *   shape for them, and their extra buttons/wheel make a different interface
  *   layout plausible.
  */
+// Widened to match Razer's own Synapse Web: intercepting its live
+// navigator.hid.requestDevice() call (synapse.razer.com/dashboard, "Add
+// Device") for the models it currently offers (Viper V4 Pro 0xe5/0xe6,
+// DeathAdder V4 Pro 0xbe/0xbf/0xef/0xf0) showed filters of exactly
+// `{vendorId, productId, usagePage}` — usagePage 0x01 AND 0x0c, with NO
+// `usage` field at all. That already matched RAZER_VIPER_V4_CONTROL_FILTERS
+// below; it did not match this constant, which added a `usage: 0x02`
+// restriction Razer's own reference implementation does not apply. Dropped
+// here to follow the same pattern, on top of razerProbeControlInterface
+// (hid.ts) trying the real protocol against whatever gets granted rather
+// than assuming which single collection is correct.
 export const RAZER_HYPERSPEED_CONTROL_FILTERS: HIDDeviceFilter[] = [
   0x0078, // Viper (see RAZER_VIPER_CONTROL_FILTERS above; kept for the doc trail)
   0x007a, // Viper Ultimate (Wired)
@@ -344,7 +355,7 @@ export const RAZER_HYPERSPEED_CONTROL_FILTERS: HIDDeviceFilter[] = [
   0x00d6, 0x00d7, // Basilisk V3 Pro 35K Phantom Green
   0x00be, 0x00bf, // DeathAdder V4 Pro
   0x00ef, 0x00f0, // DeathAdder V4 Pro Carbon Fiber Edition
-].map((productId) => ({ vendorId: VENDOR_ID.razer, productId, usagePage: 0x01, usage: 0x02 }));
+].flatMap((productId) => [0x01, 0x0c].map((usagePage) => ({ vendorId: VENDOR_ID.razer, productId, usagePage })));
 
 // The Viper Mini answers on the same kind of single Generic Desktop Mouse
 // control interface as the V3 Pro, so it gets the same narrow collection filter.


### PR DESCRIPTION
Follow-up to #92. Tested live against real hardware (both this fix and #92 originally) against a Windows machine still reporting "not a supported control interface" for a DeathAdder V3 HyperSpeed.

## What this adds
- `razerProbeControlInterface()`: when `isSupported()`'s shape check (single collection, usage page 1/usage 2) finds nothing, try the real protocol (firmware-version read) against every granted Razer-vendor collection instead of giving up. WebHID doesn't validate report ids against the descriptor, so a wrong candidate costs one failed call, not a hang.
- Widened `RAZER_HYPERSPEED_CONTROL_FILTERS` to drop the `usage: 0x02` restriction — intercepted Razer's own live Synapse Web `requestDevice()` call for the models it currently offers (Viper V4 Pro, DeathAdder V4 Pro family) and found `{vendorId, productId, usagePage}` with no `usage` field at all, on both usage pages `0x01` and `0x0c`. This constant had added a restriction their own reference implementation doesn't apply.

## What we learned testing this live
Ran the probe against the actual Windows machine from the original report: it opened the one granted collection without throwing, sent the real firmware-read command, and got no reply. That's stronger evidence than a shape mismatch — it means the interface that actually answers (confirmed present in a macOS `getDevices()` dump for the same physical mouse) is not part of what Chrome exposes for this device on this machine at all, independent of what filter shape we request.

So this doesn't confirm-fix that specific report, but it's kept because (a) the probe is a real, low-risk improvement for any other Razer model where the shape check is simply wrong, and (b) the widened filter matches Razer's own reference behavior, which is worth doing regardless.

`npm run check`: full suite passes.